### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2867,9 +2867,7 @@ directive-value = &lt;URL> ; TODO: Figure out what to use here.
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
   an attacker to predict.</p>
-    <p class="note" role="note">Note: Using a nonce to whitelist inline script or style is less secure than
-  not using a nonce, as nonces override the restrictions in the directive in
-  which they are present. An attacker who can gain access to the nonce can
+    <p class="note" role="note">Note: An attacker who can gain access to the nonce can
   execute whatever script they like, whenever they like. That said, nonces
   provide a substantial improvement over <a data-link-type="grammar" href="#grammardef-unsafe-inline">'unsafe-inline'</a> when
   layering a content security policy on top of old code. When considering <a data-link-type="grammar" href="#grammardef-unsafe-inline">'unsafe-inline'</a>, authors are encouraged to consider nonces


### PR DESCRIPTION
I don't think that sentence makes any sense in this context.

Maybe it can be replaced with content describing what would happen if attacker creates parse failure case for parsing nonce, e.g. `default-src 'nonce-\n'` would fall back to default-src 'none', or or something like that. 
