### PR TITLE
Add 'self' to ancestor-source grammar

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2158,7 +2158,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
     directive-value = <a>ancestor-source-list</a>
 
     <dfn>ancestor-source-list</dfn> = ( <a>ancestor-source</a> *( <a>RWS</a> <a>ancestor-source</a>) ) / "<a>'none'</a>"
-    <dfn>ancestor-source</dfn>      = <a>scheme-source</a> / <a>host-source</a>
+    <dfn>ancestor-source</dfn>      = <a>scheme-source</a> / <a>host-source</a> / "<a>'self'</a>"
   </pre>
 
   The `frame-ancestors` directive is enforced as part of


### PR DESCRIPTION
Noticed that https://github.com/w3c/webappsec/issues/461 didn't make it here, and suspect that wasn't intentional.