### PR TITLE
Fixes numbering in 6.1.10.3

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1871,7 +1871,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
           <a grammar>`host-source`</a> expressions to be upgraded from insecure
           schemes to secure schemes.
       
-      4.  If the first character of |expression|'s <a grammar>`host-part`</a>
+      3.  If the first character of |expression|'s <a grammar>`host-part`</a>
           is an U+002A ASTERISK character (`*`):
           
           1.  Let |remaining| be the result of removing the leading "`*`" from
@@ -1882,12 +1882,12 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
               rightmost characters of |url|'s {{URL/host}}, then return "`Does
               Not Match`".
 
-      5.  If the first character of |expression|'s <a grammar>`host-part`</a>
+      4.  If the first character of |expression|'s <a grammar>`host-part`</a>
           is not an U+002A ASTERISK character (`*`), and |url|'s {{URL/host}}
           is not an <a>ASCII case-insensitive match</a> for |expression|'s
           <a grammar>`host-part`</a>, return "`Does Not Match`".
 
-      6.  If |expression|'s <a grammar>`host-part`</a> matches the
+      5.  If |expression|'s <a grammar>`host-part`</a> matches the
           <a grammar>IPv4address</a> rule from [[!RFC3986]], and is not
           "`127.0.0.1`"; or if |expression|'s <a grammar>`host-part`</a> is an
           <a>IPv6 address</a>, return "`Does Not Match`".
@@ -1898,17 +1898,17 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
           however, authors are encouraged to prefer the latter whenever
           possible.
 
-      7.  If |expression| does not contain a <a grammar>`port-part`</a>, and
+      6.  If |expression| does not contain a <a grammar>`port-part`</a>, and
           |url|'s {{URL/port}} is not the <a>default port</a> for |url|'s
           {{URL/scheme}}, return "`Does Not Match`".
 
-      8.  If |expression| does contain a <a grammar>`port-part`</a>:
+      7.  If |expression| does contain a <a grammar>`port-part`</a>:
 
           1.  If |expression|'s <a grammar>`port-part`</a> is not "`*`", and
               is not the same number as |url|'s {{URL/port}}, return "`Does Not
               Match`".
 
-      9.  If |expression| contains a non-empty <a grammar>`path-part`</a>, and
+      8.  If |expression| contains a non-empty <a grammar>`path-part`</a>, and
           |redirect count| is 0, then:
 
           1.  Let |exact match| be `false` if the final character of
@@ -1938,7 +1938,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
               4.  If |expression piece| is not an <a>ASCII case-insensitive
                   match</a> for |url piece|, return "`Does Not Match`".
 
-      10. Return "`Matches`".
+      9. Return "`Matches`".
 
   4.  If |expression| is an <a>ASCII case-insensitive match</a> for "`'self'`",
       return "`Matches`" if one or more of the following conditions is met:


### PR DESCRIPTION
Fixes numbering in 6.1.10.3, 3:If expression matches the host-source grammar.