### PR TITLE
Make "sandbox" directive-value an enumerated list

### DIFF
--- a/document/index.src.html
+++ b/document/index.src.html
@@ -218,7 +218,8 @@ spec:dom-ls; type:interface; text:Document
 
   <pre dfn-type="grammar" link-type="grammar">
     directive-name  = "sandbox"
-    directive-value = "" / "allow-forms" / "allow-modals" / "allow-pointer-lock" /
+    directive-value = "" / <a>sandbox-token</a> *( <a>RWS</a> <a>sandbox-token</a> )
+    <dfn>sandbox-token</dfn>   = "allow-forms" / "allow-modals" / "allow-pointer-lock" /
                       "allow-popups" / "allow-popups-to-escape-sandbox" /
                       "allow-same-origin" / "allow-scripts" / "allow-top-navigation"
   </pre>

--- a/document/index.src.html
+++ b/document/index.src.html
@@ -218,7 +218,9 @@ spec:dom-ls; type:interface; text:Document
 
   <pre dfn-type="grammar" link-type="grammar">
     directive-name  = "sandbox"
-    directive-value = "" / <a>token</a> *( <a>RWS</a> <a>token</a> )
+    directive-value = "" / "allow-forms" / "allow-modals" / "allow-pointer-lock" /
+                      "allow-popups" / "allow-popups-to-escape-sandbox" /
+                      "allow-same-origin" / "allow-scripts" / "allow-top-navigation"
   </pre>
 
   This directive has no reporting requirements; it will be ignored entirely when


### PR DESCRIPTION
Normatively require that valid directive-values for the `sandbox` directive be restricted to the same enumerated list of valid values that the HTML spec requires for `iframe[sandbox]` values.

**What problems this change would help solve:** Helps authors/developers avoid making the mistake of using non-standard values for the `sandbox` directive which UAs will just (silently) ignore, by having the document-conformance (authoring) side of the spec’s requirements explicitly restrict the valid directive-values for `sandbox` to the same set of `iframe[sandbox]`values actually defined in the HTML spec.

Adding this to the spec also enables a corresponding error message to be added to the W3C HTML checker—to, e.g., help authors/developers catch simple unintended misspellings like "`allow-models`"—while also allowing other CSP evaluation tools to provide similar checking.