### PR TITLE
Restrict valid sandbox values to keywords in HTML

### DIFF
--- a/document/index.html
+++ b/document/index.html
@@ -2,54 +2,311 @@
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Content Security Policy: Document Features</title>
-<style data-fill-with="stylesheet">/* This section copied from the W3C's ED styles. */
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     -> <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<section id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure);  }
+ *        .example::before { content: "Example " counter(example); }
+ *        .issue::before   { content: "Issue "   counter(issue);   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - back-to-top link:
+ *     <p role=navigation id="back-to-top"><a href="#toc"><abbr title="Back to Top">&uarr;</abbr>
+ *
+ ******************************************************************************/
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
 
 	body {
-		color: black;
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;           /* limit line length to 50em for readability   */
+		margin: 0;                 /* start-align text within page                     */
+		padding: 1.6em 1em 2em 58px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1em 2em calc(26px + 2em); /* leave space for status flag    */
+
+		/* Typography */
+		line-height: 1.5;
 		font-family: sans-serif;
-		margin: 0 auto;
-		max-width: 50em;
-		padding: 2em 1em 2em 70px;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px 380px;
 	}
-	:link { color: #00C; background: transparent }
-	:visited { color: #609; background: transparent }
-	a[href]:active { color: #C00; background: transparent }
-	a[href]:hover { background: #ffa }
 
-	a[href] img { border-style: none }
+	.overlarge {
+		width: calc(100vw - 26px - 3em);
+		max-width: none;
+	}
+	div.figure img,    div.sidefigure img,    figure img,
+	div.figure object, div.sidefigure object, figure object,
+	table.data, table.index {
+		max-width: calc(100vw - 26px - 3em);
+		/* See below for sidebar-accommodating override. */
+	}
 
-	h1, h2, h3, h4, h5, h6 { text-align: left }
-	h1, h2, h3 { color: #005A9C; }
-	h1 { font: 170% sans-serif }
-	h2 { font: 140% sans-serif }
-	h3 { font: 120% sans-serif }
-	h4 { font: bold 100% sans-serif }
-	h5 { font: italic 100% sans-serif }
-	h6 { font: small-caps 100% sans-serif }
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
 
-	.hide { display: none }
+/** Header ********************************************************************/
 
 	div.head { margin-bottom: 1em }
-	div.head h1 { margin-top: 2em; clear: both }
-	div.head table { margin-left: 2em; margin-top: 2em }
+	div.head hr { border-style: solid; }
 
-	p.copyright { font-size: small }
-	p.copyright small { font-size: small }
-
-	pre { margin-left: 2em }
-	dt { font-weight: bold }
-
-	ul.toc, ol.toc {
-		list-style: none;
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
 	}
 
-/* The rest copied from the CSSWG's default.css */
+	div.head h2 { margin-bottom: 1.5em;}
 
-	body {
-		counter-reset: exampleno figure issue;
-		max-width: 50em;
-		margin: 0 auto !important;
-		line-height: 1.5;
+	.head > :first-child {
+		float: right;
+		margin: 0;
+	}
+
+	@media screen {
+		.head > p:first-child > a {
+			display: inline-block;
+			background: url("logos/w3c-white.svg") no-repeat center / contain content-box border-box;
+			padding: .4rem .7rem;
+			border-radius: .4rem;
+			margin: .4rem 0 0 .4rem;
+			background-color: hsl(208, 71%, 35%);
+		}
+
+		.head > p:first-child > a > img {
+			visibility: hidden;
+		}
+
+		.head > p:first-child > a:hover,
+		.head > p:first-child > a:focus {
+			background-color: hsla(208, 71%, 35%,.8);
+		}
+
+		.head > p:first-child > a:active {
+			background-color: #c00;
+		}
+	}
+
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#back-to-top,
+		.toc-toggle {
+			display: none;
+		}
+	}
+	@media not print {
+		#back-to-top,
+		body > #toc-toggle {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			width: 26px;
+			text-align: center;
+			border-top-right-radius: 26px;
+			box-shadow: 0 0 2px;
+			font: 1em monospace;
+			font: 1rem monospace;
+			color: black;
+		}
+		#back-to-top a,
+		body > #toc-toggle {
+			display: block;
+			width: 22px;
+			height: 22px;
+			padding: 4px 4px 0 0;
+			margin: 0;
+			border: none;
+			border-top-right-radius: 26px;
+		}
+		#back-to-top :first-child {
+			display: block;
+			padding-bottom: 22px;
+			margin-bottom: -22px;
+		}
+		#back-to-top > a {
+			background: white;
+			box-shadow: 0 0 2px;
+		}
+		#back-to-top > a:hover,
+		#back-to-top > a:focus {
+			background: #f8f8f8;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		.toc-toggle:active,
+		#back-to-top :active {
+			color: #C00;
+		}
+
+		#back-to-top abbr {
+			border: none;
+			text-decoration: none;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #back-to-top :first-child {
+			display: none;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+			padding-right: 1.5em;
+		}
+		body:not(.toc-inline) .overlarge,
+		body:not(.toc-inline) div.figure img,
+		body:not(.toc-inline) div.sidefigure img,
+		body:not(.toc-inline) figure img,
+		body:not(.toc-inline) div.figure object,
+		body:not(.toc-inline) div.sidefigure object,
+		body:not(.toc-inline) figure object,
+		body:not(.toc-inline) table.data,
+		body:not(.toc-inline) table.index {
+			max-width: calc(100vw - 30.5em);
+		}
+
+		body:not(.toc-inline) #back-to-top :first-child {
+			display: none;
+		}
 	}
 
 /******************************************************************************/
@@ -60,19 +317,33 @@
 
 	h1, h2, h3, h4, h5, h6, dt {
 		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
 	}
 
-	h2, h3, h5, h6 {
-		margin-top: 3em;
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
 	}
-	h4 {
-		 margin-top: 4em;
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
 	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
 
 /** Subheadings ***************************************************************/
 
 	h1 + h2,
-	#subtitle + h2 {
+	#subtitle {
 		/* #subtitle is a subtitle in an H2 under the H1 */
 		margin-top: 0;
 	}
@@ -84,8 +355,8 @@
 	}
 
 /** Section divider ***********************************************************/
-	/* <hr> used to separate TMI into the second half of a section              */
-	hr:not([title]) {
+
+	:not(.head) > hr {
 		font-size: 1.5em;
 		text-align: center;
 		margin: 1em auto;
@@ -93,10 +364,9 @@
 		border: transparent solid 0;
 		background: transparent;
 	}
-	hr:not([title])::before {
-		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
 	}
-	/* note: <hr> with title separates document header from contents */
 
 /******************************************************************************/
 /*                            Paragraphs and Lists                            */
@@ -105,8 +375,9 @@
 	p {
 		margin: 1em 0;
 	}
-	dd     > p:first-child,
-	li     > p:first-child {
+
+	dd > p:first-child,
+	li > p:first-child {
 		margin-top: 0;
 	}
 
@@ -114,26 +385,27 @@
 		margin-left: 0;
 		padding-left: 2em;
 	}
+
 	li {
-		margin: 0.25em 2em 0.5em 0;
-		padding-left: 0;
+		margin: 0.25em 0 0.5em;
+		padding: 0;
 	}
 
 	dl dd {
 		margin: 0 0 1em 2em;
 	}
-	.head dd {
+
+	.head dd + dt {
+		margin-top: .5em;
+	}
+
+	.head dd { /* undo for header */
 		margin-bottom: 0;
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol {
-	 border-left: 1px solid #90b8de;
-	 margin-left: 1em;
-	}
-	ol.algorithm ol.algorithm {
-	 border-left: none;
-	 margin-left: 0;
+	ol.algorithm ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
 	}
 
 	/* Style for switch/case <dl>s */
@@ -160,32 +432,6 @@
 	 width: 1em;
 	 text-align: right;
 	 line-height: 0.5em;
-	}
-
-	/* Style for paragraphs I know are in MD-genned lists */
-	[data-md] > :first-child {
-		margin-top: 0;
-	}
-	[data-md] > :last-child {
-		margin-bottom: 0;
-	}
-
-/** Inline Lists **************************************************************/
-	/* This is mostly to make the list inside the CR exit criteria more compact. */
-
-	ol.inline, ol.inline li {
-		display: inline;
-		padding: 0; margin: 0;
-	}
-	ol.inline {
-		counter-reset: list-item;
-	}
-	ol.inline li {
-		counter-increment: list-item;
-	}
-	ol.inline li::before {
-		content: "(" counter(list-item) ") ";
-		font-weight: bold;
 	}
 
 /** Terminology Markup ********************************************************/
@@ -227,15 +473,615 @@
 
 /** General monospace/pre rules ***********************************************/
 
-	pre, code {
-		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
 		font-size: .9em;
 		page-break-inside: avoid;
+		hyphens: none;
 	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
 	pre {
 		margin-top: 1em;
 		margin-bottom: 1em;
 		overflow: auto;
+	}
+
+/** Inline Code fragments *****************************************************/
+
+  /* Do something nice. */
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a[href] {
+		color: inherit;
+		text-decoration: none;
+		border-bottom: 2px solid #949494;
+		margin: 0 -0.1em 0;
+	}
+	a:visited {
+		border-bottom-color: silver;
+	}
+	/* Consider making the border thinner, if not everywhere, then at least
+	   in .head and .index
+	   ... or only make it 2px in p/li/dd/dt/tr/div/pre (running text)  */
+
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -1px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head > p:first-child > a {
+		border: none;
+		text-decoration: none;
+	}
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+	}
+
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
+
+	figure, div.figure, div.sidefigure {
+		page-break-inside: avoid;
+		text-align: center;
+	}
+
+	div.figure, p.figure, div.sidefigure, figure {
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	div.figure pre, div.sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	div.sidefigure, figure.sidefigure {
+		float: right;
+		width: 50%;
+		margin: 0 0 0.5em 0.5em
+	}
+	p.caption, figcaption, caption {
+		font-style: italic;
+		font-size: 90%;
+	}
+	p.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	p.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > div.figure, dd > figure { margin-left: -2em }
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	div.issue,
+	div.note,
+	details.note,
+	aside.note,
+	div.example,
+	div.advisement,
+	p.advisement,
+	strong.advisement,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue::before, .issue > .marker {
+		text-transform: uppercase;
+		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
+	}
+	/* Add .issue::before { content: "Issue " counter(issue); } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: example;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		text-transform: uppercase;
+		color: #827017;
+		min-width: 7.5em;
+		display: block;
+	}
+	/* Add .example::before { content: "Example " counter(example); } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
+
+/** Non-normative Note ********************************************************/
+
+	.note {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+	}
+	strong.advisement {
+		display: block;
+		text-align: center;
+	}
+	.advisement > .marker {
+		color: #B35F00;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details {
+		display: block;
+	}
+	summary {
+		font-weight: bolder;
+	}
+
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
+		border-radius: 1em;
+	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
+}
+
+	details.annoying-warning:not([open]) > summary {
+		text-align: center;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.def {
+		/* inherits .def box styling, see above */
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	table.def td,
+	table.def th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.def th {
+		font-style: italic;
+		font-weight: normal;
+		padding-left: 1em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
+		padding-top: 0.6em;
+	}
+	table.def           td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Data tables (and properly marked-up index tables) *************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+	*/
+
+	table {
+		hyphens: manual;
+	}
+
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		width: 100%;
+		border: hidden;
+	}
+	table.data {
+		width: auto;
+	}
+	table.data caption,
+	table.index caption {
+		width: 100%;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	table.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
+		border-bottom: 2px solid;
+	}
+
+	table.data colgroup,
+	table.index colgroup {
+		border-left: 2px solid;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+
+	table.complex.data th,
+	table.complex.data td {
+		border: 1px solid silver;
+	}
+
+	table.data.longlastcol td:last-child,
+	table.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	table.data img {
+		vertical-align: middle;
+	}
+
+
+/*
+	a.property {
+		font-weight: bold;
+		color: hsla(203, 90%, 30%,.8);
+	}
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.2rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { margin: 1.2em 0;   font-weight: bold;   }
+	.toc > li li          { margin: 0;         font-weight: normal; }
+	.toc > li li li       { margin-left:  2em; font-style:  italic; }
+	.toc > li li li li    { margin-left:    0; font-style:  normal; }
+	.toc > li li li li li { margin-left: 1rem; font-style:  italic; font-size: 85%; }
+
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1em;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Consistent layout across link hover effects */
+		border-bottom-style: solid;
+		border-bottom-width: 3px;
+		margin-bottom: -1px;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	/* Section numbers in a column of their own */
+	:not(li) > .toc {
+		margin-left: 4em;
+	}
+
+	.toc .secno {
+		float: left;
+		width: 4em;
+		margin-left: -4em;
+	}
+
+	.toc > li li li .secno {
+		margin-left: -6em;
+	}
+	.toc > li li li li .secno {
+		font-size: 85%;
+		margin-left: -7.06em;
+		margin-left: -6rem;
+	}
+	.toc > li li li li li .secno {
+		margin-left: -8.24em;
+		margin-left: -7rem;
+		font-size: 100%;
+	}
+
+	.toc li {
+		clear: both;
+	}
+
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.index       { margin-left: 0; columns: 15em; -webkit-columns: 15em; -moz-columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: gray;
+		}
+	}
+
+/** Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.index {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.index td,
+	table.index th {
+		padding: 0.4em;
+	}
+
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
+	}
+
+	/* The link in the first column in the property table (formerly a TD) */
+	table.index th:first-child a {
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		/* Pages have their own margins. */
+		html {
+			margin: 0;
+		}
+		/* Serif for print. */
+		body {
+			font-family: serif;
+		}
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+/******************************************************************************/
+/*                                  Bikeshed                                  */
+/******************************************************************************/
+
+	/* Style for paragraphs I know are in MD-genned lists */
+	[data-md] > :first-child {
+		margin-top: 0;
+	}
+	[data-md] > :last-child {
+		margin-bottom: 0;
+	}
+
+	/* This is mostly to make the list inside the CR exit criteria more compact. */
+
+	ol.inline, ol.inline li {
+		display: inline;
+		padding: 0; margin: 0;
+	}
+	ol.inline {
+		counter-reset: list-item;
+	}
+	ol.inline li {
+		counter-increment: list-item;
+	}
+	ol.inline li::before {
+		content: "(" counter(list-item) ") ";
+		font-weight: bold;
 	}
 
 /** Syntax-Highlighted Code ***************************************************/
@@ -268,20 +1114,6 @@
 		color: red;
 	}
 
-/** IDL fragments *************************************************************/
-
-	pre.idl {
-		/* Match blue propdef boxes */
-		padding: .5em 1em;
-		background: #DEF;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-	}
-	pre.idl :link, pre.idl :visited {
-		color:inherit;
-		background:transparent;
-	}
-
 /** Inline CSS fragments ******************************************************/
 
 	.css.css, .property.property, .descriptor.descriptor {
@@ -300,7 +1132,7 @@
 		white-space: nowrap;
 	}
 	.type { /* CSS value <type> */
-	font-style: italic;
+		font-style: italic;
 	}
 	pre .property::before, pre .property::after {
 		content: "";
@@ -342,42 +1174,16 @@
 		content: "";
 	}
 
-	[data-link-type=element]         { font-family: monospace; }
+	[data-link-type=element],
+	[data-link-type=element-attr] {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+		font-size: .9em;
+	}
 	[data-link-type=element]::before { content: "<" }
 	[data-link-type=element]::after  { content: ">" }
 
 	[data-link-type=biblio] {
 		white-space: pre;
-	}
-
-
-/******************************************************************************/
-/*                                    Links                                   */
-/******************************************************************************/
-
-/** General Hyperlinks ********************************************************/
-
-	/* We hyperlink a lot, so make it less intrusive */
-	a:link, a:visited {
-		color: inherit;
-		text-decoration: none;
-		border-bottom: 1px solid silver;
-	}
-	@supports (text-decoration-color: silver) {
-		a:link, a:visited {
-			border-bottom: none;
-			text-decoration: underline;
-			text-decoration-color: silver;
-		}
-		a:visited {
-			text-decoration-style: dotted;
-		}
-	}
-
-	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
-		padding: 0;
-		border: none;
-		text-decoration: none;
 	}
 
 /** Self-Links ****************************************************************/
@@ -432,55 +1238,6 @@
 /*                                    Images                                  */
 /******************************************************************************/
 
-	img {
-		border-style: none;
-	}
-
-	figure, div.figure, div.sidefigure {
-		page-break-inside: avoid;
-	}
-
-	div.figure, p.figure, div.sidefigure, figure {
-		text-align: center;
-		margin: 2.5em 0;
-	}
-	div.figure pre, div.sidefigure pre, figure pre {
-		text-align: left;
-		display: table;
-		margin: 1em auto;
-	}
-	.figure table, figure table {
-		margin: auto;
-	}
-	div.sidefigure, figure.sidefigure {
-		float: right;
-		width: 50%;
-		margin: 0 0 0.5em 0.5em
-	}
-	div.figure img, div.sidefigure img, figure img,
-	div.figure object, div.sidefigure object, figure object {
-		display: block;
-		margin: auto;
-		max-width: 100%
-	}
-	p.caption, figcaption, caption {
-		text-align: center;
-		font-style: italic;
-		font-size: 90%;
-	}
-	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
-		content: "Figure " counter(figure) ". ";
-	}
-	p.caption::before, figcaption::before, figcaption > .marker {
-		font-weight: bold;
-	}
-	p.caption, figcaption {
-		counter-increment: figure;
-	}
-
-	/* DL list is indented 2em, but figure inside it is not */
-	dd > div.figure, dd > figure { margin-left: -2em }
-
 	pre.ascii-art {
 		display: table; /* shrinkwrap */
 		margin: 1em auto;
@@ -497,393 +1254,23 @@
 	}
 
 /******************************************************************************/
-/*                             Colored Boxes                                  */
+/*                                  Counters                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .why, .advisement, blockquote {
-		padding: .5em;
-		border: .5em;
-		border-left-style: solid;
-		page-break-inside: avoid;
-	}
-	span.issue, span.note {
-		padding: .1em .5em .15em;
-		border-right-style: solid;
-	}
-
-	div.issue,
-	div.note,
-	div.example,
-	details.why,
-	blockquote {
-		margin: 1em auto;
-	}
-	.note  > p:first-child,
-	.issue > p:first-child,
-	blockquote > :first-child {
-		margin-top: 0;
-	}
-	blockquote > :last-child {
-		margin-bottom: 0;
-	}
-
-/** Blockquotes ***************************************************************/
-
-	blockquote {
-		border-color: silver;
-	}
-
-/** Open issue ****************************************************************/
-	/* not intended for CR+ publication */
-
-	.issue {
-		border-color: #E05252;
-		background: #FBE9E9;
-		counter-increment: issue;
-		overflow: auto;
-	}
 	.issue:not(.no-marker)::before {
-		content: "ISSUE " counter(issue);
-		padding-right: 1em;
-	}
-	.issue::before, .issue > .marker {
-		color: #AE1E1E;
+		content: "Issue " counter(issue);
 	}
 
-/** Example *******************************************************************/
-
-	.example {
-		border-color: #E0CB52;
-		background: #FCFAEE;
-		counter-increment: exampleno;
-		overflow: auto;
-		clear: both;
-	}
-	.example::before, .example > .marker {
-		color: #827017;
-		font-family: sans-serif;
-		min-width: 7.5em;
-		display: block;
-	}
 	.example:not(.no-marker)::before {
-		content: "EXAMPLE";
-		content: "EXAMPLE " counter(exampleno);
-	}
-	.invalid.example::before, .invalid.example > .marker,
-	.illegal.example::before, .illegal.example > .marker {
-		color: red;
+		content: "Example";
+		content: "Example " counter(example);
 	}
 	.invalid.example:not(.no-marker)::before,
 	.illegal.example:not(.no-marker)::before {
-		content: "INVALID EXAMPLE";
-		content: "INVALID EXAMPLE" counter(exampleno);
+		content: "Invalid Example";
+		content: "Invalid Example" counter(example);
 	}
 
-/** Non-normative Note ********************************************************/
-
-	.note, .why {
-		border-color: #52E052;
-		background: #E9FBE9;
-		overflow: auto;
-	}
-	.note::before, .note > .marker {
-		display: block;
-		color: hsl(120, 70%, 30%);
-	}
-
-/** Advisement Box ************************************************************/
-	/*  for attention-grabbing normative statements */
-
-	.advisement {
-		border-color: orange;
-		border-style: none solid;
-		background: #FFEECC;
-		text-align: center;
-	}
-	strong.advisement {
-		display: block;
-	}
-	/*.advisement::before { color: #FF8800; } */
-
-/** ??? ***********************************************************************/
-
-	details.why {
-		border-color: #52E052;
-		background: #E9FBE9;
-		display: block;
-	}
-
-	details.why > summary {
-		font-style: italic;
-		display: block;
-	}
-
-	details.why[open] > summary {
-		border-bottom: 1px silver solid;
-	}
-
-/** Spec Obsoletion Notice ****************************************************/
-	/* obnoxious obsoletion notice for older/abandoned specs. */
-
-	details.annoying-warning {
-		display: block;
-	}
-
-	details.annoying-warning[open] {
-		background: #fdd;
-		color: red;
-		font-weight: bold;
-		text-align: center;
-		padding: .5em;
-		border: thick solid red;
-		border-radius: 1em;
-	}
-@media not print {
-	details.annoying-warning[open] {
-		position: fixed;
-		left: 1em;
-		right: 1em;
-		bottom: 1em;
-		z-index: 1000;
-	}
-}
-
-	details.annoying-warning:not([open]) > summary {
-		background: #fdd;
-		color: red;
-		font-weight: bold;
-		text-align: center;
-		padding: .5em;
-	}
-
-/******************************************************************************/
-/*                                    Tables                                  */
-/******************************************************************************/
-
-/** Property/Descriptor Definition Tables *************************************/
-
-	table.propdef, table.propdef-extra,
-	table.descdef, table.definition-table {
-		page-break-inside: avoid;
-		width: 100%;
-		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
-		padding: 0.5em 1em;
-		background: #DEF;
-		border-spacing: 0;
-	}
-
-	table.propdef td, table.propdef-extra td,
-	table.descdef td, table.definition-table td,
-	table.propdef th, table.propdef-extra th,
-	table.descdef th, table.definition-table th {
-		padding: 0.5em;
-		vertical-align: baseline;
-		border-bottom: 1px solid #bbd7e9;
-	}
-	table.propdef > tbody > tr:last-child th,
-	table.propdef-extra > tbody > tr:last-child th,
-	table.descdef > tbody > tr:last-child th,
-	table.definition-table > tbody > tr:last-child th,
-	table.propdef > tbody > tr:last-child td,
-	table.propdef-extra > tbody > tr:last-child td,
-	table.descdef > tbody > tr:last-child td,
-	table.definition-table > tbody > tr:last-child td {
-		border-bottom: 0;
-	}
-
-	table.propdef th,
-	table.propdef-extra th,
-	table.descdef th,
-	table.definition-table th {
-		font-style: italic;
-		font-weight: normal;
-		width: 8.3em;
-		padding-left: 1em;
-	}
-
-	/* For when values are extra-complex and need formatting for readability */
-	table td.pre {
-		white-space: pre-wrap;
-	}
-
-	/* A footnote at the bottom of a propdef */
-	table.propdef td.footnote,
-	table.propdef-extra td.footnote,
-	table.descdef td.footnote,
-	table.definition-table td.footnote {
-		padding-top: 0.6em;
-	}
-	table.propdef td.footnote::before,
-	table.propdef-extra td.footnote::before,
-	table.descdef td.footnote::before,
-	table.definition-table td.footnote::before {
-		content: " ";
-		display: block;
-		height: 0.6em;
-		width: 4em;
-		border-top: thin solid;
-	}
-
-/** Profile Tables ************************************************************/
-	/* table of required features in a CSS profile */
-
-	table.features th {
-		background: #00589f;
-		color: #fff;
-		text-align: left;
-		padding: 0.2em 0.2em 0.2em 0.5em;
-	}
-	table.features td {
-		vertical-align: top;
-		border-bottom: 1px solid #ccc;
-		padding: 0.3em 0.3em 0.3em 0.7em;
-	}
-
-/** Data tables (and properly marked-up proptables) ***************************/
-	/*
-		 <table class="data"> highlights structural relationships in a table
-		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
-
-		 Use class="complex data" for particularly complicated tables --
-		 (This will draw more lines: busier, but clearer.)
-
-		 Use class="long" on table cells with paragraph-like contents
-		 (This will adjust text alignment accordingly.)
-	*/
-
-	.data, .proptable {
-		margin: 1em auto;
-		border-collapse: collapse;
-		width: 100%;
-		border: hidden;
-	}
-	.data {
-		text-align: center;
-		width: auto;
-	}
-	.data caption {
-		width: 100%;
-	}
-
-	.data td, .data th,
-	.proptable td, .proptable th {
-		padding: 0.5em;
-		border-width: 1px;
-		border-color: silver;
-		border-top-style: solid;
-	}
-
-	.data thead td:empty {
-		padding: 0;
-		border: 0;
-	}
-
-	.data thead th[scope="row"],
-	.proptable thead th[scope="row"] {
-		text-align: right;
-		color: inherit;
-	}
-
-	.data thead,
-	.proptable thead,
-	.data tbody,
-	.proptable tbody {
-		color: inherit;
-		border-bottom: 2px solid;
-	}
-
-	.data colgroup {
-		border-left: 2px solid;
-	}
-
-	.data tbody th:first-child,
-	.proptable tbody th:first-child ,
-	.data tbody td[scope="row"]:first-child,
-	.proptable tbody td[scope="row"]:first-child {
-		text-align: right;
-		color: inherit;
-		border-right: 2px solid;
-		border-top: 1px solid silver;
-		padding-right: 1em;
-	}
-	.data.define td:last-child {
-		text-align: left;
-	}
-
-	.data tbody th[rowspan],
-	.proptable tbody th[rowspan],
-	.data tbody td[rowspan],
-	.proptable tbody td[rowspan]{
-		border-left:  1px solid silver;
-		border-right: 1px solid silver;
-	}
-
-	.complex.data th,
-	.complex.data td {
-		border: 1px solid silver;
-	}
-
-	.data td.long {
-	 vertical-align: baseline;
-	 text-align: left;
-	}
-
-	.data img {
-		vertical-align: middle;
-	}
-
-
-/******************************************************************************/
-/*                                  Indices                                   */
-/******************************************************************************/
-
-
-/** Table of Contents *********************************************************/
-
-	/* ToC not indented, but font style shows hierarchy */
-	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
-	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
-	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
-	ul.toc ul ul ul  { margin: 0; }
-	ul.toc > li      { margin: 1.5em 0; }
-	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
-
-	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
-	ul.toc a { text-decoration: none; border-bottom-style: none; }
-	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
-	@supports (text-decoration-style: solid) {
-		ul.toc a:hover, ul.toc a:focus  {
-			border-bottom-style: none;
-			text-decoration-style: solid;
-		}
-	}
-	/*
-	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
-	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
-	*/
-
-	/* Section numbers in a column of their own */
-	ul.toc {
-		margin-left: 5em
-	}
-	ul.toc span.secno {
-		float: left;
-		width: 4em;
-		margin-left: -5em;
-	}
-	ul.toc ul ul span.secno {
-		margin-left: -7em;
-	}
-	/*ul.toc span.secno {text-align: right}*/
-	ul.toc li {
-		clear: both;
-	}
-	/* If we had 'tab', floats would not be needed here:
-		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
-		 ul.toc li {text-indent: 5em hanging}
-	 The second line in case items wrap
-	*/
 
 /** At-risk List **************************************************************/
 	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
@@ -903,96 +1290,6 @@
 	}
 
 	.toc .atrisk::before { content:none }
-
-/** Index *********************************************************************/
-
-	/* Index Lists: Layout */
-	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
-	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
-	ul.indexlist li li { margin-left: 1em }
-	ul.indexlist dl    { margin-top: 0; }
-	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
-	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
-	/* Index Lists: Typography */
-	ul.indexlist ul,
-	ul.indexlist dl { font-size: smaller; }
-	ul.indexlist li span {
-		white-space: nowrap;
-		position: absolute;
-		color: transparent; }
-	ul.indexlist li a:hover + span,
-	ul.indexlist li a:focus + span {
-		color: gray;
-	}
-	@media print {
-		ul.indexlist li span { color: gray; }
-	}
-
-/** Property Index Tables *****************************************************/
-	/* See also the data table styling section, which this effectively subclasses */
-
-	table.proptable {
-		font-size: small;
-		border-collapse: collapse;
-		border-spacing: 0;
-		text-align: left;
-		margin: 1em 0;
-	}
-
-	table.proptable td,
-	table.proptable th {
-		padding: 0.4em;
-		text-align: center;
-	}
-
-	table.proptable tr:hover td {
-		background: #DEF;
-	}
-	.propdef th {
-		font-style: italic;
-		font-weight: normal;
-		text-align: left;
-		width: 3em;
-	}
-	/* The link in the first column in the property table (formerly a TD) */
-	table.proptable td .property,
-	table.proptable th .property {
-		display: block;
-		text-align: left;
-		font-weight: bold;
-	}
-
-/** Extra-large Elements ******************************************************/
-
-	.big-element-wrapper {
-		max-width: 50em;
-		overflow-x: auto;
-	}
-
-/******************************************************************************/
-/*                                    Print                                   */
-/******************************************************************************/
-
-	@media print {
-		html {
-			margin: 0 !important; }
-		body {
-			font-family: serif; }
-		th, td {
-			font-family: inherit; }
-		a {
-			color: inherit !important; }
-
-		a:link, a:visited {
-			text-decoration: none !important }
-		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
-		.example::before {
-			font-family: serif !important; }
-	}
-	@page {
-		margin: 1.5cm 1.1cm;
-	}
-
 </style>
   <meta content="Bikeshed 1.0.0" name="generator">
 <style>
@@ -1008,7 +1305,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Content Security Policy: Document Features</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2015-12-07">7 December 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-01-18">18 January 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1024,7 +1321,7 @@
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -1057,73 +1354,73 @@ environment.</p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
-  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
-  <div data-fill-with="table-of-contents" role="navigation">
-   <ul class="toc" role="directory">
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
     <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
     <li>
      <a href="#directives"><span class="secno">2</span> <span class="content">Directives</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li>
        <a href="#directives-features"><span class="secno">2.1</span> <span class="content">Feature Directives</span></a>
-       <ul class="toc">
+       <ol class="toc">
         <li>
          <a href="#directive-base-uri"><span class="secno">2.1.1</span> <span class="content"><code>base-uri</code></span></a>
-         <ul class="toc">
+         <ol class="toc">
           <li><a href="#allow-base-for-document"><span class="secno">2.1.1.1</span> <span class="content"> Is <var>base</var> allowed for <var>document</var>? </span></a>
-         </ul>
+         </ol>
         <li><a href="#directive-disable"><span class="secno">2.1.2</span> <span class="content"><code>disable</code></span></a>
         <li><a href="#directive-plugin-types"><span class="secno">2.1.3</span> <span class="content"><code>plugin-types</code></span></a>
         <li>
          <a href="#directive-sandbox"><span class="secno">2.1.4</span> <span class="content"><code>sandbox</code></span></a>
-         <ul class="toc">
+         <ol class="toc">
           <li><a href="#sandbox-algorithms"><span class="secno">2.1.4.1</span> <span class="content">Algorithms</span></a>
-         </ul>
-       </ul>
+         </ol>
+       </ol>
       <li>
        <a href="#directives-navigation"><span class="secno">2.2</span> <span class="content">Navigation Directives</span></a>
-       <ul class="toc">
+       <ol class="toc">
         <li><a href="#directive-form-action"><span class="secno">2.2.1</span> <span class="content"><code>form-action</code></span></a>
         <li>
          <a href="#directive-frame-ancestors"><span class="secno">2.2.2</span> <span class="content"><code>frame-ancestors</code></span></a>
-         <ul class="toc">
+         <ol class="toc">
           <li><a href="#frame-ancestors-algorithms"><span class="secno">2.2.2.1</span> <span class="content">Algorithms</span></a>
-         </ul>
-       </ul>
-     </ul>
+         </ol>
+       </ol>
+     </ol>
     <li>
      <a href="#integrations"><span class="secno">3</span> <span class="content">Integrations</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#html-integration"><span class="secno">3.1</span> <span class="content">Integration with HTML</span></a>
-     </ul>
+     </ol>
     <li><a href="#security-considerations"><span class="secno">4</span> <span class="content">Security Considerations</span></a>
     <li>
      <a href="#privacy-considerations"><span class="secno">5</span> <span class="content">Privacy Considerations</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#ancestor-origin-leakage"><span class="secno">5.1</span> <span class="content">Ancestor Origin Leakage</span></a>
-     </ul>
+     </ol>
     <li><a href="#iana-considerations"><span class="secno">6</span> <span class="content">IANA Considerations</span></a>
     <li>
      <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
       <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
-     </ul>
+     </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
+     <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
-     </ul>
+     </ol>
     <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
-   </ul>
-  </div>
+   </ol>
+  </nav>
   <main>
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
@@ -1210,7 +1507,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>The <dfn data-dfn-type="dfn" data-noexport="" id="sandbox">sandbox<a class="self-link" href="#sandbox"></a></dfn> directive specifies an HTML sandbox policy which the
   user agent will apply to a resource, just as though it had been included in
   an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> with a <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox">sandbox</a></code> property.</p>
-    <p>The directive’s syntax is described by the following ABNF grammar:</p>
+    <p>The directive’s syntax is described by the following ABNF grammar, with
+  the additional requirement that each token value MUST be one of the
+  keywords defined by HTML specification as allowed values for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox">sandbox</a></code> attribute <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
 <pre>directive-name  = "sandbox"
 directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">RWS</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> )
 </pre>
@@ -1345,22 +1644,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
   <p>Conformance requirements are expressed with a combination of
-    descriptive assertions and RFC 2119 terminology. The key words "MUST",
-    "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
+    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
     document are to be interpreted as described in RFC 2119.
     However, for readability, these words do not appear in all uppercase
     letters in this specification. </p>
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-  <p>Examples in this specification are introduced with the words "for example"
+  <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
   <div class="example" id="example-f839f6c8">
    <a class="self-link" href="#example-f839f6c8"></a> 
    <p>This is an example of an informative example.</p>
   </div>
-  <p>Informative notes begin with the word "Note" and are set apart from the
+  <p>Informative notes begin with the word “Note” and are set apart from the
     normative text with <code>class="note"</code>, like this: </p>
   <p class="note" role="note">Note, this is an informative note.</p>
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
@@ -1375,7 +1674,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     are encouraged to optimize.</p>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="indexlist">
+  <ul class="index">
    <li><a href="#grammardef-ancestor-source">ancestor-source</a><span>, in §2.2.2</span>
    <li><a href="#grammardef-ancestor-source-list">ancestor-source-list</a><span>, in §2.2.2</span>
    <li><a href="#base-uri">base-uri</a><span>, in §2.1.1</span>
@@ -1386,7 +1685,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
    <li><a href="#sandbox">sandbox</a><span>, in §2.1.4</span>
   </ul>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
-  <ul class="indexlist">
+  <ul class="index">
    <li>
     <a data-link-type="biblio" href="#biblio-csp">[CSP]</a> defines the following terms:
     <ul>
@@ -1488,9 +1787,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
    <dt id="biblio-geolocation-api"><a class="self-link" href="#biblio-geolocation-api"></a>[geolocation-API]
    <dd>Andrei Popescu. <a href="http://www.w3.org/TR/geolocation-API/">Geolocation API Specification</a>. 28 May 2015. PER. URL: <a href="http://www.w3.org/TR/geolocation-API/">http://www.w3.org/TR/geolocation-API/</a>
    <dt id="biblio-notifications"><a class="self-link" href="#biblio-notifications"></a>[NOTIFICATIONS]
-   <dd>John Gregg; Anne van Kesteren. <a href="http://www.w3.org/TR/notifications/">Web Notifications</a>. 10 September 2015. PR. URL: <a href="http://www.w3.org/TR/notifications/">http://www.w3.org/TR/notifications/</a>
+   <dd>John Gregg; Anne van Kesteren. <a href="http://www.w3.org/TR/notifications/">Web Notifications</a>. 22 October 2015. REC. URL: <a href="http://www.w3.org/TR/notifications/">http://www.w3.org/TR/notifications/</a>
    <dt id="biblio-push-api"><a class="self-link" href="#biblio-push-api"></a>[PUSH-API]
-   <dd>Bryan Sullivan; Eduardo Fullea; Michael van Ouwerkerk. <a href="http://www.w3.org/TR/push-api/">Push API</a>. 27 April 2015. WD. URL: <a href="http://www.w3.org/TR/push-api/">http://www.w3.org/TR/push-api/</a>
+   <dd>Michael van Ouwerkerk; et al. <a href="http://www.w3.org/TR/push-api/">Push API</a>. 15 December 2015. WD. URL: <a href="http://www.w3.org/TR/push-api/">http://www.w3.org/TR/push-api/</a>
    <dt id="biblio-webmidi"><a class="self-link" href="#biblio-webmidi"></a>[WEBMIDI]
    <dd>Chris Wilson; Jussi Kalliokoski. <a href="http://www.w3.org/TR/webmidi/">Web MIDI API</a>. 17 March 2015. WD. URL: <a href="http://www.w3.org/TR/webmidi/">http://www.w3.org/TR/webmidi/</a>
    <dt id="biblio-webrtc"><a class="self-link" href="#biblio-webrtc"></a>[WEBRTC]

--- a/document/index.src.html
+++ b/document/index.src.html
@@ -214,7 +214,10 @@ spec:dom-ls; type:interface; text:Document
   user agent will apply to a resource, just as though it had been included in
   an <{iframe}> with a <{iframe/sandbox}> property.
 
-  The directive's syntax is described by the following ABNF grammar:
+  The directive's syntax is described by the following ABNF grammar, with
+  the additional requirement that each token value MUST be one of the
+  keywords defined by HTML specification as allowed values for the <{iframe}>
+  <{iframe/sandbox}> attribute [[!HTML]].
 
   <pre dfn-type="grammar" link-type="grammar">
     directive-name  = "sandbox"


### PR DESCRIPTION
Normatively require that valid directive-values for the `sandbox` directive be restricted to the allowed values the HTML spec defines for `iframe[sandbox]` (but define the allowed values indirectly, by just referencing the HTML spec (rather than explicitly listing the values in the directive-value production for the `sandbox` directive).

Supersedes #55