### PR TITLE
Add manifest-src to the default-src examples

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1634,6 +1634,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
                                <a>connect-src</a> <a grammar>'self'</a>;
                                <a>font-src</a> <a grammar>'self'</a>;
                                <a>img-src</a> <a grammar>'self'</a>;
+                               <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> <a grammar>'self'</a>;
@@ -1659,6 +1660,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
                                <a>connect-src</a> <a grammar>'self'</a>;
                                <a>font-src</a> <a grammar>'self'</a>;
                                <a>img-src</a> <a grammar>'self'</a>;
+                               <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> https://example.com;


### PR DESCRIPTION
Adding `manifest-src` to the example explaining `default-src` for the sake of complete picture