### PR TITLE
Update references to w3c.org to use HTTPS

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -34,12 +34,12 @@ spec: ECMA262; urlPrefix: https://tc39.github.io/ecma262
     text: eval(); url: sec-eval-x
     text: Function(); url: sec-function-objects
     text: JSON.stringify(); url: sec-json.stringify
-spec: DOM; urlPrefix: http://www.w3.org/TR/dom/
+spec: DOM; urlPrefix: https://www.w3.org/TR/dom/
   type: interface
     text: Element; url: interface-element
   type: attribute
     text: textContent; for: Node; url: dom-node-textcontent
-spec: HTML5; urlPrefix: http://www.w3.org/TR/html5/
+spec: HTML5; urlPrefix: https://www.w3.org/TR/html5/
   type: dfn
     urlPrefix: embedded-content-0.html
       text: an iframe srcdoc document
@@ -158,7 +158,7 @@ spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
       text: window; url:concept-request-window
   type: interface
     text: Request
-spec: MIX; urlPrefix: http://www.w3.org/TR/mixed-content/
+spec: MIX; urlPrefix: https://www.w3.org/TR/mixed-content/
   type: dfn; text: block-all-mixed-content
 spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
@@ -177,13 +177,13 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
     text: scheme; for: URL; url: concept-url-scheme
   type: interface;
     text: URL
-spec: SERVICE-WORKERS; urlPrefix: http://www.w3.org/TR/service-workers/
+spec: SERVICE-WORKERS; urlPrefix: https://www.w3.org/TR/service-workers/
   type: interface
     text: ServiceWorker; url: service-worker-interface
-spec: WORKERS; urlPrefix: http://www.w3.org/TR/workers/
+spec: WORKERS; urlPrefix: https://www.w3.org/TR/workers/
   type: interface
     text: Worker
-spec: CSSOM; urlPrefix: http://www.w3.org/TR/cssom/
+spec: CSSOM; urlPrefix: https://www.w3.org/TR/cssom/
   type: dfn
     text: insert a css rule
     text: parse a css declaration block
@@ -253,7 +253,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   },
   "HTML-DESIGN": {
     "authors": [ "Anne Van Kesteren", "Maciej Stachowiak" ],
-    "href": "http://www.w3.org/TR/html-design-principles/",
+    "href": "https://www.w3.org/TR/html-design-principles/",
     "title": "HTML Design Principles",
     "publisher": "W3C"
   },


### PR DESCRIPTION
Take advantage of w3c.org serving over HTTPS already.

N.B. @michaelficarra, can you do something about http://www.ecma-international.org serving invalid certificate?