### PR TITLE
Fixing a typo in Element Matching Algorithms

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2517,7 +2517,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
           to `true`.
 
   3.  If |contains nonce or hash| is `false`, and |list| contains a
-      <a>source expression</a> which is a <a>case-sensitive</a> match for
+      <a>source expression</a> which is a <a>case-insensitive</a> match for
       the string "`unsafe-inline`", then return "`Matches`".
 
   4.  If |type| is not "`script attribute`" or "`style attribute`":


### PR DESCRIPTION
I believe matching `unsafe-inline` keyword case-sensitively is a typo.