### PR TITLE
Change `scheme-source` grammar

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -614,13 +614,13 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
     <dfn>source-expression</dfn>      = <a>scheme-source</a> / <a>host-source</a> / <a>keyword-source</a>
                              / <a>nonce-source</a> / <a>hash-source</a>
 
-    ; Schemes:
-    <dfn>scheme-source</dfn> = <a>scheme</a> ":"
-                    ; <a>scheme</a> is defined in section 3.1 of RFC 3986.
+    ; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
+    <dfn>scheme-source</dfn> = <a>scheme-part</a> ":"
 
     ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
     <dfn>host-source</dfn> = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
-    <dfn>scheme-part</dfn> = <a>scheme</a>
+    <dfn>scheme-part</dfn> = <a>scheme</a> 
+                  ; <a>scheme</a> is defined in section 3.1 of RFC 3986.
     <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
     <dfn>host-char</dfn>   = <a>ALPHA</a> / <a>DIGIT</a> / "-"
     <dfn>port-part</dfn>   = ":" ( 1*<a>DIGIT</a> / "*" )


### PR DESCRIPTION
There is a small inaccuracy in source expression matching algorithm:
In section [6.1.11.4](https://api.csswg.org/bikeshed/#match-url-to-source-expression) we hit step 2.1 if the expression matches `scheme-source` **or** `host-source`
grammar. 
> If expression has a scheme-part that is not an ASCII case-insensitive match for url’s scheme, then return "Does Not Match" unless one of the following conditions is met:

However, checks in step 2.1 and steps 2.1.x will hit only `host-source` checks, as `scheme-part` is
not defined for `scheme-source`:

This patch changes the definition of `scheme-src` to reference `scheme-part`, so that the
logic in the source expression matching algorithm aligns with the intended logic.