### PR TITLE
A note clarifying "'unsafe-inline'" redundancy if hash/nonce present

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2652,7 +2652,11 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   5.  If |contains nonce or hash| is `false`, and |list| contains a
       <a>source expression</a> which is an <a>ASCII case-insensitive match</a>
-      for the string "`unsafe-inline`", then return "`Matches`".
+      for the string "'unsafe-inline'", then return "`Matches`".
+
+      Note: This logic means that if |source list| contains both "'unsafe-inline'"
+      and either <a grammar>`nonce-source`</a> or <a grammar>`hash-source`</a>,
+      "'unsafe-inline'" will have no effect.
 
   6.  If |type| is "`script`" or "`style`":
 


### PR DESCRIPTION
in the same source list. Apparently, that behavour is not obvious.
https://github.com/shapesecurity/salvation/issues/130, for instance.