### PR TITLE
Add missing request destination for request type "script"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2774,6 +2774,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
         1.  Switch on |request|'s <a for="request">destination</a>, and
             execute the associated steps:
 
+            : "`script`"
             : "`subresource`"
             ::
               1.  Return `script-src`.


### PR DESCRIPTION
Fetch [defines](https://fetch.spec.whatwg.org/#concept-request-destination) destination "script" for request type "script", which is missing in the [6.1.13.5. Get the effective directive for request](https://w3c.github.io/webappsec-csp/#effective-directive-for-a-request). 