### PR TITLE
Added "policyDisposition" property on SecurityPolicyViolationEvent

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -678,7 +678,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
 
   Each <a>violation</a> has a
   <dfn for="violation" id="violation-disposition" export>disposition</dfn>, which is the
-  <a>disposition</a> of the <a>policy</a> that has been violated.
+  <a for="policy">disposition</a> of the <a>policy</a> that has been violated.
 
   Each <a>violation</a> has an
   <dfn for="violation" id="violation-effective-directive" export>effective directive</dfn>

--- a/index.src.html
+++ b/index.src.html
@@ -676,6 +676,10 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
   <dfn for="violation" id="violation-policy" export>policy</dfn>, which is the
   <a>policy</a> that has been violated.
 
+  Each <a>violation</a> has a
+  <dfn for="violation" id="violation-disposition" export>disposition</dfn>, which is the
+  <a>disposition</a> of the <a>policy</a> that has been violated.
+
   Each <a>violation</a> has an
   <dfn for="violation" id="violation-effective-directive" export>effective directive</dfn>
   which is a non-empty string representing the <a>directive</a> whose
@@ -1321,6 +1325,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
         readonly    attribute DOMString      violatedDirective;
         readonly    attribute DOMString      effectiveDirective;
         readonly    attribute DOMString      originalPolicy;
+        readonly    attribute DOMString      disposition;
         readonly    attribute DOMString      sourceFile;
         readonly    attribute unsigned short statusCode;
         readonly    attribute long           lineNumber;
@@ -1334,6 +1339,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
         DOMString      violatedDirective;
         DOMString      effectiveDirective;
         DOMString      originalPolicy;
+        DOMString      disposition;
         DOMString      sourceFile;
         unsigned short statusCode;
         long           lineNumber;
@@ -1367,6 +1373,9 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
       :: |violation|'s <a for="violation">effective directive</a>
       :  "`original-policy`"
       :: The <a lt="serialized CSP">serialization</a> of |violation|'s
+         <a for="violation">policy</a>
+      :  "`disposition`"
+      :: The <a for="policy">disposition</a> of |violation|'s
          <a for="violation">policy</a>
       :  "`status-code`"
       :: |violation|'s <a for="violation">status</a>
@@ -1410,6 +1419,8 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
       :: |violation|'s <a for="violation">effective directive</a>
       :  {{SecurityPolicyViolationEvent/originalPolicy}}
       :: |violation|'s <a for="violation">policy</a>
+      :  {{SecurityPolicyViolationEvent/disposition}}
+      :: |violation|'s <a for="violation">disposition</a>
       :  {{SecurityPolicyViolationEvent/sourceFile}}
       :: |violation|'s <a for="violation">source file</a>
       :  {{SecurityPolicyViolationEvent/statusCode}}


### PR DESCRIPTION
This commit addresses #94 by adding "policyDisposition" property
on `SecurityPolicyViolationEvent` and violation object.