### PR TITLE
Add frame-src, worker-src to default-src examples

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1708,15 +1708,16 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
     will have the same behavior as the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>child-src</a> <a grammar>'self'</a>;
-                               <a>connect-src</a> <a grammar>'self'</a>;
+      <a>Content-Security-Policy</a>: <a>connect-src</a> <a grammar>'self'</a>;
                                <a>font-src</a> <a grammar>'self'</a>;
+                               <a>frame-src</a> <a grammar>'self'</a>;
                                <a>img-src</a> <a grammar>'self'</a>;
                                <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> <a grammar>'self'</a>;
-                               <a>style-src</a> <a grammar>'self'</a>
+                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
     That is, when `default-src` is set, every <a>fetch directive</a> that isn't
@@ -1734,15 +1735,16 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/publications/fips/fips180-4/fips-180
     will have the same behavior as the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>child-src</a> <a grammar>'self'</a>;
-                               <a>connect-src</a> <a grammar>'self'</a>;
+      <a>Content-Security-Policy</a>: <a>connect-src</a> <a grammar>'self'</a>;
                                <a>font-src</a> <a grammar>'self'</a>;
+                               <a>frame-src</a> <a grammar>'self'</a>;
                                <a>img-src</a> <a grammar>'self'</a>;
                                <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> https://example.com;
-                               <a>style-src</a> <a grammar>'self'</a>
+                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
     Given this behavior, one good way to build a policy for a site would be to


### PR DESCRIPTION
These are fetch directives that should be covered by `default-src`, but were missing from examples.