### PR TITLE
Fix 'unsafe-hash-attributes' example

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3795,7 +3795,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
     "`'unsafe-hashed-attributes'`" along with a hash source expression, as follows:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a grammar>'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+      <a>Content-Security-Policy</a>:  <a>default-src</a> <a grammar>'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
     </pre>
   </div>
 

--- a/index.src.html
+++ b/index.src.html
@@ -3795,7 +3795,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
     "`'unsafe-hashed-attributes'`" along with a hash source expression, as follows:
 
     <pre>
-      <a>Content-Security-Policy</a>:  <a>default-src</a> <a grammar>'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+      <a>Content-Security-Policy</a>:  <a>script-src</a> <a grammar>'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
     </pre>
   </div>
 


### PR DESCRIPTION
Missing a directive in the example.