### PR TITLE
Editorial: Update spelling of HTML terms to en-US

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -334,7 +334,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   9.  The <a>source expression</a> matching has been changed to require explicit whitelisting
       of any non-<a>network scheme</a>, rather than <a>local scheme</a>,
       unless that non-<a>network scheme</a> is the same as the scheme of protected resource,
-      as described in [[#match-url-to-source-expression]]. 
+      as described in [[#match-url-to-source-expression]].
 
   10. Hash-based source expressions may now whitelist external scripts if the
       <{script}> element that triggers the request specifies a set of integrity
@@ -354,7 +354,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   A <dfn export>policy</dfn> defines a set of allowed and
   restricted behaviors, and may be applied to a {{Window}} or
   {{WorkerGlobalScope}} as described in [[#initialize-global-object-csp]].
-  
+
   Each policy has an associated <dfn for="policy" export>directive set</dfn>, which
   is a set of <a>directives</a> that define the policy's implications when
   applied.
@@ -365,7 +365,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   A <dfn export>serialized CSP</dfn> is an ASCII string, consisting of a
   semicolon-delimited series of <a>serialized directives</a>, adhering to the
   following ABNF grammar [[!RFC5234]]:
- 
+
   <pre dfn-type="grammar" link-type="grammar">
     <dfn>serialized-policy</dfn> = <a>serialized-directive</a> *( <a>OWS</a> ";" [ <a>OWS</a> <a>serialized-directive</a> ] )
                         ; <a>OWS</a> is defined in section 3.2.3 of RFC 7230
@@ -545,20 +545,20 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
     ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
     <dfn>host-source</dfn> = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
-    <dfn>scheme-part</dfn> = <a>scheme</a> 
+    <dfn>scheme-part</dfn> = <a>scheme</a>
                   ; <a>scheme</a> is defined in section 3.1 of RFC 3986.
     <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
     <dfn>host-char</dfn>   = <a>ALPHA</a> / <a>DIGIT</a> / "-"
     <dfn>port-part</dfn>   = ":" ( 1*<a>DIGIT</a> / "*" )
     <dfn>path-part</dfn>   = <a>path</a>
                   ; <a>path</a> is defined in section 3.3 of RFC 3986.
-   
+
     ; Keywords:
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>" / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashed-attributes'</dfn>"
 
     ; Nonces: 'nonce-[nonce goes here]'
     <dfn>nonce-source</dfn>  = "'nonce-" <a>base64-value</a> "'"
-    <dfn>base64-value</dfn>  = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" ) 
+    <dfn>base64-value</dfn>  = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
 
     ; Digests: 'sha256-[digest goes here]'
     <dfn>hash-source</dfn>    = "'" <a>hash-algorithm</a> "-" <a>base64-value</a> "'"
@@ -840,7 +840,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   delivered via an HTTP response header field before any <a for="/">global object</a>
   is created in order to handle directives that require knowledge of a
   <a>response</a>'s details. To that end:
-  
+
   1.  A <a>response</a> has an associated <a for="response">CSP list</a> which
       contains any policy objects delivered in the <a>response</a>'s
       <a for="response">header list</a>.
@@ -873,7 +873,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       in |response|'s <a for="response">header list</a>, with a disposition
       of "`enforce`".
 
-  3.  Append to |policies| the result of executing 
+  3.  Append to |policies| the result of executing
       [[#parse-serialized-policy-list]] on the result of
       <a lt="parse a header value">parsing</a>
       `Content-Security-Policy-Report-Only` in |response|'s
@@ -932,7 +932,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           [[#does-request-violate-policy]] on |request| and |policy|.
 
       3.  If |violates| is not "`Does Not Violate`", then:
-     
+
           1.  Execute [[#report-violation]] on the result of executing
               [[#create-violation-for-request]] on |request|, |policy|, and
               |violates|.
@@ -1012,7 +1012,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       <a for="/">global object</a> by inserting it into the <a for="/">global object</a>'s
       <a for="global object">CSP list</a>.
 
-  3.  [[#initialize-global-object-csp]] is called during the <a>initialising a
+  3.  [[#initialize-global-object-csp]] is called during the <a>initializing a
       new `Document` object</a> and <a>run a worker</a> algorithms in order to
       bind a set of <a>policy</a> objects associated with a <a>response</a> to a
       newly created <a for="/">global object</a>.
@@ -1345,7 +1345,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
   1.  Let |object| be a new JavaScript object with properties initialized as
       follows:
-      
+
       :  "`document-uri`"
       :: The result of executing the <a>URL serializer</a> on |violation|'s
          <a for="violation">url</a>, with the `exclude fragment` flag set.
@@ -1421,7 +1421,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   2.  If |violation|'s <a for="violation">policy</a>'s <a for="policy">directive
       set</a> contains a <a>directive</a> named "<a>`report-uri`</a>"
       (|directive|):
-    
+
       1.  If |violation|'s <a for="violation">policy</a>'s
           <a for="policy">directive set</a> contains a <a>directive</a> named
           "<a>`report-to`</a>", skip the remaining substeps.
@@ -1553,7 +1553,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
      <a for="request">target browsing context</a> is a <a>nested browsing
      context</a> (e.g. requests which will populate an <{iframe}> or <{frame}>
      element)
-     
+
   *  <a for="request">destination</a> is either "`serviceworker`",
      "`sharedworker`", or "`worker`" (which are fed to the <a>run a worker</a>
      algorithm for {{ServiceWorker}}, {{SharedWorker}}, and {{Worker}},
@@ -1667,7 +1667,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
         xhr.send();
 
         var ws = new WebSocket("https://not-example.com/");
-        
+
         var es = new EventSource("https://not-example.com/");
 
         navigator.sendBeacon("https://not-example.com/", { ... });
@@ -1720,7 +1720,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
   <h4 id="directive-default-src">`default-src`</h4>
 
-  The <dfn export>default-src</dfn> directive serves as a fallback for the other 
+  The <dfn export>default-src</dfn> directive serves as a fallback for the other
   <a>fetch directives</a>. The syntax for the directive's name and value is described by
   the following ABNF:
 
@@ -2289,7 +2289,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   </pre>
 
   The `script-src` directive governs four things:
-  
+
   1.  Script <a>requests</a> MUST pass through [[#should-block-request]].
 
   2.  Script <a>responses</a> MUST pass through [[#should-block-response]].
@@ -2419,7 +2419,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
 
   1.  If |type| is "`script attribute`":
-      
+
       1.  If |list| contains a <a>source expression</a> which is an <a>ASCII
           case-insensitive</a> match for the <a grammar>keyword-source</a>
           "<a grammar>`'strict-dynamic'`</a>", and does not contain a
@@ -2467,7 +2467,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           rule.
       3.  Stylesheet requests originating from a `Link` HTTP response header
           field [[!RFC5988]].
-  
+
   2.  <a>Responses</a> to style requests MUST pass through
       [[#should-block-response]].
 
@@ -2549,7 +2549,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
 
   1.  If |type| is "`style`" or "`style attribute`":
- 
+
       1.  If the result of executing [[#match-element-to-source-list]] on
           |element|, this directive's <a for="directive">value</a>, |type|,
           and |source|, is "`Does Not Match`", return "`Blocked`".
@@ -3006,7 +3006,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
         1.  Set |current| to |parent|.
 
         2.  Let |origin| be the result of executing the <a>URL parser</a> on the
-            <a lt="unicode serialisation of an origin">unicode serialization</a>
+            <a lt="unicode serialization of an origin">unicode serialization</a>
             of |parent|'s <a>active document</a>'s <a for="">origin</a>.
 
         3.  If [[#match-url-to-source-list]] returns `Does Not Match` when
@@ -3202,10 +3202,10 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
   1.  If |expression| is the string "*", return "`Matches`" if one or more of
       the following conditions is met:
-      
+
       1. |url|'s {{URL/scheme}} is a <a>network scheme</a>.
 
-      2. |url|'s {{URL/scheme}} is the same as |origin|'s {{URL/scheme}}. 
+      2. |url|'s {{URL/scheme}} is the same as |origin|'s {{URL/scheme}}.
 
       Note: This logic means that in order to allow resource from a non-<a>network scheme</a>,
       it has to be either explicitly whitelisted: `default-src * data: custom-scheme-1: custom-scheme-2:`,
@@ -3218,11 +3218,11 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           <a>ASCII case-insensitive</a> match for |url|'s {{URL/scheme}}, then
           return "`Does Not Match`" unless one of the following conditions is
           met:
-         
+
           1.  |expression|'s <a grammar>`scheme-part`</a> is an <a>ASCII
               case-insensitive</a> match for "`http`" and |url|'s {{URL/scheme}}
               is "`https`"
-              
+
           2.  |expression|'s <a grammar>`scheme-part`</a> is an <a>ASCII
               case-insensitive</a> match for "`ws`" and |url|'s {{URL/scheme}}
               is "`wss`", "`http`" or "`https`"
@@ -3237,12 +3237,12 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       Note: This logic effectively means that `script-src http:` is
       equivalent to `script-src http: https:`, and
       `script-src http://example.com/` is equivalent to `script-src
-      http://example.com https://example.com`. As well as WebSocket 
+      http://example.com https://example.com`. As well as WebSocket
       schemes are equivalent to corresponding HTTP schemes. In short,
       we always allow a secure upgrade from an explicitly insecure expression.
 
   3.  If |expression| matches the <a grammar>`host-source`</a> grammar:
-  
+
       1.  If |url|'s {{URL/host}} is `null`, return "`Does Not Match`".
 
       2.  If |expression| does not have a <a grammar>`scheme-part`</a>, then
@@ -3260,10 +3260,10 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           Note: As with <a grammar>`scheme-part`</a> above, we allow schemeless
           <a grammar>`host-source`</a> expressions to be upgraded from insecure
           schemes to secure schemes.
-      
+
       3.  If the first character of |expression|'s <a grammar>`host-part`</a>
           is an U+002A ASTERISK character (`*`):
-          
+
           1.  Let |remaining| be the result of removing the leading "`*`" from
               |expression|.
 
@@ -3344,7 +3344,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           |origin|'s {{URL/port}} and |url|'s {{URL/port} are either the same
           or the <a>default ports</a> for their respective {{URL/scheme}}s, and
           one or more of the following conditions is met:
-          
+
           1.  |url|'s {{URL/scheme}} is "`https`" or "`wss`"
           2.  |origin|'s {{URL/scheme}} is "`http`"
 
@@ -3513,7 +3513,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       1.  For each |expression| in |list|:
 
           1.  If |expression| matches the <a grammar>`hash-source`</a> grammar:
-              
+
               1.  Let |algorithm| be `null`.
 
               2.  If |expression|'s <a grammar>`hash-algorithm`</a> part is an
@@ -3597,7 +3597,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   The [[#is-element-nonceable]] algorithm attempts to mitigate this specific
   attack by walking through <{script}> element attributes, looking for the
   string "`<script`" or "`<style`" in their names or values.
-  
+
   <h3 id="security-css-parsing">CSS Parsing</h3>
 
   The <a>style-src</a> directive restricts the locations from which the
@@ -3782,7 +3782,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   script, but now that Subresource Integrity is widely deployed, we can expand
   the scope to enable externalized JavaScript as well.
 
-  
+
   If multiple sets of integrity metadata are specified for a <{script}>, the
   request will match a policy's <a grammar>hash-source</a>s if and only if
   <em>each</em> item in a <{script}>'s integrity metadata matches the policy.


### PR DESCRIPTION
initialising -> initializing
serialisation -> serialization

Ref. https://github.com/whatwg/html/issues/654

(Trailing whitespace was also stripped and possibly a newer version
of Bikeshed caused various changes in the generated index.html.)