### PR TITLE
Use request's "current url" rather than "url".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1451,7 +1451,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-20">20 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-04">4 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2248,11 +2248,14 @@ of security-relevant policy decisions.</p>
     <ol>
      <li data-md="">
       <p><a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> is called as part of step #5 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#main-fetch">Main
-  Fetch</a> algorithm.</p>
+  Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-1">pre-request checks</a> to be executed against each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> before it hits the network,
+  and against each redirect that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> might go through on its
+  way to reaching a resource.</p>
      <li data-md="">
       <p><a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> is called as part of step #13 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#main-fetch">Main
-  Fetch</a> algorithm.</p>
+  Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-1">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-1">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> delivered
+  from the network or from a Service Worker.</p>
     </ol>
     <p>A <a data-link-type="dfn" href="#policy" id="ref-for-policy-18">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>, but the
   user agent needs to <a data-link-type="dfn" href="#parse-serialized-policy" id="ref-for-parse-serialized-policy-4">parse</a> any policy
@@ -2348,7 +2351,7 @@ of security-relevant policy decisions.</p>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
          <li data-md="">
-          <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-1">post-request check</a> is "<code>Blocked</code>", then:</p>
+          <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-2">post-request check</a> is "<code>Blocked</code>", then:</p>
           <ol>
            <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.3.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>directive</var>.</p>
@@ -2368,7 +2371,7 @@ of security-relevant policy decisions.</p>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
          <li data-md="">
-          <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-1">response check</a> on <var>request</var>, <var>response</var>,
+          <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-2">response check</a> on <var>request</var>, <var>response</var>,
   and <var>policy</var> is "<code>Blocked</code>", then:</p>
           <ol>
            <li data-md="">
@@ -3005,7 +3008,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-1">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-2">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-26">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3015,11 +3018,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-8">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
-      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-2">pre-request
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-3">pre-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-16">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-9">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-9">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-2">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-3">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-27">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3029,7 +3032,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-10">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
-      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-3">post-request
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-4">post-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-17">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-11">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-10">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
@@ -3073,7 +3076,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-3">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-4">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-28">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3090,7 +3093,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-4">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-5">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-29">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3160,7 +3163,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     particular page the policy will apply to.</p>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-4">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-5">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-30">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3176,11 +3179,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive" could return "<code>child-src</code>" and that could delegate out in the
   same way this algorithm does?</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-5">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-20">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-14">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-6">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-20">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-14">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-13">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-5">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-6">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-31">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3196,7 +3199,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive" could return "<code>child-src</code>" and that could delegate out in the
   same way this algorithm does?</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-6">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-23">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-17">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-14">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-7">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives-23">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-17">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-14">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
@@ -3224,7 +3227,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-6">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-7">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-32">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3240,7 +3243,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-7">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-8">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-33">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3272,7 +3275,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-7">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-8">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-34">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3289,7 +3292,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-8">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-9">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-35">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3324,7 +3327,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-8">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-9">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-36">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3340,7 +3343,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-9">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-10">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-37">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3372,7 +3375,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-9">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-10">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-38">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3388,7 +3391,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-10">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-11">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-39">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3423,7 +3426,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-10">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-11">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-40">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3440,7 +3443,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-11">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-12">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-41">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3484,7 +3487,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.9.1" id="object-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-11">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-12">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-42">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3500,7 +3503,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-12">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-13">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-43">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3551,7 +3554,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="note" role="note">Note: If a user agent implements non-standard sinks like <code>setImmediate()</code> or <code>execScript()</code>, they SHOULD also be gated on "<code>unsafe-eval</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.10.1" id="script-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-12">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-13">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-44">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3609,7 +3612,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.10.2" id="script-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-13">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-14">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-45">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3706,7 +3709,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.11.1" id="style-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-13">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-14">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-46">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3726,7 +3729,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.11.2" id="style-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-14">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-15">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-47">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3784,7 +3787,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.12.1" id="worker-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-14">pre-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-15">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-48">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3801,7 +3804,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.12.2" id="worker-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-15">post-request check</a> is as follows:</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-16">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-49">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
@@ -3906,7 +3909,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-16">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-17">post-request check</a> algorithm is as
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-50">policy</a> (<var>policy</var>):</p>
     <ol>
@@ -3971,7 +3974,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
   delivered in a <a data-link-type="dfn" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only-4"><code>Content-Security-Policy-Report-Only</code></a> header, or within
   a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element.</p>
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-2">response check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-3">response check</a> algorithm is as
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#policy" id="ref-for-policy-51">policy</a> (<var>policy</var>):</p>
     <ol>
@@ -4179,7 +4182,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-15">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-17">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-3">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-16">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-18">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-4">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization-5">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
     <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
@@ -4195,7 +4198,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-16">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-17">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
@@ -4223,14 +4226,14 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.1.3" id="match-request-to-source-list"><span class="secno">6.6.1.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-13">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">redirect
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note">Note: This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives-28">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-17">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> is reasonable.</p>
+    <p class="note" role="note">Note: This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives-28">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-18">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.1.4" id="match-response-to-source-list"><span class="secno">6.6.1.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-14">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note">Note: This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives-29">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-18">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> is reasonable.</p>
+    <p class="note" role="note">Note: This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives-29">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-19">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.1.5" id="match-url-to-source-list"><span class="secno">6.6.1.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-15">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
@@ -5889,85 +5892,91 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="directive-pre-request-check">
    <b><a href="#directive-pre-request-check">#directive-pre-request-check</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directive-pre-request-check-1">6.1.1.1. 
-    child-src Pre-request check </a> <a href="#ref-for-directive-pre-request-check-2">(2)</a>
-    <li><a href="#ref-for-directive-pre-request-check-3">6.1.2.1. 
+    <li><a href="#ref-for-directive-pre-request-check-1">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-directive-pre-request-check-2">6.1.1.1. 
+    child-src Pre-request check </a> <a href="#ref-for-directive-pre-request-check-3">(2)</a>
+    <li><a href="#ref-for-directive-pre-request-check-4">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-4">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directive-pre-request-check-5">(2)</a>
-    <li><a href="#ref-for-directive-pre-request-check-6">6.1.4.1. 
+    <li><a href="#ref-for-directive-pre-request-check-5">6.1.3.1. 
+    default-src Pre-request check </a> <a href="#ref-for-directive-pre-request-check-6">(2)</a>
+    <li><a href="#ref-for-directive-pre-request-check-7">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-7">6.1.5.1. 
+    <li><a href="#ref-for-directive-pre-request-check-8">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-8">6.1.6.1. 
+    <li><a href="#ref-for-directive-pre-request-check-9">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-9">6.1.7.1. 
+    <li><a href="#ref-for-directive-pre-request-check-10">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-10">6.1.8.1. 
+    <li><a href="#ref-for-directive-pre-request-check-11">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-11">6.1.9.1. 
+    <li><a href="#ref-for-directive-pre-request-check-12">6.1.9.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-12">6.1.10.1. 
+    <li><a href="#ref-for-directive-pre-request-check-13">6.1.10.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check-13">6.1.11.1. 
+    <li><a href="#ref-for-directive-pre-request-check-14">6.1.11.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check-14">6.1.12.1. 
+    <li><a href="#ref-for-directive-pre-request-check-15">6.1.12.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check-15">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check-16">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check-16">6.6.1.1. 
+    <li><a href="#ref-for-directive-pre-request-check-17">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check-17">6.6.1.3. 
+    <li><a href="#ref-for-directive-pre-request-check-18">6.6.1.3. 
     Does request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-post-request-check">
    <b><a href="#directive-post-request-check">#directive-post-request-check</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directive-post-request-check-1">4.1.4. 
+    <li><a href="#ref-for-directive-post-request-check-1">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-directive-post-request-check-2">4.1.4. 
     Should response to request be blocked by Content
     Security Policy? </a>
-    <li><a href="#ref-for-directive-post-request-check-2">6.1.1.2. 
-    child-src Post-request check </a> <a href="#ref-for-directive-post-request-check-3">(2)</a>
-    <li><a href="#ref-for-directive-post-request-check-4">6.1.2.2. 
+    <li><a href="#ref-for-directive-post-request-check-3">6.1.1.2. 
+    child-src Post-request check </a> <a href="#ref-for-directive-post-request-check-4">(2)</a>
+    <li><a href="#ref-for-directive-post-request-check-5">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-5">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directive-post-request-check-6">(2)</a>
-    <li><a href="#ref-for-directive-post-request-check-7">6.1.4.2. 
+    <li><a href="#ref-for-directive-post-request-check-6">6.1.3.2. 
+    default-src Post-request check </a> <a href="#ref-for-directive-post-request-check-7">(2)</a>
+    <li><a href="#ref-for-directive-post-request-check-8">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-8">6.1.5.2. 
+    <li><a href="#ref-for-directive-post-request-check-9">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-9">6.1.6.2. 
+    <li><a href="#ref-for-directive-post-request-check-10">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-10">6.1.7.2. 
+    <li><a href="#ref-for-directive-post-request-check-11">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-11">6.1.8.2. 
+    <li><a href="#ref-for-directive-post-request-check-12">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-12">6.1.9.2. 
+    <li><a href="#ref-for-directive-post-request-check-13">6.1.9.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-13">6.1.10.2. 
+    <li><a href="#ref-for-directive-post-request-check-14">6.1.10.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check-14">6.1.11.2. 
+    <li><a href="#ref-for-directive-post-request-check-15">6.1.11.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check-15">6.1.12.2. 
+    <li><a href="#ref-for-directive-post-request-check-16">6.1.12.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check-16">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check-17">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check-17">6.5. 
+    <li><a href="#ref-for-directive-post-request-check-18">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check-18">6.6.1.4. 
+    <li><a href="#ref-for-directive-post-request-check-19">6.6.1.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-response-check">
    <b><a href="#directive-response-check">#directive-response-check</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directive-response-check-1">4.1.4. 
+    <li><a href="#ref-for-directive-response-check-1">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-directive-response-check-2">4.1.4. 
     Should response to request be blocked by Content
     Security Policy? </a>
-    <li><a href="#ref-for-directive-response-check-2">6.2.3.1. 
+    <li><a href="#ref-for-directive-response-check-3">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-response-check-3">6.5. 
+    <li><a href="#ref-for-directive-response-check-4">6.5. 
     Directives Defined in Other Documents </a>
    </ul>
   </aside>

--- a/index.src.html
+++ b/index.src.html
@@ -866,10 +866,15 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   with a <a>network error</a>.
 
   1.  [[#should-block-request]] is called as part of step #5 of its <a>Main
-      Fetch</a> algorithm.
+      Fetch</a> algorithm. This allows directives' <a>pre-request checks</a>
+      to be executed against each <a>request</a> before it hits the network,
+      and against each redirect that a <a>request</a> might go through on its
+      way to reaching a resource.
 
   2.  [[#should-block-response]] is called as part of step #13 of its <a>Main
-      Fetch</a> algorithm.
+      Fetch</a> algorithm. This allows directives' <a>post-request checks</a>
+      and <a>response checks</a> to be executed on the <a>response</a> delivered
+      from the network or from a Service Worker.
 
   A <a>policy</a> is generally enforced upon a <a for="/">global object</a>, but the
   user agent needs to <a lt="parse a serialized CSP">parse</a> any policy
@@ -3260,7 +3265,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
   Given a <a>request</a> (|request|), and a <a>source list</a> (|source list|),
   this algorithm returns the result of executing [[#match-url-to-source-list]]
-  on |request|'s <a for="request">url</a>, |source list|, |request|'s
+  on |request|'s <a for="request">current url</a>, |source list|, |request|'s
   <a for="request">origin</a>, and |request|'s <a for="request">redirect
   count</a>.
 


### PR DESCRIPTION
In pre-request checks, we ought to be checking the current redirect
target, rather than the initial URL requested.

Addresses w3c/webappsec-csp#134. h/t @estark37 and @annevk.