### PR TITLE
Make mode explicit.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1502,10 +1502,10 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
               ::  ""
               :   <a for="request">type</a>
               ::  ""
-              :   <a for="request">cache mode</a>
-              ::  "`no-cache`"
               :   <a for="request">credentials mode</a>
               ::  "`same-origin`"
+              :   <a for="request">keepalive</a>
+              ::  "`true`"
               :   <a for="request">header list</a>
               ::  A header list containing a single header whose name is
                   "`Content-Type`", and value is "`application/csp-report`"
@@ -1514,6 +1514,8 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
                   |violation|
               :   <a for="request">redirect mode</a>
               ::  "`error`"
+
+              Note: |request|'s <a for="request">mode</a> defaults to "`no-cors`"; the response is ignored entirely.
 
           5.  <a for="/">Fetch</a> |request|. The result will be ignored.
 


### PR DESCRIPTION
As discussed with @mikewest, this PR makes the `mode` in *Report a violation* request explicit to help make it more clear for implementers. 