### PR TITLE
Fixes "Does path A match path B?"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -61,6 +61,7 @@ spec:infra;
     text:set; for: / 
     text:append; for: set
     text:empty; for: set
+    text:strictly split a string
 </pre>
 <pre class="anchors">
 spec: RFC6454; urlPrefix: https://tools.ietf.org/html/rfc6454
@@ -3568,7 +3569,9 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   6.  If |exact match| is `true`, and |path list A| does not have the same
       number of items as |path list B|, return "`Does Not Match`".
 
-  7.  For each |piece A| in |path list A|:
+  7. If |exact match| is `false`, remove last item from |path list A|.
+
+  8.  For each |piece A| in |path list A|:
 
       1.  Let |piece B| be the next item in |path list B|.
 
@@ -3579,7 +3582,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       4.  If |piece A| is not a <a>case-sensitive</a> match
           for |piece B|, return "`Does Not Match`".
 
-  8.  Return "`Matches`".
+  9.  Return "`Matches`".
 
   <h5 id="effective-directive-for-a-request" algorithm>
     Get the effective directive for |request|

--- a/index.src.html
+++ b/index.src.html
@@ -3569,7 +3569,11 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   6.  If |exact match| is `true`, and |path list A| does not have the same
       number of items as |path list B|, return "`Does Not Match`".
 
-  7. If |exact match| is `false`, remove last item from |path list A|.
+  7.  If |exact match| is `false`:                                                                                                
+ 
+      1.  Assert: the final item in |path list A| is the empty string.
+     
+      2.  Remove the final item from |path list A|.
 
   8.  For each |piece A| in |path list A|:
 


### PR DESCRIPTION
- Refer to "strictly splitting a string" definition in infra,
rather than in HTML spec, which will be removed soon.
Details in https://github.com/whatwg/html/issues/2242.
- Adjust "Does path A match path B?" to work as expected with
updated "strictly splitting a string" algorithm
Fixes #171


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/shekyan/webappsec-csp/path-matching.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/2c673cb...shekyan:aa946ed.html)