### PR TITLE
Make algo 6.6.1.1 accumulate violated directives

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -972,7 +972,8 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       3.  If |violates| is not "`Does Not Violate`", then:
 
           1.  For each |token| returned by
-	      <a lt="split a string on commas">splitting |violates| on commas</a>:xecute [[#report-violation]] on the result of executing
+	      <a lt="split a string on commas">splitting |violates| on commas</a>:
+	      execute [[#report-violation]] on the result of executing
               [[#create-violation-for-request]] on |request|, |policy|, and
               |token|.
 
@@ -3336,10 +3337,10 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
           <a for="directive">pre-request check</a> on |request| and |policy|.
 
       2.  If |result| is "`Blocked`", then if |violates| is "`none`"
-	  let |violates| be |directive|, otherwise append "`, `" and |directive|
+	  then set |violates| to |directive|, otherwise append "`, `" and |directive|
 	  to |violates|.
 	  
-  3.  If |violates| is "`none`", the let |violates| be "`Does Not Violate`"
+  3.  If |violates| is "`none`", the set |violates| to "`Does Not Violate`"
 
   4.  Return |violates|.
 

--- a/index.src.html
+++ b/index.src.html
@@ -941,10 +941,11 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       2.  Let |violates| be the result of executing
           [[#does-request-violate-policy]] on |request| and |policy|.
 
-      3.  If |violates| is not "`Does Not Violate`", then execute
-          [[#report-violation]] on the result of executing
+      3.  If |violates| is not "`Does Not Violate`", then for each |token|
+	  returned by <a lt="split a string on commas">splitting |violates| on commas</a>:
+	  execute [[#report-violation]] on the result of executing
           [[#create-violation-for-request]] on |request|, |policy|, and
-          |violates|.
+          |token|.
 
   <h4 id="should-block-request" algorithm>
     Should |request| be blocked by Content Security Policy?
@@ -970,9 +971,10 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 
       3.  If |violates| is not "`Does Not Violate`", then:
 
-          1.  Execute [[#report-violation]] on the result of executing
+          1.  For each |token| returned by
+	      <a lt="split a string on commas">splitting |violates| on commas</a>:xecute [[#report-violation]] on the result of executing
               [[#create-violation-for-request]] on |request|, |policy|, and
-              |violates|.
+              |token|.
 
           2.  Set |result| to "`Blocked`".
 
@@ -3326,16 +3328,20 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   algorithm returns the violated <a>directive</a> if the request violates the
   policy, and "`Does Not Violate`" otherwise.
 
-  1.  Let |violates| be "`Does Not Violate`".
+  1.  Let |violates| be "`none`".
 
   2.  For each |directive| in |policy|:
 
       1.  Let |result| be the result of executing |directive|'s
           <a for="directive">pre-request check</a> on |request| and |policy|.
 
-      2.  If |result| is "`Blocked`", then let |violates| be |directive|.
+      2.  If |result| is "`Blocked`", then if |violates| is "`none`"
+	  let |violates| be |directive|, otherwise append "`, `" and |directive|
+	  to |violates|.
+	  
+  3.  If |violates| is "`none`", the let |violates| be "`Does Not Violate`"
 
-  3.  Return |violates|.
+  4.  Return |violates|.
 
   <h5 id="match-nonce-to-source-list" algorithm>
     Does |nonce| match |source list|?


### PR DESCRIPTION
Fix #195

This is a little clunky - there are multiple ways to express this algorithm. And it returns a comma-separated set of directives, as a random choice.

I think I've got all the spots where the effect carries through to other algorithms, but it's late and I don't know this spec backwards, so checking twice would be smart.