### PR TITLE
Adds WorkletGlobalScope as a concept to CSP.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1217,12 +1217,19 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       therefore alias the <a>embedding document</a>'s policies for <a>an iframe
       `srcdoc` `Document`</a>.
 
-    2.  If |global| is a {{SharedWorkerGlobalScope}}, {{ServiceWorkerGlobalScope}}, or
-        {{WorkletGlobalScope}}:
+  2.  If |global| is a {{SharedWorkerGlobalScope}} or {{ServiceWorkerGlobalScope}}:
 
       1.  For each |policy| in |response|'s
           <a for="response">CSP list</a>, insert |policy| into
           |global|'s <a for="global object">CSP list</a>.
+
+  3. If |global| is a {{WorkletGlobalScope}}:
+
+      1. Let |owner| be |global|'s [=WorkletGlobalScope/owner document=].
+
+      2. For each |policy| in |owner|'s <a for="global object">CSP list</a>:
+
+          1.  Insert an alias to |policy| in |global|'s <a for="global object">CSP list</a>.
 
   <h4 id="should-block-inline" algorithm>
     Should |element|'s inline |type| behavior be blocked by Content Security Policy?

--- a/index.src.html
+++ b/index.src.html
@@ -135,11 +135,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     for: WorkerGlobalScope
       text: owner set; url: concept-WorkerGlobalScope-owner-set
-
-spec: WORKLETS-1; urlPrefix: https://drafts.css-houdini.org/worklets/
-  type: dfn
-    for: WorkletGlobalScope
-      text: owner document; url: workletglobalscope-owner-document
 </pre>
 <pre class="biblio">
 {

--- a/index.src.html
+++ b/index.src.html
@@ -370,8 +370,8 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   <h3 id="framework-policy">Policies</h3>
 
   A <dfn export lt="content security policy object" local-lt="policy">policy</dfn> defines allowed
-  and restricted behaviors, and may be applied to a {{Window}} or {{WorkerGlobalScope}} as described
-  in [[#initialize-global-object-csp]].
+  and restricted behaviors, and may be applied to a {{Window}}, {{WorkerGlobalScope}, or
+  {{WorkletGlobalScope}} as described in [[#initialize-global-object-csp]].
 
   Each policy has an associated <dfn for="policy" export>directive set</dfn>, which is an <a>ordered
   set</a> of <a>directives</a> that define the policy's implications when applied.
@@ -1031,7 +1031,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
     Integration with HTML
   </h3>
 
-  1.  The {{Document}} and {{WorkerGlobalScope}} objects have a
+  1.  The {{Document}}, {{WorkerGlobalScope}}, and {{WorkletGlobalScope}} objects have a
       <dfn for="global object" id="global-object-csp-list">CSP list</dfn>,
       which holds all the <a for="/">policy</a> objects which are active for a given
       context. This list is empty unless otherwise specified, and is populated
@@ -1166,7 +1166,8 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       therefore alias the <a>embedding document</a>'s policies for <a>an iframe
       `srcdoc` `Document`</a>.
 
-  2.  If |global| is a {{SharedWorkerGlobalScope}} or {{ServiceWorkerGlobalScope}}:
+    2.  If |global| is a {{SharedWorkerGlobalScope}}, {{ServiceWorkerGlobalScope}}, or
+        {{WorkletGlobalScope}}:
 
       1.  For each |policy| in |response|'s
           <a for="response">CSP list</a>, insert |policy| into

--- a/index.src.html
+++ b/index.src.html
@@ -135,6 +135,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     for: WorkerGlobalScope
       text: owner set; url: concept-WorkerGlobalScope-owner-set
+
+spec: WORKLETS-1; urlPrefix: https://drafts.css-houdini.org/worklets/
+  type: dfn
+    for: WorkletGlobalScope
+      text: owner document; url: workletglobalscope-owner-document
 </pre>
 <pre class="biblio">
 {


### PR DESCRIPTION
This allows worklets to properly initialize their CSP list for each
global scope they have.

Fixes #204.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/bfgeek/webappsec-csp/master.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/eff9c9c...bfgeek:a10f951.html)