### PR TITLE
Clean up CSP list initialization.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2694cf87482eb631bb8582afc69be1fae22f2bff" name="generator">
+  <meta content="Bikeshed version aa692b5bb18791d7660cd494994fd0ac2ec23132" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
 <style>
   ul.toc ul ul ul {
@@ -1454,7 +1454,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-20">20 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-27">27 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1574,7 +1574,7 @@ of security-relevant policy decisions.</p>
        <a href="#html-integration"><span class="secno">4.2</span> <span class="content"> Integration with HTML </span></a>
        <ol class="toc">
         <li><a href="#initialize-document-csp"><span class="secno">4.2.1</span> <span class="content"> Initialize a <code>Document</code>'s <code>CSP list</code> </span></a>
-        <li><a href="#initialize-global-object-csp"><span class="secno">4.2.2</span> <span class="content"> Initialize a global object’s <code>CSP list</code> </span></a>
+        <li><a href="#initialize-worker-csp"><span class="secno">4.2.2</span> <span class="content"> Initialize a worker’s <code>CSP list</code> </span></a>
         <li><a href="#should-block-inline"><span class="secno">4.2.3</span> <span class="content"> Should <var>element</var>’s inline <var>type</var> behavior be blocked by Content Security Policy? </span></a>
         <li><a href="#should-block-navigation-request"><span class="secno">4.2.4</span> <span class="content"> Should <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked
     by Content Security Policy? </span></a>
@@ -1938,8 +1938,8 @@ of security-relevant policy decisions.</p>
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
     <h3 class="heading settled" data-level="2.2" id="framework-policy"><span class="secno">2.2. </span><span class="content">Policies</span><a class="self-link" href="#framework-policy"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
-  and restricted behaviors, and may be applied to a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> as described
-  in <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>.</p>
+  and restricted behaviors, and may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> via <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>, or
+  a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> as described in <a href="#initialize-worker-csp">§4.2.2 Initialize a worker’s CSP list</a>.</p>
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-directive-set">directive set</dfn>, which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">ordered
   set</a> of <a data-link-type="dfn" href="#directives" id="ref-for-directives-1">directives</a> that define the policy’s implications when applied.</p>
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-disposition">disposition</dfn>, which is either
@@ -2237,7 +2237,7 @@ of security-relevant policy decisions.</p>
   whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<code>Content-Security-Policy</code>". For example:</p>
     <div class="example" id="example-f977fbdb">
      <a class="self-link" href="#example-f977fbdb"></a> 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">meta</span> <span class="na">http-equiv</span><span class="o">=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content</span><span class="o">=</span><span class="s">"script-src 'self'"</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;meta</span> <span class="na">http-equiv=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content=</span><span class="s">"script-src 'self'"</span><span class="nt">></span>
 </pre>
     </div>
     <p>Implementation details can be found in HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">Content Security Policy
@@ -2417,12 +2417,12 @@ of security-relevant policy decisions.</p>
       <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> objects have a <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn>,
   which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-19">policy</a> objects which are active for a given
   context. This list is empty unless otherwise specified, and is populated
-  via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
+  via the <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-worker-csp">§4.2.2 Initialize a worker’s CSP list</a> algorithms.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md="">
       <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-20">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-4">CSP list</a>.</p>
      <li data-md="">
-      <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">initializing a
+      <p><a href="#initialize-worker-csp">§4.2.2 Initialize a worker’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">run a worker</a> algorithms in order to
   bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-21">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to a
   newly created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>.</p>
@@ -2466,35 +2466,38 @@ of security-relevant policy decisions.</p>
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#process-a-navigate-response">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a></p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Initialize a Document&apos;s CSP list" data-level="4.2.1" id="initialize-document-csp"><span class="secno">4.2.1. </span><span class="content"> Initialize a <code>Document</code>'s <code>CSP list</code> </span><a class="self-link" href="#initialize-document-csp"></a></h4>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> (<var>document</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), the
-  user agent performs the following steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>:</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> (<var>document</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), the user agent performs the
+  following steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a></p>
     <ol>
      <li data-md="">
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a>:</p>
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>documents</var> be an empty list.</p>
+        <p>Let <var>ancestors</var> be an empty list.</p>
        <li data-md="">
-        <p>If <var>document</var> has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-1">embedding document</a> (<var>embedding</var>), then add <var>embedding</var> to <var>documents</var>.</p>
+        <p>If <var>document</var> has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-1">embedding document</a> (<var>embedding</var>), then add <var>embedding</var> to <var>ancestors</var>.</p>
        <li data-md="">
-        <p>If <var>document</var> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">opener browsing context</a>, then add its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> to <var>documents</var>.</p>
+        <p>If <var>document</var> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">opener browsing context</a>, then add its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> to <var>ancestors</var>.</p>
        <li data-md="">
-        <p>For each <var>doc</var> in <var>documents</var>:</p>
+        <p>For each <var>ancestor</var> in <var>ancestors</var>:</p>
         <ol>
          <li data-md="">
-          <p>For each <var>policy</var> in <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>:</p>
+          <p>For each <var>policy</var> in <var>ancestor</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>:</p>
           <ol>
            <li data-md="">
-            <p>Insert an alias to <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
+            <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
           </ol>
         </ol>
       </ol>
-      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore alias the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-2">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-23">policy</a> by embedding a frame or popping up a new window containing content it
-  controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
+      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a> includes <code>about:</code>, and this algorithm will therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-2">embedding document</a>'s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe srcdoc Document</a>.</p>
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its policy by embedding a frame or
+  popping up a new window containing content it controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md="">
-      <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
+      <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>Insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
+      </ol>
      <li data-md="">
       <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>:</p>
       <ol>
@@ -2506,36 +2509,28 @@ of security-relevant policy decisions.</p>
         </ol>
       </ol>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Initialize a global object’s CSP list" data-level="4.2.2" id="initialize-global-object-csp"><span class="secno">4.2.2. </span><span class="content"> Initialize a global object’s <code>CSP list</code> </span><a class="self-link" href="#initialize-global-object-csp"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>global</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), the user agent performs the following steps in order
-  to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-5">CSP list</a>:</p>
+    <h4 class="heading settled algorithm" data-algorithm="Initialize a worker’s CSP list" data-level="4.2.2" id="initialize-worker-csp"><span class="secno">4.2.2. </span><span class="content"> Initialize a worker’s <code>CSP list</code> </span><a class="self-link" href="#initialize-worker-csp"></a></h4>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> (<var>global</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> (<var>owner</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), the user agent performs the following steps in order to initialize <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md="">
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
+      <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>documents</var> be an empty list.</p>
+        <p>Let <var>policies</var> be an empty list.</p>
        <li data-md="">
-        <p>Add each of <var>global</var>’s <a data-link-type="dfn">document</a>s to <var>documents</var>.</p>
+        <p>If <var>owner</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code>, set <var>policies</var> to <var>owner</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated Document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
+        <p>Otherwise, <var>owner</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>: set <var>policies</var> to <var>owner</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list">CSP list</a>.</p>
        <li data-md="">
-        <p>For each <var>document</var> in <var>documents</var>:</p>
+        <p>For each <var>policy</var> in <var>policies</var>:</p>
         <ol>
          <li data-md="">
-          <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global
-  object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-6">CSP list</a>:</p>
-          <ol>
-           <li data-md="">
-            <p>Insert an alias to <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-7">CSP list</a>.</p>
-          </ol>
+          <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list">CSP list</a>.</p>
         </ol>
       </ol>
-      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore alias the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-3">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-     <li data-md="">
-      <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
+      <p>Otherwise, <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
        <li data-md="">
-        <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-8">CSP list</a>.</p>
+        <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list">CSP list</a>.</p>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should element’s inline type behavior be blocked by Content Security Policy?" data-level="4.2.3" id="should-block-inline"><span class="secno">4.2.3. </span><span class="content"> Should <var>element</var>’s inline <var>type</var> behavior be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-inline"></a></h4>
@@ -2551,7 +2546,7 @@ of security-relevant policy decisions.</p>
      <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-9">CSP list</a>:</p>
+      <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-5">CSP list</a>:</p>
       <ol>
        <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-7">directive set</a>:</p>
@@ -2680,7 +2675,7 @@ of security-relevant policy decisions.</p>
     <p>ECMAScript defines a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> abstract operation
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
-  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-10">CSP list</a> to determine whether such compilation ought to be blocked.</p>
+  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-6">CSP list</a> to determine whether such compilation ought to be blocked.</p>
     <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm)" data-noexport="" id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>"
@@ -2692,7 +2687,7 @@ of security-relevant policy decisions.</p>
       <p>For each <var>global</var> in <var>globals</var>:</p>
       <ol>
        <li data-md="">
-        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-11">CSP list</a>:</p>
+        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-7">CSP list</a>:</p>
         <ol>
          <li data-md="">
           <p>Let <var>source-list</var> be null.</p>
@@ -2709,9 +2704,9 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-24">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-23">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-25">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-24">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</dfn> {
   <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;enforce&quot;|enforce" id="dom-securitypolicyviolationeventdisposition-enforce">"enforce"<a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;report&quot;|report" id="dom-securitypolicyviolationeventdisposition-report">"report"<a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -3046,15 +3041,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>child-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-1">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://not-example.com"</span><span class="nt">></span><span class="nt">&lt;/iframe></span>
+<span class="nt">&lt;script</span><span class="nt">></span>
   <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-2">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-26">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-25">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3068,7 +3063,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-3">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-27">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-26">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3106,8 +3101,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>connect-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-2">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">ping</span><span class="o">=</span><span class="s">"https://not-example.com"</span><span class="p">></span>...
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;a</span> <span class="na">ping=</span><span class="s">"https://not-example.com"</span><span class="nt">></span>...
+<span class="nt">&lt;script</span><span class="nt">></span>
   <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">(</span><span class="p">)</span><span class="p">;</span>
   xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://not-example.com/'</span><span class="p">)</span><span class="p">;</span>
   xhr<span class="p">.</span>send<span class="p">(</span><span class="p">)</span><span class="p">;</span>
@@ -3116,13 +3111,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 
   <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">)</span><span class="p">;</span>
 
-  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">...</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">.</span><span class="p">.</span><span class="p">.</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="nt">&lt;/script></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-4">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-28">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-27">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3139,7 +3134,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-5">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-29">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-28">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3209,7 +3204,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-5">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-30">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-29">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3227,7 +3222,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-6">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-31">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-30">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3256,20 +3251,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>font-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-4">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-  <span class="p">@</span><span class="k">font-face</span> <span class="p">{</span>
+<pre class="highlight"><span class="nt">&lt;style</span><span class="nt">></span>
+  <span class="k">@font-face</span> <span class="p">{</span>
     <span class="nt">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="o">;</span>
     <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://not-example.com/font"</span><span class="o">)</span><span class="o">;</span>
   <span class="p">}</span>
   <span class="nt">body</span> <span class="p">{</span>
-    <span class="k">font-family</span><span class="p">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
+    <span class="k">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
   <span class="p">}</span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+<span class="nt">&lt;/style></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-7">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-32">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-31">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3285,7 +3280,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-8">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-33">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-32">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3311,13 +3306,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>frame-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-5">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/"</span><span class="p">></span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://not-example.com/"</span><span class="nt">></span>
+<span class="nt">&lt;/iframe></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-8">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-34">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-33">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3334,7 +3329,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-9">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-35">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-34">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3364,12 +3359,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>img-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-6">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/img"</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"https://not-example.com/img"</span><span class="nt">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-9">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-36">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-35">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3385,7 +3380,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-10">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-37">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-36">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3412,12 +3407,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>manifest-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-7">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"manifest"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://not-example.com/manifest"</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"manifest"</span> <span class="na">href=</span><span class="s">"https://not-example.com/manifest"</span><span class="nt">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-10">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-38">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-37">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3433,7 +3428,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-11">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-39">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-38">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3460,15 +3455,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>media-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-8">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">audio</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/audio"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">audio</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">video</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/video"</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">track</span> <span class="na">kind</span><span class="o">=</span><span class="s">"subtitles"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/subtitles"</span><span class="p">></span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">video</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;audio</span> <span class="na">src=</span><span class="s">"https://not-example.com/audio"</span><span class="nt">></span><span class="nt">&lt;/audio></span>
+<span class="nt">&lt;video</span> <span class="na">src=</span><span class="s">"https://not-example.com/video"</span><span class="nt">></span>
+    <span class="nt">&lt;track</span> <span class="na">kind=</span><span class="s">"subtitles"</span> <span class="na">src=</span><span class="s">"https://not-example.com/subtitles"</span><span class="nt">></span>
+<span class="nt">&lt;/video></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-11">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-40">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-39">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3485,7 +3480,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-12">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-41">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-40">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3513,9 +3508,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-9">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">embed</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://not-example.com/flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">embed</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://not-example.com/flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">object</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">applet</span> <span class="na">archive</span><span class="o">=</span><span class="s">"https://not-example.com/flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">applet</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;embed</span> <span class="na">src=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/embed></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
+<span class="nt">&lt;applet</span> <span class="na">archive=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/applet></span>
 </pre>
     </div>
     <p>If plugin content is loaded without an associated URL (perhaps an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code> element lacks a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-object-data">data</a></code> attribute, but loads some default plugin based
@@ -3528,7 +3523,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#the-applet-element">applet</a></code>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-42">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#the-applet-element">applet</a></code>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-41">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#plugin-document">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3536,7 +3531,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.9.1" id="object-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-12">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-43">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-42">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3552,7 +3547,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-13">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-44">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-43">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3603,7 +3598,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.10.1" id="script-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-13">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-45">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-44">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-26">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-21">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3666,7 +3661,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.10.2" id="script-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-14">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-46">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-45">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-27">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-22">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3774,7 +3769,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.11.1" id="style-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-14">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-47">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-46">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3794,7 +3789,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.11.2" id="style-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-15">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-48">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-47">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3843,16 +3838,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-10">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;script</span><span class="nt">></span>
   <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">)</span><span class="p">;</span>
   blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">)</span><span class="p">;</span>
   navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://not-example.com/sw.js'</span><span class="p">)</span><span class="p">;</span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.12.1" id="worker-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-15">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-49">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-48">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3869,7 +3864,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.12.2" id="worker-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-16">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-50">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-49">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3900,7 +3895,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   returns "<code>Allowed</code>" if <var>base</var> may be used as the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">href</a></code> attribute, and "<code>Blocked</code>" otherwise:</p>
     <ol>
      <li data-md="">
-      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-12">csp list</a>:</p>
+      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-8">csp list</a>:</p>
       <ol>
        <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
@@ -3956,26 +3951,26 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
      <p>Fetches for the following code will all return network errors:</p>
 <pre class="highlight"><span class="c">&lt;!--</span><span class="c"> No 'type' declaration </span><span class="c">--></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">object</span><span class="p">></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 
 <span class="c">&lt;!--</span><span class="c"> Non</span><span class="c">-</span><span class="c">matching 'type' declaration </span><span class="c">--></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">object</span><span class="p">></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 
 <span class="c">&lt;!--</span><span class="c"> Non</span><span class="c">-</span><span class="c">matching resource </span><span class="c">--></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/pdf"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">object</span><span class="p">></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/pdf"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 </pre>
      <p>If the page allowed Flash content by sending the following header:</p>
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types-2">plugin-types</a> application/x-shockwave-flash
 </pre>
      <p>Then the second item above would load successfully:</p>
 <pre class="highlight"><span class="c">&lt;!--</span><span class="c"> Matching 'type' declaration and resource </span><span class="c">--></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">object</span><span class="p">></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-17">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-51">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-50">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4041,7 +4036,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-3">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-52">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-51">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4068,7 +4063,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization-3">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox-1"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-53">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-52">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4098,7 +4093,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization-4">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-54">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-53">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4186,7 +4181,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-1"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-2"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-55">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives-31">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-3"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-17">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-54">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives-31">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-3"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-17">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-db2876b7"><a class="self-link" href="#issue-db2876b7"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#process-a-navigate-response">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigation-to"><span class="secno">6.3.3. </span><span class="content"><code>navigation-to</code></span><a class="self-link" href="#directive-navigation-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigation-to">navigation-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code>s to which
@@ -4264,7 +4259,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-56">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-55">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives-32">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4774,7 +4769,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source-9">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-57">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source-9">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-56">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -4789,13 +4784,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.2" id="security-nonce-stealing"><span class="secno">7.2. </span><span class="content">Nonce Stealing</span><a class="self-link" href="#security-nonce-stealing"></a></h3>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
   example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> element:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, [INJECTION POINT]<span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;p</span><span class="nt">></span>Hello, [INJECTION POINT]<span class="nt">&lt;/p></span>
+<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
     <p>If an attacker injects the string "<code>&lt;script src='https://evil.com/evil.js' </code>",
   then the browser will receive the following:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="p">></span>
-<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;p</span><span class="nt">></span>Hello, <span class="nt">&lt;script </span><span class="na">src=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="nt">></span>
+<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="nt">&lt;/script></span>
 </pre>
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
@@ -4891,7 +4886,7 @@ Content-Security-Policy: connect-src http://example.com/;
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce</span><span class="o">=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="nt">></span><span class="nt">&lt;/script></span>
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
@@ -4920,7 +4915,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <div class="example" id="example-58b9ab8c">
       <a class="self-link" href="#example-58b9ab8c"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
       resembling a reasonable schedule: 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;button</span> <span class="na">id=</span><span class="s">"action"</span> <span class="na">onclick=</span><span class="s">"doSubmit()"</span><span class="nt">></span>
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashed-attributes'</code>" along with a hash source expression, as follows:</p>
@@ -4944,16 +4939,16 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
       <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
       <p>Metadata that is not recognized (either because it’s entirely invalid, or
       because it specifies a not-yet-supported hashing algorithm) does not affect
@@ -4961,9 +4956,9 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       allowed to execute in the presence of the above policy, as the additional
       metadata is invalid and therefore wouldn’t allow a script whose content
       wasn’t listed explicitly in the policy to execute:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
      </div>
     </section>
@@ -4971,7 +4966,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-58">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-57">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5418,12 +5413,14 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">content security policy state</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">csp list</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">csp list <small>(for Document)</small></a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list">csp list <small>(for WorkerGlobalScope)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-object-data">data</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#disowned-its-opener">disown its opener</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-2">document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element">embed</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler idl attribute</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#fallback-base-url">fallback base url</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#forced-sandboxing-flag-set">forced sandboxing flag set</a>
@@ -5770,73 +5767,71 @@ rest of Google’s CSP Cabal.</p>
     Integration with Fetch </a>
     <li><a href="#ref-for-content-security-policy-object-19">4.2. 
     Integration with HTML </a> <a href="#ref-for-content-security-policy-object-20">(2)</a> <a href="#ref-for-content-security-policy-object-21">(3)</a> <a href="#ref-for-content-security-policy-object-22">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object-23">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object-24">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object-25">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object-26">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object-23">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object-24">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object-25">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-27">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object-26">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-28">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object-27">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-29">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object-28">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-30">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object-29">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-31">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object-30">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-32">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object-31">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-33">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object-32">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-34">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object-33">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-35">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object-34">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-36">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object-35">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-37">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object-36">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-38">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object-37">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-39">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object-38">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-40">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object-39">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-41">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object-40">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-42">6.1.9. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object-43">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object-41">6.1.9. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object-42">6.1.9.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-44">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object-43">6.1.9.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-45">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object-44">6.1.10.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-46">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object-45">6.1.10.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-47">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object-46">6.1.11.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-48">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object-47">6.1.11.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-49">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object-48">6.1.12.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-50">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object-49">6.1.12.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-51">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object-50">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-52">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object-51">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object-53">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object-52">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object-54">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object-53">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object-55">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object-54">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object-56">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object-55">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object-57">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object-58">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object-56">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object-57">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -6730,14 +6725,12 @@ rest of Google’s CSP Cabal.</p>
     Security Policy? </a>
     <li><a href="#ref-for-global-object-csp-list-4">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-global-object-csp-list-5">4.2.2. 
-    Initialize a global object’s CSP list </a> <a href="#ref-for-global-object-csp-list-6">(2)</a> <a href="#ref-for-global-object-csp-list-7">(3)</a> <a href="#ref-for-global-object-csp-list-8">(4)</a>
-    <li><a href="#ref-for-global-object-csp-list-9">4.2.3. 
+    <li><a href="#ref-for-global-object-csp-list-5">4.2.3. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-global-object-csp-list-10">4.3. Integration with ECMAScript</a>
-    <li><a href="#ref-for-global-object-csp-list-11">4.3.1. 
+    <li><a href="#ref-for-global-object-csp-list-6">4.3. Integration with ECMAScript</a>
+    <li><a href="#ref-for-global-object-csp-list-7">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm) </a>
-    <li><a href="#ref-for-global-object-csp-list-12">6.2.1.1. 
+    <li><a href="#ref-for-global-object-csp-list-8">6.2.1.1. 
     Is base allowed for document? </a>
    </ul>
   </aside>
@@ -6762,8 +6755,6 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-embedding-document-1">4.2.1. 
     Initialize a Document's CSP list </a> <a href="#ref-for-embedding-document-2">(2)</a>
-    <li><a href="#ref-for-embedding-document-3">4.2.2. 
-    Initialize a global object’s CSP list </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-report">

--- a/index.src.html
+++ b/index.src.html
@@ -28,6 +28,7 @@ spec:html
     text: browsing context; for: /
     text: plugin document
     text: fallback base url
+    text: associated document
   type: element
     text: a
     text: link
@@ -371,8 +372,8 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   <h3 id="framework-policy">Policies</h3>
 
   A <dfn export lt="content security policy object" local-lt="policy">policy</dfn> defines allowed
-  and restricted behaviors, and may be applied to a {{Window}} or {{WorkerGlobalScope}} as described
-  in [[#initialize-global-object-csp]].
+  and restricted behaviors, and may be applied to a {{Document}} via [[#initialize-document-csp]], or
+  a {{WorkerGlobalScope}} as described in [[#initialize-worker-csp]].
 
   Each policy has an associated <dfn for="policy" export>directive set</dfn>, which is an <a>ordered
   set</a> of <a>directives</a> that define the policy's implications when applied.
@@ -1036,7 +1037,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       <dfn for="global object" id="global-object-csp-list">CSP list</dfn>,
       which holds all the <a for="/">policy</a> objects which are active for a given
       context. This list is empty unless otherwise specified, and is populated
-      via the [[#initialize-global-object-csp]] algorithm.
+      via the [[#initialize-document-csp]] and [[#initialize-worker-csp]] algorithms.
 
       ISSUE(w3c/html#187): This concept is missing from W3C's Workers.
 
@@ -1044,7 +1045,7 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
       <a for="/">global object</a> by inserting it into the <a for="/">global object</a>'s
       <a for="global object">CSP list</a>.
 
-  3.  [[#initialize-global-object-csp]] is called during the <a>initializing a
+  3.  [[#initialize-worker-csp]] is called during the <a>initializing a
       new `Document` object</a> and <a>run a worker</a> algorithms in order to
       bind a set of <a for="/">policy</a> objects associated with a <a>response</a> to a
       newly created <a for="/">global object</a>.
@@ -1099,79 +1100,69 @@ spec: SHA2; urlPrefix: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
     Initialize a `Document`'s `CSP list`
   </h4>
 
-  Given a {{Document}} (|document|), and a <a>response</a> (|response|), the
-  user agent performs the following steps in order to initialize |document|'s
-  <a for="Document">CSP list</a>:
+  Given a {{Document}} (|document|), and a <a>response</a> (|response|), the user agent performs the
+  following steps in order to initialize |document|'s [=Document/CSP list=]
 
-  1.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a> is a
-      <a>local scheme</a>:
+  1.  If |response|'s [=response/url=]'s [=url/scheme=] is a [=local scheme=]:
 
-      1.  Let |documents| be an empty list.
+      1.  Let |ancestors| be an empty list.
 
-      2.  If |document| has an <a>embedding document</a> (|embedding|), then add
-          |embedding| to |documents|.
+      2.  If |document| has an [=embedding document=] (|embedding|), then add |embedding| to
+          |ancestors|.
 
-      3.  If |document| has an <a>opener browsing context</a>, then add its
-          <a>active document</a> to |documents|.
+      3.  If |document| has an [=opener browsing context=], then add its [=active document=] to
+          |ancestors|.
 
-      4.  For each |doc| in |documents|:
+      4.  For each |ancestor| in |ancestors|:
 
-          1.  For each |policy| in |doc|'s <a for="Document">CSP list</a>:
+          1.  For each |policy| in |ancestor|'s [=Document/CSP list=]:
 
-              1.  Insert an alias to |policy| in |document|'s
-                  <a for="Document">CSP list</a>.
+              1.  Insert a copy of |policy| into |document|'s [=Document/CSP list=].
 
-      Note: <a>local scheme</a> includes `about:`, and this algorithm will
-      therefore alias the <a>embedding document</a>'s policies for <a>an iframe
-      `srcdoc` `Document`</a>.
+      Note: [=local scheme=] includes `about:`, and this algorithm will therefore copy the
+      [=embedding document=]'s policies for [=an iframe srcdoc Document=].
 
-      Note: We do all this to ensure that a page cannot bypass its <a for="/">policy</a>
-      by embedding a frame or popping up a new window containing content it
-      controls (`blob:` resources, or `document.write()`).
+      Note: We do all this to ensure that a page cannot bypass its policy by embedding a frame or
+      popping up a new window containing content it controls (`blob:` resources, or
+      `document.write()`).
 
-  2.  For each |policy| in |response|'s <a for="response">CSP list</a>, insert
-      |policy| into |document|'s <a for="Document">CSP list</a>.
+  2.  For each |policy| in |response|'s [=response/CSP list=]:
+  
+      1.  Insert |policy| into |document|'s [=Document/CSP list=].
 
-  3.  For each |policy| in |document|'s <a for="Document">CSP list</a>:
+  3.  For each |policy| in |document|'s [=Document/CSP list=]:
 
       1.  For each |directive| in |policy|:
 
-          1.  Execute |directive|'s <a for="directive">initialization</a>
-              algorithm on |document| and |response|.
+          1.  Execute |directive|'s [=directive/initialization=] algorithm on |document| and
+              |response|.
 
-  <h4 id="initialize-global-object-csp" algorithm>
-    Initialize a global object's `CSP list`
+  <h4 id="initialize-worker-csp" algorithm>
+    Initialize a worker's `CSP list`
   </h4>
 
-  Given a <a for="/">global object</a> (|global|), and a <a>response</a>
-  (|response|), the user agent performs the following steps in order
-  to initialize |global|'s <a for="global object">CSP list</a>:
+  Given a {{WorkerGlobalScope}} (|global|), an [=environment settings object=] (|owner|), and a
+  [=response=] (|response|), the user agent performs the following steps in order to initialize
+  |global|'s [=WorkerGlobalScope/CSP list=]:
 
-  1.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a> is a
-      <a>local scheme</a>, or if |global| is a {{DedicatedWorkerGlobalScope}}:
+  1.  If |global| is a {{DedicatedWorkerGlobalScope}}:
 
-      1.  Let |documents| be an empty list.
+      1.  Let |policies| be an empty list.
 
-      2.  Add each of |global|'s
-          <a lt="the worker's documents">document</a>s to |documents|.
+      2.  If |owner| is a {{Window}}, set |policies| to |owner|'s [=associated Document=]'s
+          [=Document/CSP list=].
 
-      4.  For each |document| in |documents|:
+          Otherwise, |owner| is a {{WorkerGlobalScope}}: set |policies| to |owner|'s
+          [=WorkerGlobalScope/CSP list=].
 
-          1.  For each |policy| in |document|'s <a for="/">global
-              object</a>'s <a for="global object">CSP list</a>:
+      3.  For each |policy| in |policies|:
 
-              1.  Insert an alias to |policy| in |global|'s
-                  <a for="global object">CSP list</a>.
+          1.  Insert a copy of |policy| into |global|'s [=WorkerGlobalScope/CSP list=].
 
-      Note: <a>local scheme</a> includes `about:`, and this algorithm will
-      therefore alias the <a>embedding document</a>'s policies for <a>an iframe
-      `srcdoc` `Document`</a>.
+      Otherwise, |global| is a {{SharedWorkerGlobalScope}} or {{ServiceWorkerGlobalScope}}:
 
-  2.  If |global| is a {{SharedWorkerGlobalScope}} or {{ServiceWorkerGlobalScope}}:
-
-      1.  For each |policy| in |response|'s
-          <a for="response">CSP list</a>, insert |policy| into
-          |global|'s <a for="global object">CSP list</a>.
+      1.  For each |policy| in |response|'s [=response/CSP list=], insert |policy| into |global|'s
+          [=WorkerGlobalScope/CSP list=].
 
   <h4 id="should-block-inline" algorithm>
     Should |element|'s inline |type| behavior be blocked by Content Security Policy?


### PR DESCRIPTION
As discussed in #209, we haven't done a good job keeping these algorithms
up to date. This patch cleans them up, and a subsequent patch will adjust
HTML accordingly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/fix-209.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/015d649...218124c.html)