### PR TITLE
Track the source of a given policy.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1536,8 +1536,8 @@ of security-relevant policy decisions.</p>
       <li>
        <a href="#framework-policy"><span class="secno">2.2</span> <span class="content">Policies</span></a>
        <ol class="toc">
-        <li><a href="#parse-serialized-policy"><span class="secno">2.2.1</span> <span class="content"> Parse a <var>serialized CSP</var> as <var>disposition</var> </span></a>
-        <li><a href="#parse-serialized-policy-list"><span class="secno">2.2.2</span> <span class="content"> Parse a serialized CSP <var>list</var> as <var>disposition</var> </span></a>
+        <li><a href="#parse-serialized-policy"><span class="secno">2.2.1</span> <span class="content"> Parse a serialized CSP </span></a>
+        <li><a href="#parse-serialized-policy-list"><span class="secno">2.2.2</span> <span class="content"> Parse a serialized CSP list </span></a>
        </ol>
       <li>
        <a href="#framework-directives"><span class="secno">2.3</span> <span class="content">Directives</span></a>
@@ -1944,33 +1944,42 @@ of security-relevant policy decisions.</p>
   set</a> of <a data-link-type="dfn" href="#directives" id="ref-for-directives-1">directives</a> that define the policy’s implications when applied.</p>
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-disposition">disposition</dfn>, which is either
   "<code>enforce</code>" or "<code>report</code>".</p>
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-source">source</dfn>, which is either "<code>header</code>"
+  or "<code>meta</code>".</p>
+    <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-1">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-2">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="csp-list">CSP list</dfn>.</p>
+    <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list-1">CSP list</a> <dfn data-dfn-type="dfn" data-noexport="" id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-3">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-1">source</a> is "<code>header</code>".</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a> consisting of a semicolon-delimited
   series of <a data-link-type="dfn" href="#serialized-directive" id="ref-for-serialized-directive-1">serialized directives</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy">serialized-policy</dfn> = <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive-1">serialized-directive</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a> ";" [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive-2">serialized-directive</a> ] )
                     ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a> is defined in section 3.2.3 of RFC 7230
 </pre>
-    <h4 class="heading settled dfn-paneled algorithm" data-algorithm="Parse a serialized CSP as disposition" data-dfn-type="dfn" data-level="2.2.1" data-lt="parse a serialized CSP" data-noexport="" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a <var>serialized CSP</var> as <var>disposition</var> </span></h4>
-    <p>Given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-1">serialized CSP</a> (<var>serialized CSP</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-1">disposition</a> (<var>disposition</var>), this algorithm will return a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-1">policy</a> object. If the string cannot be parsed, the resulting <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-2">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-1">directive set</a> will be empty.</p>
-    <ol>
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a> consisting of a comma-delimited
+  series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-1">serialized CSPs</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
+<pre><dfn data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy-1">serialized-policy</a>
+                    ; The '#' rule is defined in section 7 of RFC 7230
+</pre>
+    <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP" data-level="2.2.1" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a serialized CSP </span><a class="self-link" href="#parse-serialized-policy"></a></h4>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-2">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-2">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-1">disposition</a> (<var>disposition</var>), execute the
+  following steps.</p>
+    <p>This algorithm returns a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-4">Content Security Policy object</a>. If <var>serialized</var> could not be
+  parsed, the object’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-1">directive set</a> will be empty.</p>
+    <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>policy</var> be a new <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-3">policy</a> with an empty <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-2">directive set</a>, and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-2">disposition</a> of <var>disposition</var>.</p>
+      <p>Let <var>policy</var> be a new <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-5">policy</a> with an empty <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-2">directive set</a>, a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-3">source</a> of <var>source</var>, and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-2">disposition</a> of <var>disposition</var>.</p>
      <li data-md="">
-      <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split">strictly splitting</a> <var>serialized
-  CSP</var> on the U+003B SEMICOLON character (<code>;</code>):</p>
+      <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split">strictly splitting</a> <var>serialized</var> on
+  the U+003B SEMICOLON character (<code>;</code>):</p>
       <ol>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">Strip leading and trailing ASCII whitespace</a> from <var>token</var>.</p>
        <li data-md="">
-        <p>If <var>token</var> is an empty string, skip the remaining substeps
-  and continue to the next item.</p>
+        <p>If <var>token</var> is an empty string, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
        <li data-md="">
-        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collecting a sequence of
-  code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>.</p>
+        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>.</p>
        <li data-md="">
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-3">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-2">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-1">name</a> is <var>directive
-  name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
-        <p>The user agent SHOULD notify developers that a directive was ignored.
-  A console warning might be appropriate, for example.</p>
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-3">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-2">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-1">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+        <p>In this case, the user agent SHOULD notify developers that a duplicate directive was
+  ignored. A console warning might be appropriate, for example.</p>
        <li data-md="">
         <p>Let <var>directive value</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">splitting <var>token</var> on
   ASCII whitespace</a>.</p>
@@ -1982,21 +1991,21 @@ of security-relevant policy decisions.</p>
      <li data-md="">
       <p>Return <var>policy</var>.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP list as disposition" data-level="2.2.2" id="parse-serialized-policy-list"><span class="secno">2.2.2. </span><span class="content"> Parse a serialized CSP <var>list</var> as <var>disposition</var> </span><a class="self-link" href="#parse-serialized-policy-list"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a> which contains a comma-delimited series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-2">serialized CSP</a> strings
-  (<var>list</var>) and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-3">disposition</a> (<var>disposition</var>), the following algorithm will
-  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-4">policy</a> objects:</p>
-    <ol>
+    <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP list" data-level="2.2.2" id="parse-serialized-policy-list"><span class="secno">2.2.2. </span><span class="content"> Parse a serialized CSP list </span><a class="self-link" href="#parse-serialized-policy-list"></a></h4>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list-1">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-4">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-3">disposition</a> (<var>disposition</var>), execute the following
+  steps.</p>
+    <p>This algorithm returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-6">Content Security Policy objects</a>. If <var>list</var> cannot be
+  parsed, the returned list will be empty.</p>
+    <ol class="algorithm">
      <li data-md="">
       <p>Let <var>policies</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a>.</p>
      <li data-md="">
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas">splitting <var>list</var> on commas</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>policy</var> be the result of executing <a href="#parse-serialized-policy" id="ref-for-parse-serialized-policy-1">§2.2.1 Parse a serialized CSP as disposition</a> on <var>token</var> with <var>disposition</var>.</p>
+        <p>Let <var>policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp-1">parsing</a> <var>token</var>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-5">source</a> of <var>source</var>, and <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-4">disposition</a> of <var>disposition</var>.</p>
        <li data-md="">
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-5">directive set</a> is empty, skip the
-  remaining substeps, and continue to the next item.</p>
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-5">directive set</a> is empty, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append">Append</a> <var>policy</var> to <var>policies</var>.</p>
       </ol>
@@ -2004,7 +2013,7 @@ of security-relevant policy decisions.</p>
       <p>Return <var>policies</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.3" id="framework-directives"><span class="secno">2.3. </span><span class="content">Directives</span><a class="self-link" href="#framework-directives"></a></h3>
-    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-5">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-6">directive set</a>), each of which controls a specific behavior. The directives
+    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-7">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set-6">directive set</a>), each of which controls a specific behavior. The directives
   defined in this document are described in detail in <a href="#csp-directives">§6 Content Security Policy Directives</a>.</p>
     <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives-4">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-3">name</a> is a
   non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-2">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-3">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty">empty</a>.</p>
@@ -2022,16 +2031,16 @@ of security-relevant policy decisions.</p>
     <p><a data-link-type="dfn" href="#directives" id="ref-for-directives-5">Directives</a> have a number of associated algorithms:</p>
     <ol>
      <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-6">policy</a> as an argument, and is executed
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-8">policy</a> as an argument, and is executed
   during <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-7">policy</a> as arguments,
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-9">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-8">policy</a> as arguments,
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-10">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
@@ -2040,7 +2049,7 @@ of security-relevant policy decisions.</p>
   type string, and a soure string as arguments, and is executed during <a href="#should-block-inline">§4.2.3 Should element’s inline type behavior be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md="">
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-9">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-11">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
      <li data-md="">
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>, type string, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing contexts</a> as arguments, and
@@ -2119,9 +2128,9 @@ of security-relevant policy decisions.</p>
   whenever possible.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
-  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-10">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>.</p>
+  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-12">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-1">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
-  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-11">policy</a> has been violated.</p>
+  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-13">policy</a> has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-2">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object-1">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-3">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
@@ -2131,8 +2140,8 @@ of security-relevant policy decisions.</p>
   which violated the policy.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-5">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-6">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-12">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-7">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-4">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-13">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-6">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-14">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-7">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-5">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-15">policy</a> that has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-8">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives-7">directive</a> whose
   enforcement caused the violation.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation-9">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
@@ -2148,7 +2157,7 @@ of security-relevant policy decisions.</p>
   characters of an inline script, event handler, or style that caused an violation. Violations
   which stem from an external file will not include a sample in the violation report.</p>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-14">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation-15">violation</a> object, and populates it with an initial set of data:</p>
+    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-16">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation-15">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
      <li data-md="">
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation-16">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object-2">global
@@ -2171,7 +2180,7 @@ of security-relevant policy decisions.</p>
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, policy, and directive" data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-15">policy</a> (<var>policy</var>), and a string
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-17">policy</a> (<var>policy</var>), and a string
   (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation-17">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
@@ -2187,14 +2196,14 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="policy-delivery"><span class="secno">3. </span><span class="content"> Policy Delivery </span><a class="self-link" href="#policy-delivery"></a></h2>
-    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-16">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3">resource
+    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-18">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3">resource
   representation</a> via an HTTP response header field whose value is a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-4">serialized CSP</a>. This mechanism is defined in detail in <a href="#csp-header">§3.1 The Content-Security-Policy HTTP Response Header Field</a> and <a href="#cspro-header">§3.2 The Content-Security-Policy-Report-Only HTTP Response Header Field</a>, and the integration with Fetch
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-17">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-19">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy-1">serialized-policy</a>
+<pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy-2">serialized-policy</a>
 </pre>
     <div class="example" id="example-cc966e28">
      <a class="self-link" href="#example-cc966e28"></a> 
@@ -2208,11 +2217,11 @@ of security-relevant policy decisions.</p>
   "<code>Content-Security-Policy</code>" with a given <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3">resource
   representation</a>.</p>
     <p>When the user agent receives a <code>Content-Security-Policy</code> header field, it
-  MUST <a data-link-type="dfn" href="#parse-serialized-policy" id="ref-for-parse-serialized-policy-2">parse</a> and <a data-link-type="dfn" href="#enforced" id="ref-for-enforced-1">enforce</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-5">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a>, <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
+  MUST <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse</a> and <a data-link-type="dfn" href="#enforced" id="ref-for-enforced-1">enforce</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-5">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a>, <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <h3 class="heading settled" data-level="3.2" id="cspro-header"><span class="secno">3.2. </span><span class="content"> The <code>Content-Security-Policy-Report-Only</code> HTTP Response Header Field </span><a class="self-link" href="#cspro-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy-2">serialized-policy</a>
+<pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy-3">serialized-policy</a>
 </pre>
     <p>This header field allows developers to piece together their security policy in
   an iterative fashion, deploying a report-only policy based on their best
@@ -2230,7 +2239,7 @@ of security-relevant policy decisions.</p>
   "<code>Content-Security-Policy-Report-Only</code>" with a given <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3">resource
   representation</a>.</p>
     <p>When the user agent receives a <code>Content-Security-Policy-Report-Only</code> header
-  field, it MUST <a data-link-type="dfn" href="#parse-serialized-policy" id="ref-for-parse-serialized-policy-3">parse</a> and <a data-link-type="dfn" href="#monitored" id="ref-for-monitored-1">monitor</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-6">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
+  field, it MUST <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse</a> and <a data-link-type="dfn" href="#monitored" id="ref-for-monitored-1">monitor</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-6">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <p class="note" role="note"><span>Note:</span> The <a data-link-type="http-header" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only-2"><code>Content-Security-Policy-Report-Only</code></a> header is <strong>not</strong> supported inside a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element.</p>
     <h3 class="heading settled" data-level="3.3" id="meta-element"><span class="secno">3.3. </span><span class="content"> The <code>&lt;meta></code> element </span><a class="self-link" href="#meta-element"></a></h3>
     <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> may deliver a policy via one or more HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> elements
@@ -2281,8 +2290,8 @@ of security-relevant policy decisions.</p>
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-1">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-1">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-18">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>, but the
-  user agent needs to <a data-link-type="dfn" href="#parse-serialized-policy" id="ref-for-parse-serialized-policy-4">parse</a> any policy
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-20">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>, but the
+  user agent needs to <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s details. To that end:</p>
     <ol>
      <li data-md="">
@@ -2298,15 +2307,13 @@ of security-relevant policy decisions.</p>
     <h4 class="heading settled algorithm" data-algorithm="Set response’s CSP list" data-level="4.1.1" id="set-response-csp-list"><span class="secno">4.1.1. </span><span class="content"> Set <var>response</var>’s <code>CSP list</code> </span><a class="self-link" href="#set-response-csp-list"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), this algorithm evaluates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a> for <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-7">serialized CSP</a> values, and
   populates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a> accordingly:</p>
-    <ol>
+    <ol class="algorithm">
      <li data-md="">
-      <p>Set <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a> to the
-  empty list.</p>
+      <p>Set <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a> to the empty list.</p>
      <li data-md="">
-      <p>Let <var>policies</var> be the result of executing <a href="#parse-serialized-policy-list">§2.2.2 Parse a serialized CSP list as disposition</a> on the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>, with a disposition of "<code>enforce</code>".</p>
+      <p>Let <var>policies</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list-1">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-6">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-6">disposition</a> of "<code>enforce</code>".</p>
      <li data-md="">
-      <p>Append to <var>policies</var> the result of executing <a href="#parse-serialized-policy-list">§2.2.2 Parse a serialized CSP list as disposition</a> on the result
-  of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>, with a disposition of "<code>report</code>".</p>
+      <p>Append to <var>policies</var> the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list-2">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source-7">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-7">disposition</a> of "<code>report</code>".</p>
      <li data-md="">
       <p>For each <var>policy</var> in <var>policies</var>:</p>
       <ol>
@@ -2324,7 +2331,7 @@ of security-relevant policy decisions.</p>
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-5">disposition</a> is "<code>enforce</code>",
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-8">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
@@ -2343,7 +2350,7 @@ of security-relevant policy decisions.</p>
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-6">disposition</a> is "<code>report</code>",
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-9">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
@@ -2380,7 +2387,7 @@ of security-relevant policy decisions.</p>
            <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>directive</var>.</p>
            <li data-md="">
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-7">disposition</a> is "<code>enforce</code>",
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-10">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2401,7 +2408,7 @@ of security-relevant policy decisions.</p>
            <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>directive</var>.</p>
            <li data-md="">
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-8">disposition</a> is "<code>enforce</code>",
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-11">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2415,16 +2422,16 @@ of security-relevant policy decisions.</p>
     <ol>
      <li data-md="">
       <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> objects have a <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn>,
-  which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-19">policy</a> objects which are active for a given
+  which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-21">policy</a> objects which are active for a given
   context. This list is empty unless otherwise specified, and is populated
   via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md="">
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-20">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-4">CSP list</a>.</p>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-22">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list-4">CSP list</a>.</p>
      <li data-md="">
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">run a worker</a> algorithms in order to
-  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-21">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to a
+  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-23">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to a
   newly created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>.</p>
      <li data-md="">
       <p><a href="#should-block-inline">§4.2.3 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
@@ -2434,7 +2441,7 @@ of security-relevant policy decisions.</p>
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-22">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced-2">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code>.</p>
+      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-24">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced-2">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code>.</p>
      <li data-md="">
       <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a> is nested.</p>
      <li data-md="">
@@ -2491,7 +2498,7 @@ of security-relevant policy decisions.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore alias the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document-2">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-23">policy</a> by embedding a frame or popping up a new window containing content it
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-25">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">CSP list</a>.</p>
@@ -2575,7 +2582,7 @@ of security-relevant policy decisions.</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-9">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-12">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2608,7 +2615,7 @@ of security-relevant policy decisions.</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-10">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-13">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2633,7 +2640,7 @@ of security-relevant policy decisions.</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-11">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-14">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2668,7 +2675,7 @@ of security-relevant policy decisions.</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-12">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-15">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2708,9 +2715,9 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-24">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-26">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-25">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-27">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</dfn> {
   <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;enforce&quot;|enforce" id="dom-securitypolicyviolationeventdisposition-enforce">"enforce"<a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;report&quot;|report" id="dom-securitypolicyviolationeventdisposition-report">"report"<a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -2776,7 +2783,7 @@ of security-relevant policy decisions.</p>
         <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp-8">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy-2">policy</a></p>
        <dt data-md="">"<code>disposition</code>"
        <dd data-md="">
-        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-13">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy-3">policy</a></p>
+        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-16">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy-3">policy</a></p>
        <dt data-md="">"<code>status-code</code>"
        <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status-2">status</a></p>
@@ -3053,7 +3060,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-2">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-26">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-28">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3067,7 +3074,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-3">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-27">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-29">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3121,7 +3128,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-4">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-28">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-30">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3138,7 +3145,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-5">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-29">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-31">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3208,7 +3215,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-5">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-30">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-32">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3226,7 +3233,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-6">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-31">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-33">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3268,7 +3275,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-7">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-32">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-34">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3284,7 +3291,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-8">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-33">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-35">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3316,7 +3323,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-8">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-34">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-36">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3333,7 +3340,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-9">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-35">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-37">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3368,7 +3375,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-9">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-36">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-38">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3384,7 +3391,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-10">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-37">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-39">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3416,7 +3423,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-10">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-38">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-40">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3432,7 +3439,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-11">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-39">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-41">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3467,7 +3474,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-11">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-40">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-42">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3484,7 +3491,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-12">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-41">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-43">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3527,7 +3534,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#the-applet-element">applet</a></code>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-42">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-embed-element">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code>, or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#the-applet-element">applet</a></code>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-44">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#plugin-document">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3535,7 +3542,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.9.1" id="object-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-12">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-43">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-45">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3551,7 +3558,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-13">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-44">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-46">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3602,7 +3609,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.10.1" id="script-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-13">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-45">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-47">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-26">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-21">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3665,7 +3672,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.10.2" id="script-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-14">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-46">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-48">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-27">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-22">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3773,7 +3780,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.11.1" id="style-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-14">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-47">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-49">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3793,7 +3800,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.11.2" id="style-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-15">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-48">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-50">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3851,7 +3858,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.12.1" id="worker-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check-15">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-49">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-51">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3868,7 +3875,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.12.2" id="worker-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-16">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-50">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-52">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3920,7 +3927,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-14">disposition</a> is "<code>enforce</code>",
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-17">disposition</a> is "<code>enforce</code>",
   return "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -3974,7 +3981,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check-17">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-51">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-53">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4040,12 +4047,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check-3">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-52">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-54">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md="">
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-15">disposition</a> is not "<code>enforce</code>", then
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-18">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is one of
@@ -4067,12 +4074,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization-3">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox-1"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-53">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-55">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md="">
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-16">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>, then abort this algorithm.</p>
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-19">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>, then abort this algorithm.</p>
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
@@ -4097,7 +4104,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization-4">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-54">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-56">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4185,7 +4192,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-1"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-2"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-55">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives-31">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-3"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-17">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-57">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives-31">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors-3"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition-20">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-db2876b7"><a class="self-link" href="#issue-db2876b7"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#process-a-navigate-response">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigation-to"><span class="secno">6.3.3. </span><span class="content"><code>navigation-to</code></span><a class="self-link" href="#directive-navigation-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigation-to">navigation-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url">URL</a></code>s to which
@@ -4263,7 +4270,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-56">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-58">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives-32">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4773,7 +4780,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source-9">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-57">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source-9">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-59">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -4970,7 +4977,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-58">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object-60">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5146,11 +5153,17 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-columnnumber">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#connect-src">connect-src</a><span>, in §6.1.2</span>
+   <li><a href="#contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy</a><span>, in §2.2</span>
    <li><a href="#header-content-security-policy">Content-Security-Policy</a><span>, in §3.1</span>
    <li><a href="#content-security-policy">Content Security Policy</a><span>, in §1</span>
    <li><a href="#content-security-policy-object">content security policy object</a><span>, in §2.2</span>
    <li><a href="#header-content-security-policy-report-only">Content-Security-Policy-Report-Only</a><span>, in §3.2</span>
-   <li><a href="#global-object-csp-list">CSP list</a><span>, in §4.2</span>
+   <li>
+    CSP list
+    <ul>
+     <li><a href="#csp-list">definition of</a><span>, in §2.2</span>
+     <li><a href="#global-object-csp-list">dfn for global object</a><span>, in §4.2</span>
+    </ul>
    <li><a href="#default-src">default-src</a><span>, in §6.1.3</span>
    <li><a href="#grammardef-directive-name">directive-name</a><span>, in §2.3</span>
    <li><a href="#directives">directives</a><span>, in §2.3</span>
@@ -5228,7 +5241,8 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationevent-originalpolicy">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-originalpolicy">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
-   <li><a href="#parse-serialized-policy">parse a serialized CSP</a><span>, in §2.2</span>
+   <li><a href="#abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</a><span>, in §2.2.1</span>
+   <li><a href="#abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</a><span>, in §2.2.2</span>
    <li><a href="#grammardef-path-part">path-part</a><span>, in §2.3.1</span>
    <li><a href="#plugin-types">plugin-types</a><span>, in §6.2.2</span>
    <li><a href="#plugin-types-post-request-check">plugin-types Post-Request Check</a><span>, in §6.2.2</span>
@@ -5274,12 +5288,15 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent">SecurityPolicyViolationEvent(type, eventInitDict)</a><span>, in §5.1</span>
    <li><a href="#grammardef-self">'self'</a><span>, in §2.3.1</span>
    <li><a href="#serialized-csp">serialized CSP</a><span>, in §2.2</span>
+   <li><a href="#serialized-csp-list">serialized CSP list</a><span>, in §2.2</span>
    <li><a href="#serialized-directive">serialized directive</a><span>, in §2.3</span>
    <li><a href="#grammardef-serialized-directive">serialized-directive</a><span>, in §2.3</span>
    <li><a href="#grammardef-serialized-policy">serialized-policy</a><span>, in §2.2</span>
+   <li><a href="#grammardef-serialized-policy-list">serialized-policy-list</a><span>, in §2.2</span>
    <li><a href="#serialized-source-list">serialized source list</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-serialized-source-list">serialized-source-list</a><span>, in §2.3.1</span>
    <li><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy">Should plugin element be blocked a priori by Content Security Policy?:</a><span>, in §6.2.2.1</span>
+   <li><a href="#policy-source">source</a><span>, in §2.2</span>
    <li><a href="#grammardef-source-expression">source-expression</a><span>, in §2.3.1</span>
    <li><a href="#source-expression">source expression</a><span>, in §2.3.1</span>
    <li><a href="#violation-source-file">source file</a><span>, in §2.4</span>
@@ -5320,6 +5337,7 @@ rest of Google’s CSP Cabal.</p>
     <a data-link-type="biblio">[CSP3]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">content-security-policy</a>
+     <li><a href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy">parse a serialized csp</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
@@ -5481,7 +5499,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://infra.spec.whatwg.org/#ascii-string">ascii string</a>
      <li><a href="https://infra.spec.whatwg.org/#ascii-whitespace">ascii whitespace</a>
-     <li><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a>
+     <li><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collecting a sequence of code points</a>
      <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
      <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
      <li><a href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>
@@ -5584,6 +5602,8 @@ rest of Google’s CSP Cabal.</p>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-csp3">[CSP3]
+   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
    <dt id="biblio-cssom">[CSSOM]
@@ -5645,8 +5665,6 @@ rest of Google’s CSP Cabal.</p>
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
    <dd>Mike West; Adam Barth; Daniel Veditz. <a href="https://www.w3.org/TR/CSP2/">Content Security Policy Level 2</a>. URL: <a href="https://www.w3.org/TR/CSP2/">https://www.w3.org/TR/CSP2/</a>
-   <dt id="biblio-csp3">[CSP3]
-   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-css-abuse">[CSS-ABUSE]
    <dd>Chris Evans. <a href="https://scarybeastsecurity.blogspot.com/2009/12/generic-cross-browser-cross-domain.html">Generic cross-browser cross-domain theft</a>. 28 December 2009. URL: <a href="https://scarybeastsecurity.blogspot.com/2009/12/generic-cross-browser-cross-domain.html">https://scarybeastsecurity.blogspot.com/2009/12/generic-cross-browser-cross-domain.html</a>
    <dt id="biblio-eventsource">[EVENTSOURCE]
@@ -5754,98 +5772,99 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="content-security-policy-object">
    <b><a href="#content-security-policy-object">#content-security-policy-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-content-security-policy-object-1">2.2.1. 
-    Parse a serialized CSP as disposition </a> <a href="#ref-for-content-security-policy-object-2">(2)</a> <a href="#ref-for-content-security-policy-object-3">(3)</a>
-    <li><a href="#ref-for-content-security-policy-object-4">2.2.2. 
-    Parse a serialized CSP list as disposition </a>
-    <li><a href="#ref-for-content-security-policy-object-5">2.3. Directives</a> <a href="#ref-for-content-security-policy-object-6">(2)</a> <a href="#ref-for-content-security-policy-object-7">(3)</a> <a href="#ref-for-content-security-policy-object-8">(4)</a> <a href="#ref-for-content-security-policy-object-9">(5)</a>
-    <li><a href="#ref-for-content-security-policy-object-10">2.4. Violations</a> <a href="#ref-for-content-security-policy-object-11">(2)</a> <a href="#ref-for-content-security-policy-object-12">(3)</a> <a href="#ref-for-content-security-policy-object-13">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object-14">2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object-1">2.2. Policies</a> <a href="#ref-for-content-security-policy-object-2">(2)</a> <a href="#ref-for-content-security-policy-object-3">(3)</a>
+    <li><a href="#ref-for-content-security-policy-object-4">2.2.1. 
+    Parse a serialized CSP </a> <a href="#ref-for-content-security-policy-object-5">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object-6">2.2.2. 
+    Parse a serialized CSP list </a>
+    <li><a href="#ref-for-content-security-policy-object-7">2.3. Directives</a> <a href="#ref-for-content-security-policy-object-8">(2)</a> <a href="#ref-for-content-security-policy-object-9">(3)</a> <a href="#ref-for-content-security-policy-object-10">(4)</a> <a href="#ref-for-content-security-policy-object-11">(5)</a>
+    <li><a href="#ref-for-content-security-policy-object-12">2.4. Violations</a> <a href="#ref-for-content-security-policy-object-13">(2)</a> <a href="#ref-for-content-security-policy-object-14">(3)</a> <a href="#ref-for-content-security-policy-object-15">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object-16">2.4.1. 
     Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object-15">2.4.2. 
+    <li><a href="#ref-for-content-security-policy-object-17">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object-16">3. 
-    Policy Delivery </a> <a href="#ref-for-content-security-policy-object-17">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object-18">4.1. 
+    <li><a href="#ref-for-content-security-policy-object-18">3. 
+    Policy Delivery </a> <a href="#ref-for-content-security-policy-object-19">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object-20">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-content-security-policy-object-19">4.2. 
-    Integration with HTML </a> <a href="#ref-for-content-security-policy-object-20">(2)</a> <a href="#ref-for-content-security-policy-object-21">(3)</a> <a href="#ref-for-content-security-policy-object-22">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object-23">4.2.1. 
+    <li><a href="#ref-for-content-security-policy-object-21">4.2. 
+    Integration with HTML </a> <a href="#ref-for-content-security-policy-object-22">(2)</a> <a href="#ref-for-content-security-policy-object-23">(3)</a> <a href="#ref-for-content-security-policy-object-24">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object-25">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object-24">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object-25">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object-26">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object-26">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object-27">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object-28">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-27">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object-29">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-28">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object-30">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-29">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object-31">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-30">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object-32">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-31">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object-33">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-32">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object-34">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-33">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object-35">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-34">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object-36">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-35">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object-37">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-36">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object-38">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-37">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object-39">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-38">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object-40">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-39">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object-41">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-40">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object-42">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-41">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object-43">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-42">6.1.9. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object-43">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object-44">6.1.9. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object-45">6.1.9.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-44">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object-46">6.1.9.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-45">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object-47">6.1.10.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-46">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object-48">6.1.10.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object-47">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object-49">6.1.11.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-48">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object-50">6.1.11.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-49">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object-51">6.1.12.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-50">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object-52">6.1.12.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-51">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object-53">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object-52">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object-54">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object-53">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object-55">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object-54">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object-56">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object-55">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object-57">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object-56">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object-58">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object-57">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object-58">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object-59">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object-60">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
    <b><a href="#policy-directive-set">#policy-directive-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive-set-1">2.2.1. 
-    Parse a serialized CSP as disposition </a> <a href="#ref-for-policy-directive-set-2">(2)</a> <a href="#ref-for-policy-directive-set-3">(3)</a> <a href="#ref-for-policy-directive-set-4">(4)</a>
+    Parse a serialized CSP </a> <a href="#ref-for-policy-directive-set-2">(2)</a> <a href="#ref-for-policy-directive-set-3">(3)</a> <a href="#ref-for-policy-directive-set-4">(4)</a>
     <li><a href="#ref-for-policy-directive-set-5">2.2.2. 
-    Parse a serialized CSP list as disposition </a>
+    Parse a serialized CSP list </a>
     <li><a href="#ref-for-policy-directive-set-6">2.3. Directives</a>
     <li><a href="#ref-for-policy-directive-set-7">4.2.3. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
@@ -5859,44 +5878,63 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#policy-disposition">#policy-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-disposition-1">2.2.1. 
-    Parse a serialized CSP as disposition </a> <a href="#ref-for-policy-disposition-2">(2)</a>
+    Parse a serialized CSP </a> <a href="#ref-for-policy-disposition-2">(2)</a>
     <li><a href="#ref-for-policy-disposition-3">2.2.2. 
-    Parse a serialized CSP list as disposition </a>
-    <li><a href="#ref-for-policy-disposition-4">2.4. Violations</a>
-    <li><a href="#ref-for-policy-disposition-5">4.1.2. 
+    Parse a serialized CSP list </a> <a href="#ref-for-policy-disposition-4">(2)</a>
+    <li><a href="#ref-for-policy-disposition-5">2.4. Violations</a>
+    <li><a href="#ref-for-policy-disposition-6">4.1.1. 
+    Set response’s CSP list </a> <a href="#ref-for-policy-disposition-7">(2)</a>
+    <li><a href="#ref-for-policy-disposition-8">4.1.2. 
     Report Content Security Policy violations for request </a>
-    <li><a href="#ref-for-policy-disposition-6">4.1.3. 
+    <li><a href="#ref-for-policy-disposition-9">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-disposition-7">4.1.4. 
+    <li><a href="#ref-for-policy-disposition-10">4.1.4. 
     Should response to request be blocked by Content
-    Security Policy? </a> <a href="#ref-for-policy-disposition-8">(2)</a>
-    <li><a href="#ref-for-policy-disposition-9">4.2.3. 
+    Security Policy? </a> <a href="#ref-for-policy-disposition-11">(2)</a>
+    <li><a href="#ref-for-policy-disposition-12">4.2.3. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-disposition-10">4.2.4. 
+    <li><a href="#ref-for-policy-disposition-13">4.2.4. 
     Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-policy-disposition-11">(2)</a>
-    <li><a href="#ref-for-policy-disposition-12">4.2.5. 
+    by Content Security Policy? </a> <a href="#ref-for-policy-disposition-14">(2)</a>
+    <li><a href="#ref-for-policy-disposition-15">4.2.5. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-disposition-13">5.2. 
+    <li><a href="#ref-for-policy-disposition-16">5.2. 
     Obtain the deprecated serialization of violation </a>
-    <li><a href="#ref-for-policy-disposition-14">6.2.1.1. 
+    <li><a href="#ref-for-policy-disposition-17">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-policy-disposition-15">6.2.3.1. 
+    <li><a href="#ref-for-policy-disposition-18">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-policy-disposition-16">6.2.3.2. 
+    <li><a href="#ref-for-policy-disposition-19">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-policy-disposition-17">6.3.2.2. 
+    <li><a href="#ref-for-policy-disposition-20">6.3.2.2. 
 		Relation to X-Frame-Options </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="policy-source">
+   <b><a href="#policy-source">#policy-source</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-policy-source-1">2.2. Policies</a>
+    <li><a href="#ref-for-policy-source-2">2.2.1. 
+    Parse a serialized CSP </a> <a href="#ref-for-policy-source-3">(2)</a>
+    <li><a href="#ref-for-policy-source-4">2.2.2. 
+    Parse a serialized CSP list </a> <a href="#ref-for-policy-source-5">(2)</a>
+    <li><a href="#ref-for-policy-source-6">4.1.1. 
+    Set response’s CSP list </a> <a href="#ref-for-policy-source-7">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="csp-list">
+   <b><a href="#csp-list">#csp-list</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-csp-list-1">2.2. Policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-csp">
    <b><a href="#serialized-csp">#serialized-csp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serialized-csp-1">2.2.1. 
-    Parse a serialized CSP as disposition </a>
-    <li><a href="#ref-for-serialized-csp-2">2.2.2. 
-    Parse a serialized CSP list as disposition </a>
+    <li><a href="#ref-for-serialized-csp-1">2.2. Policies</a>
+    <li><a href="#ref-for-serialized-csp-2">2.2.1. 
+    Parse a serialized CSP </a>
     <li><a href="#ref-for-serialized-csp-3">2.3.1. Source Lists</a>
     <li><a href="#ref-for-serialized-csp-4">3. 
     Policy Delivery </a>
@@ -5913,23 +5951,32 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-serialized-policy">
    <b><a href="#grammardef-serialized-policy">#grammardef-serialized-policy</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-serialized-policy-1">3.1. 
+    <li><a href="#ref-for-grammardef-serialized-policy-1">2.2. Policies</a>
+    <li><a href="#ref-for-grammardef-serialized-policy-2">3.1. 
     The Content-Security-Policy HTTP Response Header Field </a>
-    <li><a href="#ref-for-grammardef-serialized-policy-2">3.2. 
+    <li><a href="#ref-for-grammardef-serialized-policy-3">3.2. 
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-serialized-policy">
-   <b><a href="#parse-serialized-policy">#parse-serialized-policy</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="serialized-csp-list">
+   <b><a href="#serialized-csp-list">#serialized-csp-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-serialized-policy-1">2.2.2. 
-    Parse a serialized CSP list as disposition </a>
-    <li><a href="#ref-for-parse-serialized-policy-2">3.1. 
-    The Content-Security-Policy HTTP Response Header Field </a>
-    <li><a href="#ref-for-parse-serialized-policy-3">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
-    <li><a href="#ref-for-parse-serialized-policy-4">4.1. 
-    Integration with Fetch </a>
+    <li><a href="#ref-for-serialized-csp-list-1">2.2.2. 
+    Parse a serialized CSP list </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp">
+   <b><a href="#abstract-opdef-parse-a-serialized-csp">#abstract-opdef-parse-a-serialized-csp</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-parse-a-serialized-csp-1">2.2.2. 
+    Parse a serialized CSP list </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp-list">
+   <b><a href="#abstract-opdef-parse-a-serialized-csp-list">#abstract-opdef-parse-a-serialized-csp-list</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-parse-a-serialized-csp-list-1">4.1.1. 
+    Set response’s CSP list </a> <a href="#ref-for-abstract-opdef-parse-a-serialized-csp-list-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directives">
@@ -5937,7 +5984,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directives-1">2.2. Policies</a>
     <li><a href="#ref-for-directives-2">2.2.1. 
-    Parse a serialized CSP as disposition </a> <a href="#ref-for-directives-3">(2)</a>
+    Parse a serialized CSP </a> <a href="#ref-for-directives-3">(2)</a>
     <li><a href="#ref-for-directives-4">2.3. Directives</a> <a href="#ref-for-directives-5">(2)</a>
     <li><a href="#ref-for-directives-6">2.3.1. Source Lists</a>
     <li><a href="#ref-for-directives-7">2.4. Violations</a>
@@ -5980,7 +6027,7 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name-1">2.2.1. 
-    Parse a serialized CSP as disposition </a> <a href="#ref-for-directive-name-2">(2)</a>
+    Parse a serialized CSP </a> <a href="#ref-for-directive-name-2">(2)</a>
     <li><a href="#ref-for-directive-name-3">2.3. Directives</a>
     <li><a href="#ref-for-directive-name-4">4.2.4. 
     Should navigation request of type from source in target be blocked
@@ -6012,7 +6059,7 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#directive-value">#directive-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value-1">2.2.1. 
-    Parse a serialized CSP as disposition </a>
+    Parse a serialized CSP </a>
     <li><a href="#ref-for-directive-value-2">2.3. Directives</a> <a href="#ref-for-directive-value-3">(2)</a>
     <li><a href="#ref-for-directive-value-4">2.3.1. Source Lists</a>
     <li><a href="#ref-for-directive-value-5">4.2.3. 

--- a/index.src.html
+++ b/index.src.html
@@ -385,6 +385,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Each policy has an associated <dfn for="policy" export>disposition</dfn>, which is either
   "`enforce`" or "`report`".
 
+  Each policy has an associated <dfn for="policy" export>source</dfn>, which is either "`header`"
+  or "`meta`".
+
+  Multiple [=/policies=] can be applied to a single resource, and are collected into a [=list=] of
+  [=/policies=] known as a <dfn>CSP list</dfn>.
+
+  A [=/CSP list=] <dfn>contains a header-delivered Content Security Policy</dfn> if it
+  [=list/contains=] a [=/policy=] whose [=policy/source=] is "`header`".
+
   A <dfn export>serialized CSP</dfn> is an <a>ASCII string</a> consisting of a semicolon-delimited
   series of <a>serialized directives</a>, adhering to the following ABNF grammar [[!RFC5234]]:
 
@@ -393,73 +402,83 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                         ; <a>OWS</a> is defined in section 3.2.3 of RFC 7230
   </pre>
 
-  <h4 id="parse-serialized-policy" dfn lt="parse a serialized CSP" algorithm>
-    Parse a |serialized CSP| as |disposition|
+  A <dfn export>serialized CSP list</dfn> is an [=ASCII string=] consisting of a comma-delimited
+  series of [=serialized CSPs=], adhering to the following ABNF grammar [[!RFC5234]]:
+
+  <pre dfn-type="grammar" link-type="grammar">
+    <dfn>serialized-policy-list</dfn> = 1#<a>serialized-policy</a>
+                        ; The '#' rule is defined in section 7 of RFC 7230
+  </pre>
+
+  <h4 id="parse-serialized-policy" algorithm>
+    Parse a serialized CSP
   </h4>
 
-  Given a <a>serialized CSP</a> (|serialized CSP|), and a
-  <a for="policy">disposition</a> (|disposition|), this algorithm will return a
-  <a for="/">policy</a> object. If the string cannot be parsed, the resulting
-  <a for="/">policy</a>'s <a>directive set</a> will be empty.
+  To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=serialized CSP=] (|serialized|), a
+  [=policy/source=] (|source|), and a [=policy/disposition=] (|disposition|), execute the
+  following steps.
 
-  1.  Let |policy| be a new <a for="/">policy</a> with an empty
-      <a for="policy">directive set</a>, and a <a for="policy">disposition</a>
-      of |disposition|.
+  This algorithm returns a [=Content Security Policy object=]. If |serialized| could not be
+  parsed, the object's [=policy/directive set=] will be empty.
 
-  2.  For each |token| returned by
-      <a lt="strictly split a string">strictly splitting</a> |serialized
-      CSP| on the U+003B SEMICOLON character (`;`):
+  <ol class="algorithm">
+    1.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
+        of |source|, and a [=policy/disposition=] of |disposition|.
 
-      1.  <a>Strip leading and trailing ASCII whitespace</a> from |token|.
+    2.  For each |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
+        the U+003B SEMICOLON character (`;`):
 
-      2.  If |token| is an empty string, skip the remaining substeps
-          and continue to the next item.
+        1.  [=Strip leading and trailing ASCII whitespace=] from |token|.
 
-      3.  Let |directive name| be the result of
-          <a lt="collect a sequence of code points">collecting a sequence of
-          code points</a> from |token| which are not <a>ASCII whitespace</a>.
+        2.  If |token| is an empty string, [=iteration/continue=].
 
-      4.  If |policy|'s <a>directive set</a> contains a
-          <a>directive</a> whose <a for="directive">name</a> is |directive
-          name|, <a for="iteration">continue</a>.
+        3.  Let |directive name| be the result of [=collecting a sequence of code points=] from
+            |token| which are not [=ASCII whitespace=].
 
-          The user agent SHOULD notify developers that a directive was ignored.
-          A console warning might be appropriate, for example.
+        4.  If |policy|'s [=policy/directive set=] contains a [=directive=] whose [=directive/name=]
+            is |directive name|, [=iteration/continue=].
 
-      5.  Let |directive value| be the result of
-          <a lt="split a string on ASCII whitespace">splitting |token| on
-          ASCII whitespace</a>.
+            In this case, the user agent SHOULD notify developers that a duplicate directive was
+            ignored. A console warning might be appropriate, for example.
 
-      6.  Let |directive| be a new <a>directive</a> whose
-          <a for="directive">name</a> is |directive name|, and
-          <a for="directive">value</a> is |directive value|.
+        5.  Let |directive value| be the result of
+            <a lt="split a string on ASCII whitespace">splitting |token| on
+            ASCII whitespace</a>.
 
-      7.  <a for="set">Append</a> |directive| to |policy|'s <a>directive set</a>.
+        6.  Let |directive| be a new [=directive=] whose [=directive/name=] is |directive name|, and
+            [=directive/value=] is |directive value|.
 
-  3.  Return |policy|.
+        7.  [=set/append|Append=] |directive| to |policy|'s [=policy/directive set=].
+
+    3.  Return |policy|.
+  </ol>
 
   <h4 id="parse-serialized-policy-list" algorithm>
-    Parse a serialized CSP |list| as |disposition|
+    Parse a serialized CSP list
   </h4>
 
-  Given a <a>string</a> which contains a comma-delimited series of <a>serialized CSP</a> strings
-  (|list|) and a <a for="policy">disposition</a> (|disposition|), the following algorithm will
-  return a <a>list</a> of <a for="/">policy</a> objects:
+  To <dfn abstract-op>parse a serialized CSP list</dfn>, given a [=serialized CSP list=] (|list|), a
+  [=policy/source=] (|source|), and a [=policy/disposition=] (|disposition|), execute the following
+  steps.
+ 
+  This algorithm returns a [=list=] of [=Content Security Policy objects=]. If |list| cannot be
+  parsed, the returned list will be empty.
 
-  1.  Let |policies| be an empty <a>list</a>.
+  <ol class="algorithm">
+    1.  Let |policies| be an empty [=list=].
 
-  2.  For each |token| returned by
-      <a lt="split a string on commas">splitting |list| on commas</a>:
+    2.  For each |token| returned by <a lt="split a string on commas">splitting |list| on commas</a>:
 
-      1.  Let |policy| be the result of executing
-          [[#parse-serialized-policy]] on |token| with |disposition|.
+        1.  Let |policy| be the result of <a abstract-op lt="parse a serialized CSP">parsing</a>
+            |token|, with a [=policy/source=] of |source|, and [=policy/disposition=] of
+            |disposition|.
 
-      2.  If |policy|'s <a>directive set</a> is empty, skip the
-          remaining substeps, and continue to the next item.
+        2.  If |policy|'s [=policy/directive set=] is empty, [=iteration/continue=].
 
-      3.  <a for="list">Append</a> |policy| to |policies|.
+        3.  [=list/append|Append=] |policy| to |policies|.
 
-  3.  Return |policies|.
+    3.  Return |policies|.
+  </ol>
 
   <h3 id="framework-directives">Directives</h3>
 
@@ -907,20 +926,24 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   <a for="response">header list</a> for <a>serialized CSP</a> values, and
   populates its <a for="response">CSP list</a> accordingly:
 
-  1.  Set |response|'s <a for="response">CSP list</a> to the
-      empty list.
+  <ol class="algorithm">
+    1.  Set |response|'s [=response/CSP list=] to the empty list.
 
-  2.  Let |policies| be the result of executing [[#parse-serialized-policy-list]] on the result of
-      <a>extracting header list values</a> given `Content-Security-Policy` and |response|'s
-      <a for="response">header list</a>, with a disposition of "`enforce`".
+    2.  Let |policies| be the result of <a abstract-op lt="parse a serialized CSP list">parsing</a>
+        the result of [=extracting header list values=] given `Content-Security-Policy` and
+        |response|'s [=response/header list=], with a [=policy/source=] of "`header`", and a
+        [=policy/disposition=] of "`enforce`".
 
-  3.  Append to |policies| the result of executing [[#parse-serialized-policy-list]] on the result
-      of <a>extracting header list values</a> given `Content-Security-Policy-Report-Only` and
-      |response|'s <a for="response">header list</a>, with a disposition of "`report`".
+    3.  Append to |policies| the result of
+        <a abstract-op lt="parse a serialized CSP list">parsing</a> the result of
+        [=extracting header list values=] given `Content-Security-Policy-Report-Only` and
+        |response|'s [=response/header list=], with a [=policy/source=] of "`header`", and a
+        [=policy/disposition=] of "`report`".
 
-  4.  For each |policy| in |policies|:
+    4.  For each |policy| in |policies|:
 
-      1.  Insert |policy| into |response|'s <a for="response">CSP list</a>.
+        1.  Insert |policy| into |response|'s <a for="response">CSP list</a>.
+  </ol>
 
   <h4 id="report-for-request" algorithm>
     Report Content Security Policy violations for |request|


### PR DESCRIPTION
In order to support the nonce-hiding changes suggested in whatwg/html#2373, this
patch adds a 'source' to each policy object, which allows us to determine whether
it was sent via an HTTP header or a '<meta>' element.

As a drive-by, it also cleans up the formatting and structure of the parsing
algorithms, and more formally defines a 'CSP list' for clarity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/nonce-hiding.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/0b236a7...03fc037.html)