### PR TITLE
Replace Request.type based logic with Request.destination

### DIFF
--- a/index.html
+++ b/index.html
@@ -3171,7 +3171,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-12">value</a> is
@@ -3187,7 +3187,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-13">value</a> is "<code>Does Not Match</code>", return
@@ -3464,7 +3464,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-22">value</a> is
@@ -3480,7 +3480,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-23">value</a> is "<code>Does Not Match</code>", return
@@ -3651,7 +3651,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-26">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-21">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a for="request">script-like destination:</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is <a data-link-type="dfn">script-like destination</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3714,7 +3714,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-27">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-22">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a for="request">script-like destination:</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is <a data-link-type="dfn">script-like destination</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -4613,8 +4613,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is
-  "<code>manifest</code>", return <code>manifest-src</code>.</p>
+          <p>Return <code>manifest-src</code>.</p>
         </ol>
        <dt data-md="">"<code>object</code>"
        <dt data-md="">"<code>embed</code>"
@@ -4667,7 +4666,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>child-src</code>.</p>
+          <p>Return <code>worker-src</code>.</p>
         </ol>
       </dl>
      <li data-md="">

--- a/index.html
+++ b/index.html
@@ -3651,7 +3651,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-26">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-21">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is <a data-link-type="dfn">script-like destination</a>:</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a <a data-link-type="dfn">script-like destination</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3714,7 +3714,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-27">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-22">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is <a data-link-type="dfn">script-like destination</a>:</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a <a data-link-type="dfn">script-like destination</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: medium;
+		font-size: normal;
 	}
 	dfn var {
 		font-style: normal;
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 760cc1c5c9221f585aba069d03f7e9f2a0ecb1df" name="generator">
+  <meta content="Bikeshed version 5eac41affc3976771f238ed8f80db1c877b65b40" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
 <style>
   ul.toc ul ul ul {
@@ -1397,67 +1397,67 @@ Possible extra rowspan handling
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-code.highlight { padding: .1em; border-radius: .3em; }
-pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-</style>
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+        code.highlight { padding: .1em; border-radius: .3em; }
+        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+        </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-04">4 August 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-21">21 August 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2976,9 +2976,6 @@ of security-relevant policy decisions.</p>
            <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a>
            <dd data-md="">
             <p>""</p>
-           <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a>
-           <dd data-md="">
-            <p>""</p>
            <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">credentials mode</a>
            <dd data-md="">
             <p>"<code>same-origin</code>"</p>
@@ -3093,9 +3090,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>child-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-1">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://not-example.com"</span><span class="nt">>&lt;/iframe></span>
-<span class="nt">&lt;script></span>
-  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
+<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://not-example.com"</span><span class="nt">></span><span class="nt">&lt;/iframe></span>
+<span class="nt">&lt;script</span><span class="nt">></span>
+  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">)</span><span class="p">;</span>
 <span class="nt">&lt;/script></span>
 </pre>
     </div>
@@ -3154,16 +3151,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>connect-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-2">source list</a>:</p>
 <pre class="highlight"><span class="nt">&lt;a</span> <span class="na">ping=</span><span class="s">"https://not-example.com"</span><span class="nt">></span>...
-<span class="nt">&lt;script></span>
-  <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">();</span>
-  xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://not-example.com/'</span><span class="p">);</span>
-  xhr<span class="p">.</span>send<span class="p">();</span>
+<span class="nt">&lt;script</span><span class="nt">></span>
+  <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+  xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://not-example.com/'</span><span class="p">)</span><span class="p">;</span>
+  xhr<span class="p">.</span>send<span class="p">(</span><span class="p">)</span><span class="p">;</span>
 
-  <span class="kd">var</span> ws <span class="o">=</span> <span class="k">new</span> WebSocket<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">);</span>
+  <span class="kd">var</span> ws <span class="o">=</span> <span class="k">new</span> WebSocket<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">)</span><span class="p">;</span>
 
-  <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">);</span>
+  <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">)</span><span class="p">;</span>
 
-  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>
+  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">.</span><span class="p">.</span><span class="p">.</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 <span class="nt">&lt;/script></span>
 </pre>
     </div>
@@ -3174,8 +3171,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is
-  "":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-12">value</a> is
@@ -3191,8 +3187,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is
-  "<code>subresource</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>fetch</code>", or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-13">value</a> is "<code>Does Not Match</code>", return
@@ -3303,10 +3298,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>font-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-4">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;style></span>
+<pre class="highlight"><span class="nt">&lt;style</span><span class="nt">></span>
   <span class="k">@font-face</span> <span class="p">{</span>
     <span class="nt">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="o">;</span>
-    <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://not-example.com/font"</span><span class="o">);</span>
+    <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://not-example.com/font"</span><span class="o">)</span><span class="o">;</span>
   <span class="p">}</span>
   <span class="nt">body</span> <span class="p">{</span>
     <span class="k">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
@@ -3321,7 +3316,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>font</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>font</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-16">value</a> is
@@ -3337,7 +3332,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>font</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>font</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-17">value</a> is "<code>Does Not Match</code>", return
@@ -3369,7 +3364,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing
   context</a>:</p>
       <ol>
        <li data-md="">
@@ -3386,7 +3381,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing
   context</a>:</p>
       <ol>
        <li data-md="">
@@ -3404,7 +3399,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list-6">serialized-source-list</a>
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> which load images. More formally, this
-  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
+  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
     <div class="example" id="example-cf60eb05">
      <a class="self-link" href="#example-cf60eb05"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src-3">img-src</a> https://example.com/
@@ -3421,7 +3416,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>image</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>image</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-20">value</a> is
@@ -3437,7 +3432,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>image</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>image</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-21">value</a> is "<code>Does Not Match</code>", return
@@ -3469,7 +3464,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "", and its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-22">value</a> is
@@ -3485,7 +3480,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "", and its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-23">value</a> is "<code>Does Not Match</code>", return
@@ -3507,7 +3502,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>media-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-8">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;audio</span> <span class="na">src=</span><span class="s">"https://not-example.com/audio"</span><span class="nt">>&lt;/audio></span>
+<pre class="highlight"><span class="nt">&lt;audio</span> <span class="na">src=</span><span class="s">"https://not-example.com/audio"</span><span class="nt">></span><span class="nt">&lt;/audio></span>
 <span class="nt">&lt;video</span> <span class="na">src=</span><span class="s">"https://not-example.com/video"</span><span class="nt">></span>
     <span class="nt">&lt;track</span> <span class="na">kind=</span><span class="s">"subtitles"</span> <span class="na">src=</span><span class="s">"https://not-example.com/subtitles"</span><span class="nt">></span>
 <span class="nt">&lt;/video></span>
@@ -3520,7 +3515,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is one of "<code>audio</code>", "<code>video</code>",
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is one of "<code>audio</code>", "<code>video</code>",
   or "<code>track</code>":</p>
       <ol>
        <li data-md="">
@@ -3537,7 +3532,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is one of "<code>audio</code>", "<code>video</code>",
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is one of "<code>audio</code>", "<code>video</code>",
   or "<code>track</code>":</p>
       <ol>
        <li data-md="">
@@ -3560,9 +3555,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-9">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;embed</span> <span class="na">src=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">>&lt;/embed></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">>&lt;/object></span>
-<span class="nt">&lt;applet</span> <span class="na">archive=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">>&lt;/applet></span>
+<pre class="highlight"><span class="nt">&lt;embed</span> <span class="na">src=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/embed></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
+<span class="nt">&lt;applet</span> <span class="na">archive=</span><span class="s">"https://not-example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/applet></span>
 </pre>
     </div>
     <p>If plugin content is loaded without an associated URL (perhaps an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-object-element">object</a></code> element lacks a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-object-data">data</a></code> attribute, but loads some default plugin based
@@ -3588,7 +3583,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "", and its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>unknown</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-26">value</a> is
@@ -3604,7 +3599,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "", and its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>unknown</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value-27">value</a> is "<code>Does Not Match</code>", return
@@ -3656,7 +3651,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-26">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-21">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>script</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a for="request">script-like destination:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3719,7 +3714,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives-27">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-22">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>script</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is a for="request">script-like destination:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3826,7 +3821,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>style</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>style</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3846,7 +3841,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a> is "<code>style</code>":</p>
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is "<code>style</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a> and this
@@ -3890,10 +3885,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists-10">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;script></span>
-  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
-  blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">);</span>
-  navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://not-example.com/sw.js'</span><span class="p">);</span>
+<pre class="highlight"><span class="nt">&lt;script</span><span class="nt">></span>
+  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">)</span><span class="p">;</span>
+  blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://not-example.com/"</span><span class="p">)</span><span class="p">;</span>
+  navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://not-example.com/sw.js'</span><span class="p">)</span><span class="p">;</span>
 <span class="nt">&lt;/script></span>
 </pre>
     </div>
@@ -4002,21 +3997,21 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types-1">plugin-types</a> application/pdf
 </pre>
      <p>Fetches for the following code will all return network errors:</p>
-<pre class="highlight"><span class="c">&lt;!-- No 'type' declaration --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span><span class="nt">>&lt;/object></span>
+<pre class="highlight"><span class="c">&lt;!--</span><span class="c"> No 'type' declaration </span><span class="c">--></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 
-<span class="c">&lt;!-- Non-matching 'type' declaration --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">>&lt;/object></span>
+<span class="c">&lt;!--</span><span class="c"> Non</span><span class="c">-</span><span class="c">matching 'type' declaration </span><span class="c">--></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 
-<span class="c">&lt;!-- Non-matching resource --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/pdf"</span><span class="nt">>&lt;/object></span>
+<span class="c">&lt;!--</span><span class="c"> Non</span><span class="c">-</span><span class="c">matching resource </span><span class="c">--></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/pdf"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 </pre>
      <p>If the page allowed Flash content by sending the following header:</p>
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types-2">plugin-types</a> application/x-shockwave-flash
 </pre>
      <p>Then the second item above would load successfully:</p>
-<pre class="highlight"><span class="c">&lt;!-- Matching 'type' declaration and resource --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">>&lt;/object></span>
+<pre class="highlight"><span class="c">&lt;!--</span><span class="c"> Matching 'type' declaration and resource </span><span class="c">--></span>
+<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">></span><span class="nt">&lt;/object></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
@@ -4600,31 +4595,39 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives-3">fetch directive</a> controls a specific type of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>. Given
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives-3">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a>. Given
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name-24">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
     <ol>
      <li data-md="">
-      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-type">type</a>, and execute
+      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a>, and execute
   the associated steps:</p>
       <dl>
        <dt data-md="">""
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> are both the empty string, return <code>connect-src</code>.</p>
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is
+  the empty string, return <code>connect-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>manifest</code>"
+       <dd data-md="">
+        <ol>
          <li data-md="">
           <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> is
   "<code>manifest</code>", return <code>manifest-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>object</code>"
+       <dt data-md="">"<code>embed</code>"
+       <dd data-md="">
+        <ol>
          <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is
-  "<code>subresource</code>", return <code>connect-src</code>.</p>
+          <p>Return <code>object-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>document</code>"
+       <dd data-md="">
+        <ol>
          <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is
-  "<code>unknown</code>", return <code>object-src</code>.</p>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is
-  "<code>document</code>" <em>and</em> the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing
-  context</a>, return <code>frame-src</code>.</p>
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, return <code>frame-src</code>.</p>
         </ol>
        <dt data-md="">"<code>audio</code>"
        <dt data-md="">"<code>track</code>"
@@ -4653,28 +4656,18 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
           <p>Return <code>style-src</code>.</p>
         </ol>
        <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>xslt</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a>, and
-  execute the associated steps:</p>
-          <dl>
-           <dt data-md="">"<code>script</code>"
-           <dt data-md="">"<code>subresource</code>"
-           <dd data-md="">
-            <ol>
-             <li data-md="">
-              <p>Return <code>script-src</code>.</p>
-            </ol>
-           <dt data-md="">"<code>serviceworker</code>"
-           <dt data-md="">"<code>sharedworker</code>"
-           <dt data-md="">"<code>worker</code>"
-           <dd data-md="">
-            <ol>
-             <li data-md="">
-              <p>Return <code>worker-src</code>.</p>
-            </ol>
-          </dl>
+          <p>Return <code>script-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>sharedworker</code>"
+       <dt data-md="">"<code>worker</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>child-src</code>.</p>
         </ol>
       </dl>
      <li data-md="">
@@ -4854,12 +4847,12 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.2" id="security-nonce-stealing"><span class="secno">7.2. </span><span class="content">Nonce Stealing</span><a class="self-link" href="#security-nonce-stealing"></a></h3>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
   example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> element:</p>
-<pre class="highlight"><span class="nt">&lt;p></span>Hello, [INJECTION POINT]<span class="nt">&lt;/p></span>
-<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="nt">&lt;p</span><span class="nt">></span>Hello, [INJECTION POINT]<span class="nt">&lt;/p></span>
+<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
     <p>If an attacker injects the string "<code>&lt;script src='https://evil.com/evil.js' </code>",
   then the browser will receive the following:</p>
-<pre class="highlight"><span class="nt">&lt;p></span>Hello, <span class="nt">&lt;script </span><span class="na">src=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="nt">></span>
+<pre class="highlight"><span class="nt">&lt;p</span><span class="nt">></span>Hello, <span class="nt">&lt;script </span><span class="na">src=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="nt">></span>
 <span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="nt">&lt;/script></span>
 </pre>
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
@@ -4873,11 +4866,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   origin. This, generally, is fine, and desirable from the developer’s perspective. However, if an
   attacker can inject a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a></code> element, then an otherwise safe page can be subverted when relative
   URLs are resolved. That is, on <code>https://example.com/</code> the following code will load <code>https://example.com/good.js</code>:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
     <p>However, the following will load <code>https://evil.com/good.js</code>:</p>
 <pre class="highlight"><span class="nt">&lt;base</span> <span class="na">href=</span><span class="s">"https://evil.com"</span><span class="nt">></span>
-<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri-2"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
@@ -4992,17 +4985,17 @@ Content-Security-Policy: connect-src http://example.com/;
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
-<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="nt">>&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="nt">></span><span class="nt">&lt;/script></span>
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
     will not be blocked because of the matching <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nonce">nonce</a></code> attribute.</p>
      <p>If <code>script.js</code> contains the following code:</p>
-<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> document<span class="p">.</span>createElement<span class="p">(</span><span class="s1">'script'</span><span class="p">);</span>
+<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> document<span class="p">.</span>createElement<span class="p">(</span><span class="s1">'script'</span><span class="p">)</span><span class="p">;</span>
 s<span class="p">.</span>src <span class="o">=</span> <span class="s1">'https://othercdn.not-example.net/dependency.js'</span><span class="p">;</span>
-document<span class="p">.</span>head<span class="p">.</span>appendChild<span class="p">(</span><span class="s1">'s'</span><span class="p">);</span>
+document<span class="p">.</span>head<span class="p">.</span>appendChild<span class="p">(</span><span class="s1">'s'</span><span class="p">)</span><span class="p">;</span>
 
-document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&lt;scr'</span> <span class="o">+</span> <span class="s1">'ipt src='</span><span class="o">/</span>sadness<span class="p">.</span>js<span class="s1">'>&lt;/scr'</span> <span class="o">+</span> <span class="s1">'ipt>'</span><span class="p">);</span>
+document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&lt;scr'</span> <span class="o">+</span> <span class="s1">'ipt src='</span><span class="o">/</span>sadness<span class="p">.</span>js<span class="s1">'>&lt;/scr'</span> <span class="o">+</span> <span class="s1">'ipt>'</span><span class="p">)</span><span class="p">;</span>
 </pre>
      <p><code>dependency.js</code> will load, as the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> element created by <code>createElement()</code> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">"parser-inserted"</a>.</p>
      <p><code>sadness.js</code> will <em>not</em> load, however, as <code>document.write()</code> produces <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">"parser-inserted"</a>.</p>
@@ -5052,16 +5045,16 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
       <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
       <p>Metadata that is not recognized (either because it’s entirely invalid, or
       because it specifies a not-yet-supported hashing algorithm) does not affect
@@ -5069,9 +5062,9 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       allowed to execute in the presence of the above policy, as the additional
       metadata is invalid and therefore wouldn’t allow a script whose content
       wasn’t listed explicitly in the policy to execute:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
+<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">></span><span class="nt">&lt;/script></span>
 </pre>
      </div>
     </section>
@@ -5516,7 +5509,6 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request">request</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-request-type">type</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url <small>(for request)</small></a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-url">url <small>(for response)</small></a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-window">window</a>
@@ -5800,39 +5792,39 @@ rest of Google’s CSP Cabal.</p>
    <dd>James Clark. <a href="https://www.w3.org/TR/xslt">XSL Transformations (XSLT) Version 1.0</a>. 16 November 1999. REC. URL: <a href="https://www.w3.org/TR/xslt">https://www.w3.org/TR/xslt</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><span class="kt">enum</span> <a class="nv" href="#enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></a> {
-  <a class="s" href="#dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code></a>, <a class="s" href="#dom-securitypolicyviolationeventdisposition-report"><code>"report"</code></a>
+<pre class="idl highlight def"><span class="kt"><span class="kt">enum</span></span> <a class="nv" href="#enumdef-securitypolicyviolationeventdisposition"><code><span class="nv">SecurityPolicyViolationEventDisposition</span></code></a> {
+  <a class="s" href="#dom-securitypolicyviolationeventdisposition-enforce"><code><span class="s">"enforce"</span></code></a>, <a class="s" href="#dom-securitypolicyviolationeventdisposition-report"><code><span class="s">"report"</span></code></a>
 };
 
-[<a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
-<span class="kt">interface</span> <a class="nv" href="#securitypolicyviolationevent"><code>SecurityPolicyViolationEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-documenturi"><code>documentURI</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-referrer"><code>referrer</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-blockeduri"><code>blockedURI</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective"><code>violatedDirective</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code>effectiveDirective</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code>originalPolicy</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sourcefile"><code>sourceFile</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code>sample</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a>      <a class="nv" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code>disposition</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code>statusCode</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a>           <a class="nv" data-readonly="" data-type="long" href="#dom-securitypolicyviolationevent-linenumber"><code>lineNumber</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a>           <a class="nv" data-readonly="" data-type="long" href="#dom-securitypolicyviolationevent-columnnumber"><code>columnNumber</code></a>;
+[<a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code><span class="nv">Constructor</span></code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code><span class="nv">type</span></code></a>, <span class="kt"><span class="kt">optional</span></span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit"><span class="n">SecurityPolicyViolationEventInit</span></a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code><span class="nv">eventInitDict</span></code></a>)]
+<span class="kt"><span class="kt">interface</span></span> <a class="nv" href="#securitypolicyviolationevent"><code><span class="nv">SecurityPolicyViolationEvent</span></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event"><span class="n">Event</span></a> {
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-documenturi"><code><span class="nv">documentURI</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-referrer"><code><span class="nv">referrer</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-blockeduri"><code><span class="nv">blockedURI</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective"><code><span class="nv">violatedDirective</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code><span class="nv">effectiveDirective</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code><span class="nv">originalPolicy</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sourcefile"><code><span class="nv">sourceFile</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code><span class="nv">sample</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition"><span class="n">SecurityPolicyViolationEventDisposition</span></a>      <a class="nv" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code><span class="nv">disposition</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">short</span></span></a> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code><span class="nv">statusCode</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt"><span class="kt">long</span></span></a>           <a class="nv" data-readonly="" data-type="long" href="#dom-securitypolicyviolationevent-linenumber"><code><span class="nv">lineNumber</span></code></a>;
+    <span class="kt"><span class="kt">readonly</span></span>    <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt"><span class="kt">long</span></span></a>           <a class="nv" data-readonly="" data-type="long" href="#dom-securitypolicyviolationevent-columnnumber"><code><span class="nv">columnNumber</span></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-securitypolicyviolationeventinit"><code>SecurityPolicyViolationEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-documenturi"><code>documentURI</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-referrer"><code>referrer</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-blockeduri"><code>blockedURI</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-violateddirective"><code>violatedDirective</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code>effectiveDirective</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code>originalPolicy</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code>sourceFile</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code>sample</code></a>;
-    <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a>      <a class="nv" data-type="SecurityPolicyViolationEventDisposition      " href="#dom-securitypolicyviolationeventinit-disposition"><code>disposition</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code>statusCode</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a>           <a class="nv" data-type="long           " href="#dom-securitypolicyviolationeventinit-linenumber"><code>lineNumber</code></a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a>           <a class="nv" data-type="long           " href="#dom-securitypolicyviolationeventinit-columnnumber"><code>columnNumber</code></a>;
+<span class="kt"><span class="kt">dictionary</span></span> <a class="nv" href="#dictdef-securitypolicyviolationeventinit"><code><span class="nv">SecurityPolicyViolationEventInit</span></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit"><span class="n">EventInit</span></a> {
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-documenturi"><code><span class="nv">documentURI</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-referrer"><code><span class="nv">referrer</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-blockeduri"><code><span class="nv">blockedURI</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-violateddirective"><code><span class="nv">violatedDirective</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code><span class="nv">effectiveDirective</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code><span class="nv">originalPolicy</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code><span class="nv">sourceFile</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt"><span class="kt">DOMString</span></span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code><span class="nv">sample</span></code></a>;
+    <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition"><span class="n">SecurityPolicyViolationEventDisposition</span></a>      <a class="nv" data-type="SecurityPolicyViolationEventDisposition      " href="#dom-securitypolicyviolationeventinit-disposition"><code><span class="nv">disposition</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">short</span></span></a> <a class="nv" data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code><span class="nv">statusCode</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt"><span class="kt">long</span></span></a>           <a class="nv" data-type="long           " href="#dom-securitypolicyviolationeventinit-linenumber"><code><span class="nv">lineNumber</span></code></a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt"><span class="kt">long</span></span></a>           <a class="nv" data-type="long           " href="#dom-securitypolicyviolationeventinit-columnnumber"><code><span class="nv">columnNumber</span></code></a>;
 };
 
 </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -1656,8 +1656,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
               ::  "`report`"
               :   <a for="request">initiator</a>
               ::  ""
-              :   <a for="request">type</a>
-              ::  ""
               :   <a for="request">credentials mode</a>
               ::  "`same-origin`"
               :   <a for="request">keepalive flag</a>
@@ -1901,8 +1899,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Assert: |policy| is unused.
 
   2.  If |request|'s <a for="request">initiator</a> is "`fetch`", or its
-      <a for="request">type</a> is "" and <a for="request">destination</a> is
-      "":
+      <a for="request">destination</a> is "":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -1922,8 +1919,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Assert: |policy| is unused.
 
   2.  If |request|'s <a for="request">initiator</a> is "`fetch`", or its
-      <a for="request">type</a> is "" and <a for="request">destination</a> is
-      "`subresource`":
+      <a for="request">destination</a> is "":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2104,7 +2100,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`font`":
+  2.  If |request|'s <a for="request">destination</a> is "`font`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -2123,7 +2119,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`font`":
+  2.  If |request|'s <a for="request">destination</a> is "`font`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2169,7 +2165,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`document`" and
+  2.  If |request|'s <a for="request">destination</a> is "`document`" and
       <a for="request">target browsing context</a> is a <a>nested browsing
       context</a>:
 
@@ -2190,7 +2186,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`document`" and
+  2.  If |request|'s <a for="request">destination</a> is "`document`" and
       <a for="request">target browsing context</a> is a <a>nested browsing
       context</a>:
 
@@ -2213,7 +2209,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   </pre>
 
   This directive controls <a for="/">requests</a> which load images. More formally, this
-  includes <a for="/">requests</a> whose <a for="request">type</a> is "`image`"
+  includes <a for="/">requests</a> whose <a for="request">destination</a> is "`image`"
   [[FETCH]].
 
   <div class="example">
@@ -2241,7 +2237,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`image`":
+  2.  If |request|'s <a for="request">destination</a> is "`image`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -2260,7 +2256,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`image`":
+  2.  If |request|'s <a for="request">destination</a> is "`image`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2305,8 +2301,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "", and its
-      <a for="request">initiator</a> is "`manifest`":
+  2.  If |request|'s <a for="request">initiator</a> is "`manifest`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -2325,8 +2320,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "", and its
-      <a for="request">initiator</a> is "`manifest`":
+  2.  If |request|'s <a for="request">initiator</a> is "`manifest`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2374,7 +2368,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is one of "`audio`", "`video`",
+  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
       or "`track`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
@@ -2394,7 +2388,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is one of "`audio`", "`video`",
+  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
       or "`track`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
@@ -2465,8 +2459,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "", and its
-      <a for="request">destination</a> is "`unknown`":
+  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -2485,8 +2478,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "", and its
-      <a for="request">destination</a> is "`unknown`":
+  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2546,7 +2538,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">type</a> is "`script`":
+  2.  If |request|'s <a for="request">destination</a> is a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -2620,7 +2612,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">type</a> is "`script`":
+  2.  If |request|'s <a for="request">destination</a> is a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -2735,7 +2727,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`style`":
+  2.  If |request|'s <a for="request">destination</a> is "`style`":
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -2759,7 +2751,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">type</a> is "`style`":
+  2.  If |request|'s <a for="request">destination</a> is "`style`":
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -3736,28 +3728,30 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     Get the effective directive for |request|
   </h5>
 
-  Each <a>fetch directive</a> controls a specific type of <a for="/">request</a>. Given
+  Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
   a <a for="/">request</a> (|request|), the following algorithm returns either
   `null` or the <a for="directive">name</a> of the request's
   <dfn for="request" export>effective directive</dfn>:
 
-  1.  Switch on |request|'s <a for="request">type</a>, and execute
+  1.  Switch on |request|'s <a for="request">destination</a>, and execute
       the associated steps:
 
       : ""
       ::
-        1.  If the |request|'s <a for="request">initiator</a> and <a for="request">destination</a>
-            are both the empty string, return `connect-src`.
-        2.  If the |request|'s <a for="request">initiator</a> is
+        1.  If the |request|'s <a for="request">initiator</a> is
+            the empty string, return `connect-src`.
+      : "`manifest`"
+      ::
+        1.  If the |request|'s <a for="request">initiator</a> is
             "`manifest`", return `manifest-src`.
-        3.  If the |request|'s <a for="request">destination</a> is
-            "`subresource`", return `connect-src`.
-        4.  If the |request|'s <a for="request">destination</a> is
-            "`unknown`", return `object-src`.
-        5.  If the |request|'s <a for="request">destination</a> is
-            "`document`" <em>and</em> the |request|'s
-            <a for="request">target browsing context</a> is a <a>nested browsing
-            context</a>, return `frame-src`.
+      : "`object`"
+      : "`embed`"
+      ::
+        1.  Return `object-src`.
+      : "`document`"
+      ::
+        1.  If the |request|'s <a for="request">target browsing context</a>
+            is a <a>nested browsing context</a>, return `frame-src`.
 
       : "`audio`"
       : "`track`"
@@ -3778,20 +3772,14 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
         1.  Return `style-src`.
 
       : "`script`"
+      : "`xslt`"
       ::
-        1.  Switch on |request|'s <a for="request">destination</a>, and
-            execute the associated steps:
+        1. Return `script-src`.
 
-            : "`script`"
-            : "`subresource`"
-            ::
-              1.  Return `script-src`.
-
-            : "`serviceworker`"
-            : "`sharedworker`"
-            : "`worker`"
-            ::
-              1.  Return `worker-src`.
+      : "`sharedworker`"
+      : "`worker`"
+      ::
+        1. Return `child-src`.
 
   2.  Return `null`.
 

--- a/index.src.html
+++ b/index.src.html
@@ -1898,7 +1898,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`", or its
+  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
       <a for="request">destination</a> is "":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
@@ -1918,7 +1918,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`", or its
+  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
       <a for="request">destination</a> is "":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
@@ -2301,7 +2301,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`manifest`":
+  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on
           |request| and this directive's <a for="directive">value</a> is
@@ -2320,7 +2320,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`manifest`":
+  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, and this directive's
@@ -2538,7 +2538,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">destination</a> is a for="request">script-like destination</a>:
+  2.  If |request|'s <a for="request">destination</a> is <a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -2612,7 +2612,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">destination</a> is a for="request">script-like destination</a>:
+  2.  If |request|'s <a for="request">destination</a> is <a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -3742,8 +3742,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
             the empty string, return `connect-src`.
       : "`manifest`"
       ::
-        1.  If the |request|'s <a for="request">initiator</a> is
-            "`manifest`", return `manifest-src`.
+        1.  Return `manifest-src`.
       : "`object`"
       : "`embed`"
       ::
@@ -3779,7 +3778,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       : "`sharedworker`"
       : "`worker`"
       ::
-        1. Return `child-src`.
+        1. Return `worker-src`.
 
   2.  Return `null`.
 

--- a/index.src.html
+++ b/index.src.html
@@ -2538,7 +2538,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request">script-like destination</a>:
+  2.  If |request|'s <a for="request">destination</a> is a <a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
@@ -2612,7 +2612,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       Note: If `worker-src` is present, we'll defer to it when handling worker requests.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request">script-like destination</a>:
+  2.  If |request|'s <a for="request">destination</a> is a <a for="request">script-like destination</a>:
 
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this


### PR DESCRIPTION
As Fetch is eliminating Request.type (https://github.com/whatwg/fetch/pull/582), this PR (tries to) replace the related logic to Request.destination.

At the same time, CSP had references to no-longer-existing destinations. I've aligned it with latest Fetch definitions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/webappsec-csp/replace_request_type_with_destination.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/eff9c9c...yoavweiss:65895a1.html)