### PR TITLE
Fixed ambigous grammar around `path-part`

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -91,7 +91,7 @@ spec: RFC2045; urlPrefix: https://tools.ietf.org/html/rfc2045
     text: subtype; url: section-5.1
 spec: RFC3986; urlPrefix: https://tools.ietf.org/html/rfc3986
   type: grammar
-    text: path-abempty; url: section-3.3
+    text: path-absolute; url: section-3.3
     text: scheme; url: section-3.1
     text: IPv4address; url: section-3.2.2
     text: uri-reference; url: section-4.1
@@ -602,8 +602,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
     <dfn>host-char</dfn>   = <a>ALPHA</a> / <a>DIGIT</a> / "-"
     <dfn>port-part</dfn>   = 1*<a>DIGIT</a> / "*"
-    <dfn>path-part</dfn>   = <a>path-abempty</a>
-                  ; <a>path-abempty</a> is defined in section 3.3 of RFC 3986.
+    <dfn>path-part</dfn>   = <a>path-absolute</a>
+                  ; <a>path-absolute</a> is defined in section 3.3 of RFC 3986.
 
     ; Keywords:
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>"


### PR DESCRIPTION
https://github.com/w3c/webappsec-csp/issues/249


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/andypaicu/webappsec-csp/ambigous-grammar.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/39faa1b...andypaicu:1cf57f6.html)