### PR TITLE
Slight correction of `host-matching` description

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -574,7 +574,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   4.  Hosts such as `example.com` (which matches any resource on
       the host, regardless of scheme) or `*.example.com` (which
-      matches any resource on the host or any of its subdomains (and any of
+      matches any resource on the host's subdomains (and any of
       its subdomains' subdomains, and so on))
 
   5.  Nonces such as `'nonce-ch4hvvbHDpv7xCSvXCs3BrNggHdTzxUA'` (which can match


### PR DESCRIPTION
https://github.com/w3c/webappsec-csp/issues/241


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/andypaicu/webappsec-csp/any-host-thing.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-csp/39faa1b...andypaicu:da0f902.html)