### PR TITLE
Introduce 'prefetch-src'. Closes w3c/webappsec-csp#107.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,9 +1176,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version fbf1456a756299b3ff6d248d0857ec87f2e68cd7" name="generator">
+  <meta content="Bikeshed version d1c8ac9ac0bb0f0e970e3942633cfb7d2f7e12e6" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="98bea96e4d55fcd98d8648cef16416a462516cc1" name="document-revision">
+  <meta content="b0420ce3f1f6ccb255595818144a4f83b9f03d61" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-12-21">21 December 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-15">15 January 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1480,7 +1480,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1505,10 +1505,10 @@ of security-relevant policy decisions.</p>
 	“[csp3] <em>…summary of comment…</em>” </p>
    <p> This document was produced by the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
    <p></p>
   </div>
@@ -1653,30 +1653,36 @@ of security-relevant policy decisions.</p>
           <li><a href="#media-src-post-request"><span class="secno">6.1.8.2</span> <span class="content"> <code>media-src</code> Post-request check </span></a>
          </ol>
         <li>
-         <a href="#directive-object-src"><span class="secno">6.1.9</span> <span class="content"><code>object-src</code></span></a>
+         <a href="#directive-prefetch-src"><span class="secno">6.1.9</span> <span class="content"><code>prefetch-src</code></span></a>
          <ol class="toc">
-          <li><a href="#object-src-pre-request"><span class="secno">6.1.9.1</span> <span class="content"> <code>object-src</code> Pre-request check </span></a>
-          <li><a href="#object-src-post-request"><span class="secno">6.1.9.2</span> <span class="content"> <code>object-src</code> Post-request check </span></a>
+          <li><a href="#prefetch-src-pre-request"><span class="secno">6.1.9.1</span> <span class="content"> <code>prefetch-src</code> Pre-request check </span></a>
+          <li><a href="#prefetch-src-post-request"><span class="secno">6.1.9.2</span> <span class="content"> <code>prefetch-src</code> Post-request check </span></a>
          </ol>
         <li>
-         <a href="#directive-script-src"><span class="secno">6.1.10</span> <span class="content"><code>script-src</code></span></a>
+         <a href="#directive-object-src"><span class="secno">6.1.10</span> <span class="content"><code>object-src</code></span></a>
          <ol class="toc">
-          <li><a href="#script-src-pre-request"><span class="secno">6.1.10.1</span> <span class="content"> <code>script-src</code> Pre-request check </span></a>
-          <li><a href="#script-src-post-request"><span class="secno">6.1.10.2</span> <span class="content"> <code>script-src</code> Post-request check </span></a>
-          <li><a href="#script-src-inline"><span class="secno">6.1.10.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
+          <li><a href="#object-src-pre-request"><span class="secno">6.1.10.1</span> <span class="content"> <code>object-src</code> Pre-request check </span></a>
+          <li><a href="#object-src-post-request"><span class="secno">6.1.10.2</span> <span class="content"> <code>object-src</code> Post-request check </span></a>
          </ol>
         <li>
-         <a href="#directive-style-src"><span class="secno">6.1.11</span> <span class="content"><code>style-src</code></span></a>
+         <a href="#directive-script-src"><span class="secno">6.1.11</span> <span class="content"><code>script-src</code></span></a>
          <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.11.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.11.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+          <li><a href="#script-src-pre-request"><span class="secno">6.1.11.1</span> <span class="content"> <code>script-src</code> Pre-request check </span></a>
+          <li><a href="#script-src-post-request"><span class="secno">6.1.11.2</span> <span class="content"> <code>script-src</code> Post-request check </span></a>
+          <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.12</span> <span class="content"><code>worker-src</code></span></a>
+         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
          <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -2185,7 +2191,7 @@ of security-relevant policy decisions.</p>
       <p>If the user agent is currently executing script, and can extract a source
   file’s URL, line number, and column number from the <var>global</var>, set <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file">source file</a>, <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number">line
   number</a>, and <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number">column number</a> accordingly.</p>
-      <p class="issue" id="issue-c404edb5"><a class="self-link" href="#issue-c404edb5"></a> Is this kind of thing specified anywhere? I didn’t see anything
+      <p class="issue" id="issue-de937cf3"><a class="self-link" href="#issue-de937cf3"></a> Is this kind of thing specified anywhere? I didn’t see anything
   that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.</p>
       <p class="note" role="note"><span>Note:</span> User agents need to ensure that the <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file①">source file</a> is the URL requested by
   the page, pre-redirects. If that’s not possible, user agents need to strip the URL down to an
@@ -2268,7 +2274,7 @@ of security-relevant policy decisions.</p>
   whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv①">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<code>Content-Security-Policy</code>". For example:</p>
     <div class="example" id="example-f977fbdb">
      <a class="self-link" href="#example-f977fbdb"></a> 
-<pre class="highlight"><span class="nt">&lt;meta</span> <span class="na">http-equiv=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content=</span><span class="s">"script-src 'self'"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">meta</span> <span class="na">http-equiv</span><span class="o">=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content</span><span class="o">=</span><span class="s">"script-src 'self'"</span><span class="p">></span>
 </pre>
     </div>
     <p>Implementation details can be found in HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy" id="ref-for-attr-meta-http-equiv-content-security-policy">Content Security Policy
@@ -2780,7 +2786,7 @@ of security-relevant policy decisions.</p>
         <p>If <var>result</var> is "<code>Blocked</code>", throw an <code>EvalError</code> exception.</p>
       </ol>
     </ol>
-    <p class="issue" id="issue-910d1dca"><a class="self-link" href="#issue-910d1dca"></a> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings①">HostEnsureCanCompileStrings()</a></code> does not include the string which is
+    <p class="issue" id="issue-c0b6be8f"><a class="self-link" href="#issue-c0b6be8f"></a> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings①">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
   to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a></p>
    </section>
@@ -3116,16 +3122,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
  "<code>sharedworker</code>", or "<code>worker</code>" (which are fed to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker①">run a worker</a> algorithm for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker">ServiceWorker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker">SharedWorker</a></code>, and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker①">Worker</a></code>,
  respectively).</p>
     </ul>
-    <div class="example" id="example-8a4405cf">
-     <a class="self-link" href="#example-8a4405cf"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-7c658652">
+     <a class="self-link" href="#example-7c658652"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#child-src" id="ref-for-child-src①">child-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>child-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://example.org"</span><span class="nt">>&lt;/iframe></span>
-<span class="nt">&lt;script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
@@ -3167,8 +3173,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping" id="ref-for-dom-a-ping">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
-    <div class="example" id="example-ea16035e">
-     <a class="self-link" href="#example-ea16035e"></a> JavaScript offers a few mechanisms that directly connect to an external
+    <div class="example" id="example-48d9ac69">
+     <a class="self-link" href="#example-48d9ac69"></a> JavaScript offers a few mechanisms that directly connect to an external
     server to send or receive information. <code>EventSource</code> maintains an open
     HTTP connection to a server in order to receive push notifications, <code>WebSockets</code> open a bidirectional communication channel between your
     browser and a server, and <code>XMLHttpRequest</code> makes arbitrary HTTP requests
@@ -3182,8 +3188,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>connect-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;a</span> <span class="na">ping=</span><span class="s">"https://example.org"</span><span class="nt">></span>...
-<span class="nt">&lt;script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">ping</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">></span>...
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">();</span>
   xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://example.org/'</span><span class="p">);</span>
   xhr<span class="p">.</span>send<span class="p">();</span>
@@ -3193,7 +3199,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
 
   navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
@@ -3239,8 +3245,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-ff4cda9d">
-     <a class="self-link" href="#example-ff4cda9d"></a> The following header: 
+    <div class="example" id="example-c1f9348d">
+     <a class="self-link" href="#example-c1f9348d"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3250,31 +3256,33 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#img-src" id="ref-for-img-src">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤">'self'</a>;
                          <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>;
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-e1c8ddf3">
-     <a class="self-link" href="#example-e1c8ddf3"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-99b46628">
+     <a class="self-link" href="#example-99b46628"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src②">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src②">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
                          <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3324,21 +3332,21 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "font-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list③">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-9055d098">
-     <a class="self-link" href="#example-9055d098"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-18a1ab95">
+     <a class="self-link" href="#example-18a1ab95"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#font-src" id="ref-for-font-src③">font-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>font-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists③">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;style></span>
-  <span class="k">@font-face</span> <span class="p">{</span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="p">@</span><span class="k">font-face</span> <span class="p">{</span>
     <span class="nt">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="o">;</span>
     <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://example.org/font"</span><span class="o">);</span>
   <span class="p">}</span>
   <span class="nt">body</span> <span class="p">{</span>
-    <span class="k">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
+    <span class="k">font-family</span><span class="p">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
   <span class="p">}</span>
-<span class="nt">&lt;/style></span>
+<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
@@ -3379,14 +3387,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list④">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-367911bc">
-     <a class="self-link" href="#example-367911bc"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-bfc084b5">
+     <a class="self-link" href="#example-bfc084b5"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src③">frame-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>frame-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists④">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">src=</span><span class="s">"https://example.org/"</span><span class="nt">></span>
-<span class="nt">&lt;/iframe></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
@@ -3432,13 +3440,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">requests</a> which load images. More formally, this
   includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
-    <div class="example" id="example-d81d31f9">
-     <a class="self-link" href="#example-d81d31f9"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-92004bdb">
+     <a class="self-link" href="#example-92004bdb"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src②">img-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>img-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑤">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"https://example.org/img"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/img"</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
@@ -3480,13 +3488,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "manifest-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑥">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-c0df126a">
-     <a class="self-link" href="#example-c0df126a"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-3cb9bb0f">
+     <a class="self-link" href="#example-3cb9bb0f"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src②">manifest-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>manifest-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑥">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"manifest"</span> <span class="na">href=</span><span class="s">"https://example.org/manifest"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"manifest"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://example.org/manifest"</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
@@ -3528,16 +3536,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "media-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑦">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-0bdf4506">
-     <a class="self-link" href="#example-0bdf4506"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-bed19558">
+     <a class="self-link" href="#example-bed19558"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#media-src" id="ref-for-media-src②">media-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>media-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑦">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;audio</span> <span class="na">src=</span><span class="s">"https://example.org/audio"</span><span class="nt">>&lt;/audio></span>
-<span class="nt">&lt;video</span> <span class="na">src=</span><span class="s">"https://example.org/video"</span><span class="nt">></span>
-    <span class="nt">&lt;track</span> <span class="na">kind=</span><span class="s">"subtitles"</span> <span class="na">src=</span><span class="s">"https://example.org/subtitles"</span><span class="nt">></span>
-<span class="nt">&lt;/video></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">audio</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/audio"</span><span class="p">>&lt;/</span><span class="nt">audio</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">video</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/video"</span><span class="p">></span>
+    <span class="p">&lt;</span><span class="nt">track</span> <span class="na">kind</span><span class="o">=</span><span class="s">"subtitles"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/subtitles"</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">video</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
@@ -3574,22 +3582,70 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.9" id="directive-object-src"><span class="secno">6.1.9. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.9" id="directive-prefetch-src"><span class="secno">6.1.9. </span><span class="content"><code>prefetch-src</code></span><a class="self-link" href="#directive-prefetch-src"></a></h4>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="prefetch-src">prefetch-src</dfn> directive restrictes the URLs from which resources may be
+  prefetched or prerendered. The syntax for the directive’s name and value is described by the
+  following ABNF:</p>
+<pre>directive-name  = "prefetch-src"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑧">serialized-source-list</a>
+</pre>
+    <div class="example" id="example-debaa663">
+     <a class="self-link" href="#example-debaa663"></a> Given a page with the following Content Security Policy: 
+<pre>Content-Security-Policy: <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src②">prefetch-src</a> https://example.com/
+</pre>
+     <p>Fetches for the following code will return network errors, as the URLs provided does not match <code>prefetch-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prefetch"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prerender"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
+</pre>
+    </div>
+    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator③">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator④">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
+  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.10" id="directive-object-src"><span class="secno">6.1.10. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="object-src">object-src</dfn> directive restricts the URLs from which plugin
   content may be loaded. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "object-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑧">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑨">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-942e3a4c">
-     <a class="self-link" href="#example-942e3a4c"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-b2f34a63">
+     <a class="self-link" href="#example-b2f34a63"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#object-src" id="ref-for-object-src③">object-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
-    provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;embed</span> <span class="na">src=</span><span class="s">"https://example.org/flash"</span><span class="nt">>&lt;/embed></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.org/flash"</span><span class="nt">>&lt;/object></span>
-<span class="nt">&lt;applet</span> <span class="na">archive=</span><span class="s">"https://example.org/flash"</span><span class="nt">>&lt;/applet></span>
+    provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">embed</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">embed</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">applet</span> <span class="na">archive</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">applet</span><span class="p">></span>
 </pre>
     </div>
     <p>If plugin content is loaded without an associated URL (perhaps an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element①">object</a></code> element lacks a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data" id="ref-for-attr-object-data">data</a></code> attribute, but loads some default plugin based
@@ -3602,15 +3658,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
   sometimes-interesting security model presented by Flash and others), this could mitigate the risk
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
-    <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.9.1" id="object-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3618,15 +3674,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑥">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3634,25 +3690,25 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑦">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.10" id="directive-script-src"><span class="secno">6.1.10. </span><span class="content"><code>script-src</code></span><a class="self-link" href="#directive-script-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.11" id="directive-script-src"><span class="secno">6.1.11. </span><span class="content"><code>script-src</code></span><a class="self-link" href="#directive-script-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src">script-src</dfn> directive restricts the locations from which scripts
   may be executed. This includes not only URLs loaded directly into <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script③">script</a></code> elements, but also things like inline script blocks and XSLT stylesheets <a data-link-type="biblio" href="#biblio-xslt">[XSLT]</a> which can trigger script execution. The syntax for the directive’s
   name and value is described by the following ABNF:</p>
 <pre>directive-name  = "script-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑨">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⓪">serialized-source-list</a>
 </pre>
     <p>The <code>script-src</code> directive governs five things:</p>
     <ol>
      <li data-md="">
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
      <li data-md="">
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script④">script</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. Their
@@ -3678,9 +3734,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Navigation to <code>javascript:</code> URLs MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. These navigations
   will only execute script if every policy allows inline script, as per #3 above.</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.10.1" id="script-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3690,11 +3746,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
         <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source expressions</a> in
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
        <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
@@ -3710,7 +3766,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md="">
-            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> does not
+            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -3724,7 +3780,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   this directive. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
+        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>:</p>
         <ol>
@@ -3735,15 +3791,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.10.2" id="script-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
@@ -3753,20 +3809,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> contains
+        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.10.3" id="script-src-inline"><span class="secno">6.1.10.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
     <ol>
@@ -3776,7 +3832,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, <var>type</var>,
+        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3785,7 +3841,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>Let <var>unsafe-inline flag</var> be <code>false</code>.</p>
        <li data-md="">
-        <p>For each <var>expression</var> in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a>:</p>
+        <p>For each <var>expression</var> in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>:</p>
         <ol>
          <li data-md="">
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤"><code>hash-source</code></a> grammar, return "<code>Blocked</code>".</p>
@@ -3803,17 +3859,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.11" id="directive-style-src"><span class="secno">6.1.11. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⓪">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3825,7 +3881,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
@@ -3849,9 +3905,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.11.1" id="style-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3860,18 +3916,18 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.11.2" id="style-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3880,16 +3936,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.11.3" id="style-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
     <ol>
@@ -3897,7 +3953,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>type</var> is "<code>style</code>" or "<code>style attribute</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a>, <var>type</var>,
+        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3907,29 +3963,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-eba1ebc1"><a class="self-link" href="#issue-eba1ebc1"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-worker-src"><span class="secno">6.1.12. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-04ba5239">
-     <a class="self-link" href="#example-04ba5239"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-3567d8b2">
+     <a class="self-link" href="#example-3567d8b2"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③">worker-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
-    provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
-<pre class="highlight"><span class="nt">&lt;script></span>
+    provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
   blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
   navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://example.org/sw.js'</span><span class="p">);</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.12.1" id="worker-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3938,15 +3994,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol start="4">
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.12.2" id="worker-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3955,7 +4011,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3969,7 +4025,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -3984,7 +4040,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
@@ -4027,32 +4083,32 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
      <li data-md="">
       <p>The fetched resource does not match the declared type.</p>
     </ol>
-    <div class="example" id="example-b40ed0be">
-     <a class="self-link" href="#example-b40ed0be"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-81bbed59">
+     <a class="self-link" href="#example-81bbed59"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types">plugin-types</a> application/pdf
 </pre>
      <p>Fetches for the following code will all return network errors:</p>
 <pre class="highlight"><span class="c">&lt;!-- No 'type' declaration --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span><span class="nt">>&lt;/object></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 
 <span class="c">&lt;!-- Non-matching 'type' declaration --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">>&lt;/object></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 
 <span class="c">&lt;!-- Non-matching resource --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/pdf"</span><span class="nt">>&lt;/object></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/pdf"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 </pre>
      <p>If the page allowed Flash content by sending the following header:</p>
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types①">plugin-types</a> application/x-shockwave-flash
 </pre>
      <p>Then the second item above would load successfully:</p>
 <pre class="highlight"><span class="c">&lt;!-- Matching 'type' declaration and resource --></span>
-<span class="nt">&lt;object</span> <span class="na">data=</span><span class="s">"https://example.com/flash"</span> <span class="na">type=</span><span class="s">"application/x-shockwave-flash"</span><span class="nt">>&lt;/object></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4065,7 +4121,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4095,7 +4151,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4118,7 +4174,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4131,7 +4187,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4145,7 +4201,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4154,7 +4210,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4177,7 +4233,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4185,17 +4241,17 @@ directive-value = ""
       <p>If <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context" id="ref-for-responsible-browsing-context">responsible browsing context</a> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing
   context</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#disowned-its-opener" id="ref-for-disowned-its-opener①">disown its opener</a>.</p>
     </ol>
-    <p class="issue" id="issue-466edd09"><a class="self-link" href="#issue-466edd09"></a> What should this do in an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>? Anything?</p>
+    <p class="issue" id="issue-7782dc5e"><a class="self-link" href="#issue-7782dc5e"></a> What should this do in an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>? Anything?</p>
     <h3 class="heading settled" data-level="6.3" id="directives-navigation"><span class="secno">6.3. </span><span class="content"> Navigation Directives </span><a class="self-link" href="#directives-navigation"></a></h3>
     <h4 class="heading settled" data-level="6.3.1" id="directive-form-action"><span class="secno">6.3.1. </span><span class="content"><code>form-action</code></span><a class="self-link" href="#directive-form-action"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="form-action">form-action</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑥">URL</a></code>s which can be used
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a string (<var>type</var>, "<code>form-submission</code> or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string (<var>type</var>, "<code>form-submission</code> or
   "<code>other</code>") and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), this
   algorithm returns "<code>Blocked</code>" if one or more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive delivered with the response, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
@@ -4206,7 +4262,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4222,14 +4278,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
-    <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source
+    <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>navigation response</var>)
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>)
   and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
   returns "<code>Blocked</code>" if one or more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive delivered with the response, and "<code>Allowed</code>"
   otherwise. This constitutes the <code>frame-ancestors</code>' directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation
@@ -4253,7 +4309,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4265,14 +4321,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-db2876b7"><a class="self-link" href="#issue-db2876b7"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <section class="wip">
      <h4 class="heading settled" data-level="6.3.3" id="directive-navigation-to"><span class="secno">6.3.3. </span><span class="content"><code>navigation-to</code></span><a class="self-link" href="#directive-navigation-to"></a></h4>
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigation-to">navigation-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
     a document can navigate by any means (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code>, <code>window.location</code>, <code>window.open</code>, etc.). The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigation-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
 </pre>
      <p class="issue" id="issue-86f8d392"><a class="self-link" href="#issue-86f8d392"></a> Should we use <code>ancestor-source-list</code> (basically, origins as opposed to
     paths?) It doesn’t appear that blocking navigation targets is any worse than
@@ -4280,7 +4336,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     behavior, this devolves to an origin check in the presence of a malicious
     party anyway...</p>
      <h5 class="heading settled algorithm" data-algorithm="navigation-to Pre-Navigation Check" data-level="6.3.3.1" id="navigation-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigation-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigation-to-pre-navigate"></a></h5>
-     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string (<var>type</var>, "<code>form-submission</code> or
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string (<var>type</var>, "<code>form-submission</code> or
     "<code>other</code>") and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing contexts</a> (<var>source</var> and <var>target</var>), this
     algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigation-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigation-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
      <ol class="algorithm">
@@ -4289,7 +4345,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   Likewise, <var>type</var> is unused, as all navigation requests are treated
   identically.</p>
       <li data-md="">
-       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> is
+       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       <li data-md="">
        <p>Return "<code>Allowed</code>".</p>
@@ -4339,13 +4395,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
     <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4355,7 +4411,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
@@ -4363,7 +4419,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.1.2" id="match-nonce-to-source-list"><span class="secno">6.6.1.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4382,17 +4438,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.1.3" id="match-request-to-source-list"><span class="secno">6.6.1.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.1.4" id="match-response-to-source-list"><span class="secno">6.6.1.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.1.5" id="match-url-to-source-list"><span class="secno">6.6.1.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4630,8 +4686,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
     <ol>
      <li data-md="">
       <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑥">destination</a>, and execute
@@ -4641,7 +4697,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator③">initiator</a> is
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator⑤">initiator</a> is
   the empty string, return <code>connect-src</code>.</p>
         </ol>
        <dt data-md="">"<code>manifest</code>"
@@ -4656,6 +4712,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <ol>
          <li data-md="">
           <p>Return <code>object-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>prefetch</code>"
+       <dt data-md="">"<code>prerender</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>prefetch-src</code>.</p>
         </ol>
        <dt data-md="">"<code>document</code>"
        <dd data-md="">
@@ -4736,7 +4799,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Nonceable</code>".</p>
     </ol>
-    <p class="issue" id="issue-c41e2850"><a class="self-link" href="#issue-c41e2850"></a> This processing is meant to mitigate the risk
+    <p class="issue" id="issue-f811e9ff"><a class="self-link" href="#issue-f811e9ff"></a> This processing is meant to mitigate the risk
   of dangling markup attacks that steal the nonce from an existing element
   in order to load injected script. It is fairly expensive, however, as it
   requires that we walk through all attributes and their values in order to
@@ -4745,9 +4808,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
     <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.2.2" id="allow-all-inline"><span class="secno">6.6.2.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
-    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③"><code>'unsafe-inline'</code></a>, and does not override that
+    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
-    <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
+    <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
   algorithm returns "<code>Allows</code>" if all inline content of a given <var>type</var> is
   allowed and "<code>Does Not Allow</code>" otherwise.</p>
     <ol>
@@ -4770,17 +4833,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>If <var>allow all inline</var> is <code>true</code>, return "<code>Allows</code>".
   Otherwise, return "<code>Does Not Allow</code>".</p>
     </ol>
-    <div class="example" id="example-da6a7e8f">
-     <a class="self-link" href="#example-da6a7e8f"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
+    <div class="example" id="example-8c103cdb">
+     <a class="self-link" href="#example-8c103cdb"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
 <pre>'unsafe-inline' http://a.com http://b.com
 'unsafe-inline'
 </pre>
-     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior①">allow all inline behavior</a> due to
+     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑨">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior①">allow all inline behavior</a> due to
     the presence of nonces and/or hashes, or absence of '<code>unsafe-inline</code>':</p>
 <pre>'sha512-321cba' 'nonce-abc'
 http://example.com 'unsafe-inline' 'nonce-abc'
 </pre>
-     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑨">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior②">allow all inline behavior</a> when <var>type</var> is
+     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②⓪">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior②">allow all inline behavior</a> when <var>type</var> is
      '<code>script</code>' or '<code>script attribute</code>' due to the presence of
      '<code>strict-dynamic</code>', but <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior③">allow all inline behavior</a> otherwise:</p>
 <pre>'unsafe-inline' 'strict-dynamic'
@@ -4788,7 +4851,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.2.3" id="match-element-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②⓪">source list</a> (<var>list</var>), a string
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <ol>
@@ -4808,7 +4871,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
         <ol>
          <li data-md="">
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧"><code>nonce-source</code></a> grammar,
-  and <var>element</var> has a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce" id="ref-for-dom-noncedelement-nonce">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
+  and <var>element</var> has a <code class="idl"><a data-link-type="idl">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑨">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element②">style</a></code>, not to
@@ -4871,7 +4934,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -4886,13 +4949,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.2" id="security-nonce-stealing"><span class="secno">7.2. </span><span class="content">Nonce Stealing</span><a class="self-link" href="#security-nonce-stealing"></a></h3>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
   example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> element:</p>
-<pre class="highlight"><span class="nt">&lt;p></span>Hello, [INJECTION POINT]<span class="nt">&lt;/p></span>
-<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, [INJECTION POINT]<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>If an attacker injects the string "<code>&lt;script src='https://evil.com/evil.js' </code>",
   then the browser will receive the following:</p>
-<pre class="highlight"><span class="nt">&lt;p></span>Hello, <span class="nt">&lt;script </span><span class="na">src=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="nt">></span>
-<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="nt">&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="p">></span>
+<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①②">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
@@ -4905,11 +4968,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   origin. This, generally, is fine, and desirable from the developer’s perspective. However, if an
   attacker can inject a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element③">base</a></code> element, then an otherwise safe page can be subverted when relative
   URLs are resolved. That is, on <code>https://example.com/</code> the following code will load <code>https://example.com/good.js</code>:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>However, the following will load <code>https://evil.com/good.js</code>:</p>
-<pre class="highlight"><span class="nt">&lt;base</span> <span class="na">href=</span><span class="s">"https://evil.com"</span><span class="nt">></span>
-<span class="nt">&lt;script </span><span class="na">nonce=</span><span class="s">abc</span> <span class="na">src=</span><span class="s">/good.js</span><span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">base</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://evil.com"</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
@@ -4969,7 +5032,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-7a5b0df0">
      <a class="self-link" href="#example-7a5b0df0"></a> If this would not happen a page could execute inline scripts even without <code>unsafe-inline</code> in the page’s execution context by simply embedding a <code>srcdoc</code> <code>iframe</code>. 
-<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">srcdoc=</span><span class="s">"&lt;script>alert(1);&lt;/script>"</span><span class="nt">>&lt;/iframe></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">"&lt;script>alert(1);&lt;/script>"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 </pre>
     </div>
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
@@ -4980,10 +5043,10 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
     iframe will load (assuming the main page policy does not block it) since the
     policy inserted in the iframe will not affect it. 
-<pre class="highlight"><span class="nt">&lt;iframe</span> <span class="na">srcdoc=</span><span class="s">'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></span>
-<span class="s">                   &lt;img src="not-example.com/image">'</span><span class="nt">>&lt;/iframe></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></span>
+<span class="s">                   &lt;img src="not-example.com/image">'</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 
-<span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"not-example.com/image"</span><span class="nt">></span>
+<span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"not-example.com/image"</span><span class="p">></span>
 </pre>
     </div>
    </section>
@@ -5030,7 +5093,7 @@ Content-Security-Policy: connect-src http://example.com/;
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑦"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑨">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①⓪">nonce-source</a> expressions
   will be honored.</p>
@@ -5043,17 +5106,17 @@ Content-Security-Policy: connect-src http://example.com/;
     <p>The second allows scripts which are given access to the page via nonces or
   hashes to bring in their dependencies without adding them explicitly to the
   page’s policy.</p>
-    <div class="example" id="example-e30022c4">
-     <a class="self-link" href="#example-e30022c4"></a> Suppose MegaCorp, Inc. deploys the following policy: 
+    <div class="example" id="example-f17d31c2">
+     <a class="self-link" href="#example-f17d31c2"></a> Suppose MegaCorp, Inc. deploys the following policy: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑧">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
-<span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="nt">>&lt;/script></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce</span><span class="o">=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
-    will not be blocked because of the matching <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce" id="ref-for-dom-noncedelement-nonce①">nonce</a></code> attribute.</p>
+    will not be blocked because of the matching <code class="idl"><a data-link-type="idl">nonce</a></code> attribute.</p>
      <p>If <code>script.js</code> contains the following code:</p>
 <pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> document<span class="p">.</span>createElement<span class="p">(</span><span class="s1">'script'</span><span class="p">);</span>
 s<span class="p">.</span>src <span class="o">=</span> <span class="s1">'https://othercdn.not-example.net/dependency.js'</span><span class="p">;</span>
@@ -5075,10 +5138,10 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashed-attributes" id="ref-for-grammardef-unsafe-hashed-attributes②"><code>'unsafe-hashed-attributes'</code></a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.</p>
-     <div class="example" id="example-58b9ab8c">
-      <a class="self-link" href="#example-58b9ab8c"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
+     <div class="example" id="example-86e7f347">
+      <a class="self-link" href="#example-86e7f347"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
       resembling a reasonable schedule: 
-<pre class="highlight"><span class="nt">&lt;button</span> <span class="na">id=</span><span class="s">"action"</span> <span class="na">onclick=</span><span class="s">"doSubmit()"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashed-attributes'</code>" along with a hash source expression, as follows:</p>
@@ -5100,8 +5163,8 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
     the scope to enable externalized JavaScript as well.</p>
      <p>If multiple sets of integrity metadata are specified for a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑦">script</a></code>, the
     request will match a policy’s <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source①⓪">hash-source</a>s if and only if <em>each</em> item in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑧">script</a></code>'s integrity metadata matches the policy.</p>
-     <div class="example" id="example-7bc6634d">
-      <a class="self-link" href="#example-7bc6634d"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
+     <div class="example" id="example-20c337e7">
+      <a class="self-link" href="#example-20c337e7"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
       that ensures that the content matches their expectations. They do so by
       setting the following policy: 
 <pre>Content-Security-Policy: script-src 'sha256-abc123' 'sha512-321cba'
@@ -5109,16 +5172,16 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑨">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
       <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script②⓪">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
       <p>Metadata that is not recognized (either because it’s entirely invalid, or
       because it specifies a not-yet-supported hashing algorithm) does not affect
@@ -5126,9 +5189,9 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       allowed to execute in the presence of the above policy, as the additional
       metadata is invalid and therefore wouldn’t allow a script whose content
       wasn’t listed explicitly in the policy to execute:</p>
-<pre class="highlight"><span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="nt">>&lt;/script></span>
-<span class="nt">&lt;script </span><span class="na">integrity=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="nt">>&lt;/script></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
      </div>
     </section>
@@ -5136,7 +5199,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5191,7 +5254,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>This document (see <a href="#directive-media-src">§6.1.8 media-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-object-src">§6.1.9 object-src</a>)</p>
+      <p>This document (see <a href="#directive-object-src">§6.1.10 object-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-plugin-types">§6.2.2 plugin-types</a>)</p>
@@ -5206,13 +5269,13 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-script-src">§6.1.10 script-src</a>)</p>
+      <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.11 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src④"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.12 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5394,7 +5457,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#navigation-to">navigation-to</a><span>, in §6.3.3</span>
    <li><a href="#grammardef-nonce-source">nonce-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-none">'none'</a><span>, in §2.3.1</span>
-   <li><a href="#object-src">object-src</a><span>, in §6.1.9</span>
+   <li><a href="#object-src">object-src</a><span>, in §6.1.10</span>
    <li>
     originalPolicy
     <ul>
@@ -5416,6 +5479,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-port-part">port-part</a><span>, in §2.3.1</span>
    <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.1.9</span>
    <li><a href="#directive-post-request-check">post-request check</a><span>, in §2.3</span>
+   <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.9</span>
    <li><a href="#directive-pre-navigation-check">pre-navigation check</a><span>, in §2.3</span>
    <li><a href="#directive-pre-request-check">pre-request check</a><span>, in §2.3</span>
    <li>
@@ -5443,7 +5507,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-scheme-part">scheme-part</a><span>, in §2.3.1</span>
    <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.1.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
-   <li><a href="#script-src">script-src</a><span>, in §6.1.10</span>
+   <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5478,7 +5542,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.11</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashed-attributes">'unsafe-hashed-attributes'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-inline">'unsafe-inline'</a><span>, in §2.3.1</span>
@@ -5492,7 +5556,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.12</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -5622,7 +5686,6 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through">nested through</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce">nonce</a>
      <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">opener browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origin</a>
@@ -5837,7 +5900,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 26 October 2017. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 29 November 2017. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -5910,7 +5973,7 @@ rest of Google’s CSP Cabal.</p>
    <div class="issue"> <code>disown-opener</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/194">&lt;https://github.com/w3c/webappsec-csp/issues/194></a><a href="#issue-0915ad11"> ↵ </a></div>
    <div class="issue"> <code>navigation-to</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/125">&lt;https://github.com/w3c/webappsec-csp/issues/125></a><a href="#issue-a305d3f5"> ↵ </a></div>
    <div class="issue"> Is this kind of thing specified anywhere? I didn’t see anything
-  that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-c404edb5"> ↵ </a></div>
+  that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-de937cf3"> ↵ </a></div>
    <div class="issue"> How, exactly, do we get the status code? We don’t actually store it
   anywhere.<a href="#issue-99576800"> ↵ </a></div>
    <div class="issue"> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a><a href="#issue-a794766b"> ↵ </a></div>
@@ -5923,7 +5986,7 @@ rest of Google’s CSP Cabal.</p>
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a><a href="#issue-7b0f92da"> ↵ </a></div>
    <div class="issue"> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
-  to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-910d1dca"> ↵ </a></div>
+  to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-c0b6be8f"> ↵ </a></div>
    <div class="issue"> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a><a href="#issue-ba1a0a35"> ↵ </a></div>
    <div class="issue"> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
@@ -5933,7 +5996,7 @@ rest of Google’s CSP Cabal.</p>
     well, and there might be a cleverer syntax that could encompass both a
     document’s opener, and a document’s openees. <code>disown-openee</code> is weird.
     Maybe <code>disown 'opener' 'openee'</code>? Do we need origin restrictions on either/both?<a href="#issue-55f190c5"> ↵ </a></div>
-   <div class="issue"> What should this do in an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a></code>? Anything?<a href="#issue-466edd09"> ↵ </a></div>
+   <div class="issue"> What should this do in an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a></code>? Anything?<a href="#issue-7782dc5e"> ↵ </a></div>
    <div class="issue"> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a><a href="#issue-db2876b7"> ↵ </a></div>
    <div class="issue"> Should we use <code>ancestor-source-list</code> (basically, origins as opposed to
     paths?) It doesn’t appear that blocking navigation targets is any worse than
@@ -5949,7 +6012,7 @@ rest of Google’s CSP Cabal.</p>
   determine whether the script should execute. Here, we try to minimize the
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
-  we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-c41e2850"> ↵ </a></div>
+  we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-f811e9ff"> ↵ </a></div>
    <div class="issue"> Work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a><a href="#issue-0e25e974"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="content-security-policy-object">
@@ -6008,37 +6071,41 @@ rest of Google’s CSP Cabal.</p>
     media-src Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object④②">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④③">6.1.9. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object④④">6.1.9.1. 
-    object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.9.2. 
-    object-src Post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object④③">6.1.9.1. 
+    prefetch-src Pre-request check </a>
+    <li><a href="#ref-for-content-security-policy-object④④">6.1.9.2. 
+    prefetch-src Post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.10. object-src</a>
     <li><a href="#ref-for-content-security-policy-object④⑥">6.1.10.1. 
-    script-src Pre-request check </a>
+    object-src Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object④⑦">6.1.10.2. 
-    script-src Post-request check </a>
+    object-src Post-request check </a>
     <li><a href="#ref-for-content-security-policy-object④⑧">6.1.11.1. 
-    style-src Pre-request Check </a>
+    script-src Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object④⑨">6.1.11.2. 
-    style-src Post-request Check </a>
+    script-src Post-request check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.12.1. 
-    worker-src Pre-request Check </a>
+    style-src Pre-request Check </a>
     <li><a href="#ref-for-content-security-policy-object⑤①">6.1.12.2. 
+    style-src Post-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.13.1. 
+    worker-src Pre-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤③">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤④">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑥①">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -6191,9 +6258,9 @@ rest of Google’s CSP Cabal.</p>
     default-src Pre-request check </a> <a href="#ref-for-directives①⑧">(2)</a> <a href="#ref-for-directives①⑨">(3)</a> <a href="#ref-for-directives②⓪">(4)</a>
     <li><a href="#ref-for-directives②①">6.1.3.2. 
     default-src Post-request check </a> <a href="#ref-for-directives②②">(2)</a> <a href="#ref-for-directives②③">(3)</a> <a href="#ref-for-directives②④">(4)</a>
-    <li><a href="#ref-for-directives②⑤">6.1.10.1. 
+    <li><a href="#ref-for-directives②⑤">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directives②⑥">6.1.10.2. 
+    <li><a href="#ref-for-directives②⑥">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directives②⑦">6.2.1.1. 
     Is base allowed for document? </a> <a href="#ref-for-directives②⑧">(2)</a>
@@ -6232,9 +6299,9 @@ rest of Google’s CSP Cabal.</p>
     default-src Pre-request check </a> <a href="#ref-for-directive-name①③">(2)</a> <a href="#ref-for-directive-name①④">(3)</a> <a href="#ref-for-directive-name①⑤">(4)</a>
     <li><a href="#ref-for-directive-name①⑥">6.1.3.2. 
     default-src Post-request check </a> <a href="#ref-for-directive-name①⑦">(2)</a> <a href="#ref-for-directive-name①⑧">(3)</a> <a href="#ref-for-directive-name①⑨">(4)</a>
-    <li><a href="#ref-for-directive-name②⓪">6.1.10.1. 
+    <li><a href="#ref-for-directive-name②⓪">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directive-name②①">6.1.10.2. 
+    <li><a href="#ref-for-directive-name②①">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-name②②">6.2.1.1. 
     Is base allowed for document? </a>
@@ -6288,41 +6355,45 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-value②④">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-directive-value②⑤">6.1.9.1. 
-    object-src Pre-request check </a>
+    prefetch-src Pre-request check </a>
     <li><a href="#ref-for-directive-value②⑥">6.1.9.2. 
-    object-src Post-request check </a>
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-directive-value②⑦">6.1.10.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-value②⑧">(2)</a> <a href="#ref-for-directive-value②⑨">(3)</a> <a href="#ref-for-directive-value③⓪">(4)</a> <a href="#ref-for-directive-value③①">(5)</a>
-    <li><a href="#ref-for-directive-value③②">6.1.10.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-value③③">(2)</a> <a href="#ref-for-directive-value③④">(3)</a>
-    <li><a href="#ref-for-directive-value③⑤">6.1.10.3. 
-    script-src Inline Check </a> <a href="#ref-for-directive-value③⑥">(2)</a>
-    <li><a href="#ref-for-directive-value③⑦">6.1.11.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑧">(2)</a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.11.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.11.3. 
+    object-src Pre-request check </a>
+    <li><a href="#ref-for-directive-value②⑧">6.1.10.2. 
+    object-src Post-request check </a>
+    <li><a href="#ref-for-directive-value②⑨">6.1.11.1. 
+    script-src Pre-request check </a> <a href="#ref-for-directive-value③⓪">(2)</a> <a href="#ref-for-directive-value③①">(3)</a> <a href="#ref-for-directive-value③②">(4)</a> <a href="#ref-for-directive-value③③">(5)</a>
+    <li><a href="#ref-for-directive-value③④">6.1.11.2. 
+    script-src Post-request check </a> <a href="#ref-for-directive-value③⑤">(2)</a> <a href="#ref-for-directive-value③⑥">(3)</a>
+    <li><a href="#ref-for-directive-value③⑦">6.1.11.3. 
+    script-src Inline Check </a> <a href="#ref-for-directive-value③⑧">(2)</a>
+    <li><a href="#ref-for-directive-value③⑨">6.1.12.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
+    <li><a href="#ref-for-directive-value④①">6.1.12.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
+    <li><a href="#ref-for-directive-value④③">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value④②">6.1.12.1. 
+    <li><a href="#ref-for-directive-value④④">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④③">6.1.12.2. 
+    <li><a href="#ref-for-directive-value④⑤">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④④">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑥">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑤">6.2.2.1. 
+    <li><a href="#ref-for-directive-value④⑦">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⑧">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.3.1. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value④⑨">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤①">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.3.3.1. 
+    <li><a href="#ref-for-directive-value⑤③">6.3.3.1. 
       navigation-to Pre-Navigation Check </a>
    </ul>
   </aside>
@@ -6372,18 +6443,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①⓪">6.1.8.1. 
     media-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①①">6.1.9.1. 
-    object-src Pre-request check </a>
+    prefetch-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①②">6.1.10.1. 
-    script-src Pre-request check </a>
+    object-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
-    style-src Pre-request Check </a>
+    script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
+    style-src Pre-request Check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.6.1.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.1.3. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.1.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -6412,18 +6485,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①①">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①②">6.1.9.2. 
-    object-src Post-request check </a>
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①③">6.1.10.2. 
-    script-src Post-request check </a>
+    object-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
-    style-src Post-request Check </a>
+    script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
+    style-src Post-request Check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.5. 
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.6.1.4. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6449,9 +6524,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check①">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-inline-check②">6.1.10.3. 
+    <li><a href="#ref-for-directive-inline-check②">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check③">6.1.11.3. 
+    <li><a href="#ref-for-directive-inline-check③">6.1.12.3. 
     style-src Inline Check </a>
    </ul>
   </aside>
@@ -6460,7 +6535,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.11.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -6503,20 +6578,21 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑤">6.1.6. img-src</a>
     <li><a href="#ref-for-source-lists⑥">6.1.7. manifest-src</a>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
-    <li><a href="#ref-for-source-lists⑧">6.1.9. object-src</a>
-    <li><a href="#ref-for-source-lists⑨">6.1.12. worker-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-source-lists①①">6.6.1.2. 
+    <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
+    <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
+    <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-source-lists①②">6.6.1.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-source-lists①②">6.6.1.3. 
+    <li><a href="#ref-for-source-lists①③">6.6.1.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-source-lists①③">6.6.1.4. 
+    <li><a href="#ref-for-source-lists①④">6.6.1.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-source-lists①④">6.6.1.5. 
+    <li><a href="#ref-for-source-lists①⑤">6.6.1.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-source-lists①⑤">6.6.2.2. 
-    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑥">(2)</a> <a href="#ref-for-source-lists①⑦">(3)</a> <a href="#ref-for-source-lists①⑧">(4)</a> <a href="#ref-for-source-lists①⑨">(5)</a>
-    <li><a href="#ref-for-source-lists②⓪">6.6.2.3. 
+    <li><a href="#ref-for-source-lists①⑥">6.6.2.2. 
+    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑦">(2)</a> <a href="#ref-for-source-lists①⑧">(3)</a> <a href="#ref-for-source-lists①⑨">(4)</a> <a href="#ref-for-source-lists②⓪">(5)</a>
+    <li><a href="#ref-for-source-lists②①">6.6.2.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -6527,7 +6603,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-expression①">2.3.1. Source Lists</a>
     <li><a href="#ref-for-source-expression②">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-source-expression③">6.1.10.1. 
+    <li><a href="#ref-for-source-expression③">6.1.11.1. 
     script-src Pre-request check </a> <a href="#ref-for-source-expression④">(2)</a> <a href="#ref-for-source-expression⑤">(3)</a> <a href="#ref-for-source-expression⑥">(4)</a>
     <li><a href="#ref-for-source-expression⑦">6.6.1.6. 
     Does url match expression in origin with redirect count? </a>
@@ -6546,13 +6622,14 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑤">6.1.6. img-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑥">6.1.7. manifest-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑦">6.1.8. media-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. object-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.3. navigation-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigation-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -6641,9 +6718,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-keyword-source">#grammardef-keyword-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-keyword-source">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-keyword-source①">6.1.10.1. 
+    <li><a href="#ref-for-grammardef-keyword-source①">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-keyword-source②">6.1.10.3. 
+    <li><a href="#ref-for-grammardef-keyword-source②">6.1.11.3. 
     script-src Inline Check </a> <a href="#ref-for-grammardef-keyword-source③">(2)</a>
     <li><a href="#ref-for-grammardef-keyword-source④">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-keyword-source⑤">(2)</a> <a href="#ref-for-grammardef-keyword-source⑥">(3)</a>
@@ -6657,9 +6734,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a>
-    <li><a href="#ref-for-grammardef-self②②">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②③">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
+    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -6668,7 +6745,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-inline">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-grammardef-unsafe-inline①">6.1.10.3. 
+    <li><a href="#ref-for-grammardef-unsafe-inline①">6.1.11.3. 
     script-src Inline Check </a> <a href="#ref-for-grammardef-unsafe-inline②">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline③">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
@@ -6687,11 +6764,11 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-strict-dynamic">
    <b><a href="#grammardef-strict-dynamic">#grammardef-strict-dynamic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-strict-dynamic">6.1.10.1. 
+    <li><a href="#ref-for-grammardef-strict-dynamic">6.1.11.1. 
     script-src Pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
-    <li><a href="#ref-for-grammardef-strict-dynamic②">6.1.10.2. 
+    <li><a href="#ref-for-grammardef-strict-dynamic②">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-grammardef-strict-dynamic③">6.1.10.3. 
+    <li><a href="#ref-for-grammardef-strict-dynamic③">6.1.11.3. 
     script-src Inline Check </a> <a href="#ref-for-grammardef-strict-dynamic④">(2)</a>
     <li><a href="#ref-for-grammardef-strict-dynamic⑤">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a>
@@ -6722,10 +6799,10 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-nonce-source">#grammardef-nonce-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
-    <li><a href="#ref-for-grammardef-nonce-source②">6.1.10. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.10.3. 
+    <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-grammardef-nonce-source④">6.1.11. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source④">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.1.2. 
     Does nonce match source list? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.2.1. 
@@ -6743,7 +6820,7 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-base64-value">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-base64-value①">(2)</a> <a href="#ref-for-grammardef-base64-value②">(3)</a> <a href="#ref-for-grammardef-base64-value③">(4)</a>
-    <li><a href="#ref-for-grammardef-base64-value④">6.1.10.1. 
+    <li><a href="#ref-for-grammardef-base64-value④">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-grammardef-base64-value⑤">6.6.1.2. 
     Does nonce match source list? </a>
@@ -6755,12 +6832,12 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-hash-source">#grammardef-hash-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
-    <li><a href="#ref-for-grammardef-hash-source②">6.1.10. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.10.1. 
+    <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.11.1. 
     script-src Pre-request check </a> <a href="#ref-for-grammardef-hash-source④">(2)</a>
-    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.10.3. 
+    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-grammardef-hash-source⑥">6.1.11. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source⑥">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-hash-source⑦">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a>
     <li><a href="#ref-for-grammardef-hash-source⑧">6.6.2.3. 
@@ -6775,7 +6852,7 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-hash-algorithm">#grammardef-hash-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-algorithm">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-hash-algorithm①">6.1.10.1. 
+    <li><a href="#ref-for-grammardef-hash-algorithm①">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-grammardef-hash-algorithm②">6.6.2.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-hash-algorithm③">(2)</a> <a href="#ref-for-grammardef-hash-algorithm④">(3)</a>
@@ -7224,13 +7301,20 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="prefetch-src">
+   <b><a href="#prefetch-src">#prefetch-src</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-prefetch-src">6.1.3. default-src</a> <a href="#ref-for-prefetch-src①">(2)</a>
+    <li><a href="#ref-for-prefetch-src②">6.1.9. prefetch-src</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="object-src">
    <b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">6. 
     Content Security Policy Directives </a>
     <li><a href="#ref-for-object-src①">6.1.3. default-src</a> <a href="#ref-for-object-src②">(2)</a>
-    <li><a href="#ref-for-object-src③">6.1.9. object-src</a>
+    <li><a href="#ref-for-object-src③">6.1.10. object-src</a>
     <li><a href="#ref-for-object-src④">10.1. 
     Directive Registry </a>
    </ul>
@@ -7265,7 +7349,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.1. child-src</a>
     <li><a href="#ref-for-worker-src①">6.1.3. default-src</a> <a href="#ref-for-worker-src②">(2)</a>
-    <li><a href="#ref-for-worker-src③">6.1.12. worker-src</a>
+    <li><a href="#ref-for-worker-src③">6.1.13. worker-src</a>
     <li><a href="#ref-for-worker-src④">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.src.html
+++ b/index.src.html
@@ -2443,7 +2443,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   <h4 id="directive-prefetch-src">`prefetch-src`</h4>
 
   The <dfn export>prefetch-src</dfn> directive restrictes the URLs from which resources may be
-  prefetched. The syntax for the directive's name and value is described by the following ABNF:
+  prefetched or prerendered. The syntax for the directive's name and value is described by the
+  following ABNF:
 
   <pre>
     directive-name  = "prefetch-src"
@@ -2457,11 +2458,12 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       Content-Security-Policy: <a>prefetch-src</a> https://example.com/
     </pre>
 
-    Fetches for the following code will return a network error, as the URL
-    provided does not match `prefetch-src`'s <a>source list</a>:
+    Fetches for the following code will return network errors, as the URLs provided does not match
+    `prefetch-src`'s <a>source list</a>:
 
     <pre highlight="html">
       &lt;link rel="prefetch" src="https://example.org/"&gt;&lt;/link&gt;
+      &lt;link rel="prerender" src="https://example.org/"&gt;&lt;/link&gt;
     </pre>
   </div>
 
@@ -2475,7 +2477,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`":
+  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
 
       1.  If the result of executing [[#match-request-to-source-list]] on |request| and this
           directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
@@ -2493,7 +2495,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`":
+  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
 
       1.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
           and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
@@ -3854,6 +3856,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       ::
         1.  Return `object-src`.
       : "`prefetch`"
+      : "`prerender`"
       ::
         1.  Return `prefetch-src`.
       : "`document`"

--- a/index.src.html
+++ b/index.src.html
@@ -3853,6 +3853,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       : "`embed`"
       ::
         1.  Return `object-src`.
+      : "`prefetch`"
+      ::
+        1.  Return `prefetch-src`.
       : "`document`"
       ::
         1.  If the |request|'s <a for="request">target browsing context</a>

--- a/index.src.html
+++ b/index.src.html
@@ -2002,6 +2002,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>img-src</a> <a grammar>'self'</a>;
                                <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
+                               <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> <a grammar>'self'</a>;
                                <a>style-src</a> <a grammar>'self'</a>;
@@ -2029,6 +2030,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>img-src</a> <a grammar>'self'</a>;
                                <a>manifest-src</a> <a grammar>'self'</a>;
                                <a>media-src</a> <a grammar>'self'</a>;
+                               <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src</a> https://example.com;
                                <a>style-src</a> <a grammar>'self'</a>;
@@ -2437,6 +2439,70 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
           "`Blocked`".
 
   3.  Return "`Allowed`".
+
+  <h4 id="directive-prefetch-src">`prefetch-src`</h4>
+
+  The <dfn export>prefetch-src</dfn> directive restrictes the URLs from which resources may be
+  prefetched. The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "prefetch-src"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  <div class="example">
+    Given a page with the following Content Security Policy:
+
+    <pre>
+      Content-Security-Policy: <a>prefetch-src</a> https://example.com/
+    </pre>
+
+    Fetches for the following code will return a network error, as the URL
+    provided does not match `prefetch-src`'s <a>source list</a>:
+
+    <pre highlight="html">
+      &lt;link rel="prefetch" src="https://example.org/"&gt;&lt;/link&gt;
+    </pre>
+  </div>
+
+  <h5 algorithm id="prefetch-src-pre-request">
+    `prefetch-src` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Assert: |policy| is unused.
+
+  2.  If |request|'s <a for="request">destination</a> is "`prefetch`":
+
+      1.  If the result of executing [[#match-request-to-source-list]] on
+          |request| and this directive's <a for="directive">value</a> is
+          "`Does Not Match`", return "`Blocked`".
+
+  3.  Return "`Allowed`".
+
+  <h5 algorithm id="prefetch-src-post-request">
+    `prefetch-src` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Assert: |policy| is unused.
+
+  2.  If |request|'s <a for="request">destination</a> is "`prefetch`":
+
+      1.  If the result of executing [[#match-response-to-source-list]] on
+          |response|, |request|, and this directive's
+          <a for="directive">value</a> is "`Does Not Match`", return
+          "`Blocked`".
+
+  3.  Return "`Allowed`".
+
 
   <h4 id="directive-object-src">`object-src`</h4>
 

--- a/index.src.html
+++ b/index.src.html
@@ -2475,11 +2475,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">destination</a> is "`prefetch`":
+  2.  If |request|'s [=request/initiator=] is "`prefetch`":
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+      1.  If the result of executing [[#match-request-to-source-list]] on |request| and this
+          directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
   3.  Return "`Allowed`".
 
@@ -2494,12 +2493,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Assert: |policy| is unused.
 
-  2.  If |request|'s <a for="request">destination</a> is "`prefetch`":
+  2.  If |request|'s [=request/initiator=] is "`prefetch`":
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+      1.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
+          and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
   3.  Return "`Allowed`".
 


### PR DESCRIPTION
@yoavweiss, @annevk, @andypaicu: WDYT?

/cc @dveditz, @ckerschb


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/283.html" title="Last updated on Jan 15, 2018, 2:18 PM GMT (78ac5e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/283/7a4577c...78ac5e8.html" title="Last updated on Jan 15, 2018, 2:18 PM GMT (78ac5e8)">Diff</a>