### PR TITLE
Introduce 'webrtc-src'.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version d1c8ac9ac0bb0f0e970e3942633cfb7d2f7e12e6" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="b0420ce3f1f6ccb255595818144a4f83b9f03d61" name="document-revision">
+  <meta content="32d3db13eee93f09c2e5a15c7c613cde9b8d92df" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-15">15 January 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-17">17 January 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1586,9 +1586,14 @@ of security-relevant policy decisions.</p>
         <li><a href="#should-block-navigation-response"><span class="secno">4.2.6</span> <span class="content"> Should <var>navigation response</var> to <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked by Content Security Policy? </span></a>
        </ol>
       <li>
-       <a href="#ecma-integration"><span class="secno">4.3</span> <span class="content">Integration with ECMAScript</span></a>
+       <a href="#webrtc-integration"><span class="secno">4.3</span> <span class="content">Integration with WebRTC</span></a>
        <ol class="toc">
-        <li><a href="#can-compile-strings"><span class="secno">4.3.1</span> <span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span></a>
+        <li><a href="#should-block-rtc-connection"><span class="secno">4.3.1</span> <span class="content"> Should an RTC connection to (<var>host</var>,<var>port</var>) be blocked for <var>global</var>? </span></a>
+       </ol>
+      <li>
+       <a href="#ecma-integration"><span class="secno">4.4</span> <span class="content">Integration with ECMAScript</span></a>
+       <ol class="toc">
+        <li><a href="#can-compile-strings"><span class="secno">4.4.1</span> <span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span></a>
        </ol>
      </ol>
     <li>
@@ -1615,12 +1620,14 @@ of security-relevant policy decisions.</p>
          <ol class="toc">
           <li><a href="#connect-src-pre-request"><span class="secno">6.1.2.1</span> <span class="content"> <code>connect-src</code> Pre-request check </span></a>
           <li><a href="#connect-src-post-request"><span class="secno">6.1.2.2</span> <span class="content"> <code>connect-src</code> Post-request check </span></a>
+          <li><a href="#connect-src-pre-connect"><span class="secno">6.1.2.3</span> <span class="content"> <code>connect-src</code> Preconnect Check </span></a>
          </ol>
         <li>
          <a href="#directive-default-src"><span class="secno">6.1.3</span> <span class="content"><code>default-src</code></span></a>
          <ol class="toc">
           <li><a href="#default-src-pre-request"><span class="secno">6.1.3.1</span> <span class="content"> <code>default-src</code> Pre-request check </span></a>
           <li><a href="#default-src-post-request"><span class="secno">6.1.3.2</span> <span class="content"> <code>default-src</code> Post-request check </span></a>
+          <li><a href="#default-src-pre-connect"><span class="secno">6.1.3.3</span> <span class="content"> <code>default-src</code> Preconnect Check </span></a>
          </ol>
         <li>
          <a href="#directive-font-src"><span class="secno">6.1.4</span> <span class="content"><code>font-src</code></span></a>
@@ -1679,10 +1686,15 @@ of security-relevant policy decisions.</p>
           <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
+         <a href="#directive-webrtc-src"><span class="secno">6.1.13</span> <span class="content"><code>webrtc-src</code></span></a>
          <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#webrtc-src-pre-connect"><span class="secno">6.1.13.1</span> <span class="content"> <code>webrtc-src</code> Preconnect Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-worker-src"><span class="secno">6.1.14</span> <span class="content"><code>worker-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -2066,7 +2078,7 @@ of security-relevant policy decisions.</p>
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
-  type string, and a soure string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
+  type string, and a source string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
@@ -2081,6 +2093,10 @@ of security-relevant policy decisions.</p>
   arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>.
   It returns "<code>Allowed</code>" unless otherwise specified.</p>
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-connect-check">pre-connect check</dfn>, which takes a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-host" id="ref-for-concept-host">host</a>, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a>, and
+  an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a>, and is executed during <a href="#should-block-rtc-connection">§4.3.1 Should an RTC connection to (host,port) be blocked for global?</a>. It returns "<code>Allowed</code>"
+  unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
     <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
@@ -2153,9 +2169,9 @@ of security-relevant policy decisions.</p>
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
-  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
+  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
-  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> has been violated.</p>
+  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
@@ -2165,8 +2181,8 @@ of security-relevant policy decisions.</p>
   which violated the policy.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> that has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
   enforcement caused the violation.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
@@ -2182,7 +2198,7 @@ of security-relevant policy decisions.</p>
   characters of an inline script, event handler, or style that caused an violation. Violations
   which stem from an external file will not include a sample in the violation report.</p>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
+    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
      <li data-md="">
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
@@ -2208,7 +2224,7 @@ of security-relevant policy decisions.</p>
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, policy, and directive" data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> (<var>policy</var>), and a string
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> (<var>policy</var>), and a string
   (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
@@ -2224,10 +2240,10 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="policy-delivery"><span class="secno">3. </span><span class="content"> Policy Delivery </span><a class="self-link" href="#policy-delivery"></a></h2>
-    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
+    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
   representation</a> via an HTTP response header field whose value is a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp③">serialized CSP</a>. This mechanism is defined in detail in <a href="#csp-header">§3.1 The Content-Security-Policy HTTP Response Header Field</a> and <a href="#cspro-header">§3.2 The Content-Security-Policy-Report-Only HTTP Response Header Field</a>, and the integration with Fetch
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
@@ -2318,7 +2334,7 @@ of security-relevant policy decisions.</p>
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
   user agent needs to <a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#parse-serialized-policy" id="ref-for-parse-serialized-policy②">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
@@ -2449,18 +2465,18 @@ of security-relevant policy decisions.</p>
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
      <li data-md="">
-      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> objects which are
+      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md="">
       <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑥">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a> as the <code>object</code>.</p>
      <li data-md="">
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
      <li data-md="">
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithms in order to
-  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
+  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
      <li data-md="">
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
@@ -2469,7 +2485,7 @@ of security-relevant policy decisions.</p>
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
+      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
      <li data-md="">
       <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
      <li data-md="">
@@ -2526,7 +2542,7 @@ of security-relevant policy decisions.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> by embedding a frame or popping up a new window containing content it
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
@@ -2703,7 +2719,7 @@ of security-relevant policy decisions.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?" data-level="4.2.6" id="should-block-navigation-response"><span class="secno">4.2.6. </span><span class="content"> Should <var>navigation response</var> to <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-navigation-response"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①④">request</a> (<var>navigation request</var>),, a string (<var>type</var>, either
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①④">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
   "<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑥">response</a> <var>navigation
   response</var>, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
   returns "<code>Blocked</code>" if the active policy blocks the navigation, and "<code>Allowed</code>"
@@ -2736,12 +2752,52 @@ of security-relevant policy decisions.</p>
      <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
-    <h3 class="heading settled" data-level="4.3" id="ecma-integration"><span class="secno">4.3. </span><span class="content">Integration with ECMAScript</span><a class="self-link" href="#ecma-integration"></a></h3>
+    <h3 class="heading settled" data-level="4.3" id="webrtc-integration"><span class="secno">4.3. </span><span class="content">Integration with WebRTC</span><a class="self-link" href="#webrtc-integration"></a></h3>
+    <p>Mostly TODO. The general idea is that WebRTC should call into <a href="#should-block-rtc-connection">§4.3.1 Should an RTC connection to (host,port) be blocked for global?</a>,
+  passing in enough detail for CSP to return a "<code>Blocked</code>"/"<code>Allowed</code>" decision, and react
+  accordingly.</p>
+    <h4 class="heading settled" data-level="4.3.1" id="should-block-rtc-connection"><span class="secno">4.3.1. </span><span class="content"> Should an RTC connection to (<var>host</var>,<var>port</var>) be blocked for <var>global</var>? </span><a class="self-link" href="#should-block-rtc-connection"></a></h4>
+    <p>Given a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-host" id="ref-for-concept-host①">host</a> (<var>host</var>), a port (<var>port</var>), and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a> (<var>global</var>), this algorithm returns "<code>Blocked</code>"
+  if the active policy for <var>global</var> blocks a connection to <var>host</var>, and "<code>Allowed</code>" otherwise:</p>
+    <ol class="algorithm">
+     <li data-md="">
+      <p>Let <var>result</var> be "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>Let <var>directive</var> be <code>null</code>.</p>
+       <li data-md="">
+        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a> is "<code>webrtc-src</code>", then
+  set <var>directive</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>.</p>
+        <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a> is
+  "<code>connect-src</code>", then set <var>directive</var> to that directive.</p>
+        <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is
+  "<code>default-src</code>", then set <var>directive</var> to that directive.</p>
+       <li data-md="">
+        <p>If <var>directive</var> is not <code>null</code>, and the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-connect-check" id="ref-for-directive-pre-connect-check">pre-connect check</a> on <var>host</var>, <var>policy</var>, and <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> is
+  "<code>Blocked</code>":</p>
+        <ol>
+         <li data-md="">
+          <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>global</var>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a>.</p>
+         <li data-md="">
+          <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>host</var>.</p>
+         <li data-md="">
+          <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
+         <li data-md="">
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then
+  set <var>result</var> to "<code>Blocked</code>".</p>
+        </ol>
+      </ol>
+     <li data-md="">
+      <p>Return <var>result</var>.</p>
+    </ol>
+    <h3 class="heading settled" data-level="4.4" id="ecma-integration"><span class="secno">4.4. </span><span class="content">Integration with ECMAScript</span><a class="self-link" href="#ecma-integration"></a></h3>
     <p>ECMAScript defines a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> abstract operation
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
-  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a> to determine whether such compilation ought to be blocked.</p>
-    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport="" id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
+  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a> to determine whether such compilation ought to be blocked.</p>
+    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.4.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport="" id="can-compile-strings"><span class="secno">4.4.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm" id="ref-for-realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a string (<var>source</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>" if not:</p>
     <ol>
@@ -2753,14 +2809,14 @@ of security-relevant policy decisions.</p>
        <li data-md="">
         <p>Let <var>result</var> be "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a>:</p>
+        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">CSP list</a>:</p>
         <ol>
          <li data-md="">
           <p>Let <var>source-list</var> be <code>null</code>.</p>
          <li data-md="">
-          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a> is "<code>script-src</code>", then
-  set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
-          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a> is
+          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is "<code>script-src</code>", then
+  set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
+          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is
   "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
          <li data-md="">
           <p>If <var>source-list</var> is non-<code>null</code>, and does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression②">source expression</a> which is
@@ -2770,7 +2826,7 @@ of security-relevant policy decisions.</p>
            <li data-md="">
             <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>global</var>, <var>policy</var>, and "<code>script-src</code>".</p>
            <li data-md="">
-            <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to "<code>inline</code>".</p>
+            <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑦">resource</a> to "<code>inline</code>".</p>
            <li data-md="">
             <p>If <var>source-list</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contains</a> the expression
   "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample②"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample③">sample</a> to
@@ -2778,7 +2834,7 @@ of security-relevant policy decisions.</p>
            <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md="">
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
   "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2792,9 +2848,9 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></dfn> {
   <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;enforce&quot;|enforce" id="dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;report&quot;|report" id="dom-securitypolicyviolationeventdisposition-report"><code>"report"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -2848,7 +2904,7 @@ of security-relevant policy decisions.</p>
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer①">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer①">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
        <dt data-md="">"<code>blocked-uri</code>"
        <dd data-md="">
-        <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer②">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑦">resource</a>, with the <code>exclude fragment</code> flag set.</p>
+        <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer②">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑧">resource</a>, with the <code>exclude fragment</code> flag set.</p>
        <dt data-md="">"<code>effective-directive</code>"
        <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive①">effective directive</a></p>
@@ -2860,7 +2916,7 @@ of security-relevant policy decisions.</p>
         <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑦">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy①">policy</a></p>
        <dt data-md="">"<code>disposition</code>"
        <dd data-md="">
-        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
+        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
        <dt data-md="">"<code>status-code</code>"
        <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status①">status</a></p>
@@ -2931,7 +2987,7 @@ of security-relevant policy decisions.</p>
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑤">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer②">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
          <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri">blockedURI</a></code>
          <dd data-md="">
-          <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑥">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑧">resource</a>, with the <code>exclude fragment</code> flag set.</p>
+          <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑥">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑨">resource</a>, with the <code>exclude fragment</code> flag set.</p>
          <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code>
          <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive③">effective directive</a></p>
@@ -2974,11 +3030,11 @@ of security-relevant policy decisions.</p>
   the main tree.</p>
        <li data-md="">
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑥">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑦">directive
-  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
+  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
   (<var>directive</var>):</p>
         <ol>
          <li data-md="">
-          <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> named
+          <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> named
   "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to①"><code>report-to</code></a>", skip the remaining substeps.</p>
          <li data-md="">
           <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①"> splitting a string on ASCII whitespace</a> with <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑦">value</a> as the <code>input</code>.</p>
@@ -3043,7 +3099,7 @@ of security-relevant policy decisions.</p>
   with browsers that don’t support the new mechanism.</p>
        <li data-md="">
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑧">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑨">directive
-  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
+  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
   (<var>directive</var>):</p>
         <ol>
          <li data-md="">
@@ -3074,7 +3130,7 @@ of security-relevant policy decisions.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="6" id="csp-directives"><span class="secno">6. </span><span class="content"> Content Security Policy Directives </span><a class="self-link" href="#csp-directives"></a></h2>
-    <p>This specification defines a number of types of <a data-link-type="dfn" href="#directives" id="ref-for-directives①④">directives</a> which allow
+    <p>This specification defines a number of types of <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directives</a> which allow
   developers to control certain aspects of their sites' behavior. This document
   defines directives which govern resource fetching (in <a href="#directives-fetch">§6.1 Fetch Directives</a>),
   directives which govern the state of a document (in <a href="#directives-document">§6.2 Document Directives</a>),
@@ -3136,31 +3192,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If <var>name</var> is not <code>frame-src</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If <var>name</var> is not <code>frame-src</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
@@ -3204,7 +3260,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3220,7 +3276,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3233,6 +3289,19 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="connect-src Preconnect Check" data-level="6.1.2.3" id="connect-src-pre-connect"><span class="secno">6.1.2.3. </span><span class="content"> <code>connect-src</code> Preconnect Check </span><a class="self-link" href="#connect-src-pre-connect"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-connect-check" id="ref-for-directive-pre-connect-check①">pre-connect check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-host" id="ref-for-concept-host②">host</a> (<var>host</var>), a port (<var>port</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+     <li data-md="">
+      <p>Let <var>url</var> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">url</a> whose <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a> is <var>host</var>, and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> is <var>port</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>url</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a>, and <var>origin</var> is "<code>Matches</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Blocked</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.3" id="directive-default-src"><span class="secno">6.1.3. </span><span class="content"><code>default-src</code></span><a class="self-link" href="#directive-default-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-src">default-src</dfn> directive serves as a fallback for the other <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives">fetch directives</a>. The syntax for the directive’s name and value is described by
@@ -3291,25 +3360,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3322,8 +3373,39 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the comparison.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
   comparison.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="default-src Preconnect Check" data-level="6.1.3.3" id="default-src-pre-connect"><span class="secno">6.1.3.3. </span><span class="content"> <code>default-src</code> Preconnect Check </span><a class="self-link" href="#default-src-pre-connect"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-connect-check" id="ref-for-directive-pre-connect-check②">pre-connect check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-host" id="ref-for-concept-host③">host</a> (<var>host</var>), a port (<var>port</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> (<var>origin</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+     <li data-md="">
+      <p>Let <var>url</var> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">url</a> whose <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host①">host</a> is <var>host</var>, and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> is <var>port</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>url</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a>, and <var>origin</var> is "<code>Matches</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Blocked</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="font-src">font-src</dfn> directive restricts the URLs from which font resources
@@ -3351,7 +3433,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3359,7 +3441,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is "<code>font</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3367,7 +3449,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3375,7 +3457,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is "<code>font</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3399,7 +3481,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3408,7 +3490,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   context</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3416,7 +3498,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3425,7 +3507,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   context</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3451,7 +3533,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3459,7 +3541,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⓪">destination</a> is "<code>image</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3467,7 +3549,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3475,7 +3557,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①①">destination</a> is "<code>image</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3499,7 +3581,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3507,7 +3589,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①②">destination</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3515,7 +3597,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3523,7 +3605,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①③">destination</a> is "<code>manifest</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3550,7 +3632,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3559,7 +3641,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   or "<code>track</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3567,7 +3649,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3576,7 +3658,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   or "<code>track</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3600,7 +3682,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3609,14 +3691,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3625,7 +3707,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
-  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -3658,7 +3740,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3666,7 +3748,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3674,7 +3756,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑥">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3682,7 +3764,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3690,7 +3772,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑦">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3736,26 +3818,26 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②④">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑧">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
         <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source expressions</a> in
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
        <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>integrity sources</var> be the result of executing the algorithn
+          <p>Let <var>integrity sources</var> be the result of executing the algorithm
   defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
          <li data-md="">
           <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
@@ -3766,7 +3848,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md="">
-            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> does not
+            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -3780,7 +3862,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   this directive. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
+        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>:</p>
         <ol>
@@ -3791,7 +3873,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3799,24 +3881,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑤">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑨">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> contains
+        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3832,7 +3914,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
+        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3841,7 +3923,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>Let <var>unsafe-inline flag</var> be <code>false</code>.</p>
        <li data-md="">
-        <p>For each <var>expression</var> in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>:</p>
+        <p>For each <var>expression</var> in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>:</p>
         <ol>
          <li data-md="">
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤"><code>hash-source</code></a> grammar, return "<code>Blocked</code>".</p>
@@ -3907,7 +3989,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3916,10 +3998,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3927,7 +4009,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3936,10 +4018,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3953,7 +4035,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>type</var> is "<code>style</code>" or "<code>style attribute</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -3963,19 +4045,57 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-eba1ebc1"><a class="self-link" href="#issue-eba1ebc1"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-webrtc-src"><span class="secno">6.1.13. </span><span class="content"><code>webrtc-src</code></span><a class="self-link" href="#directive-webrtc-src"></a></h4>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="webrtc-src">webrtc-src</dfn> directive restricts the set of servers or peers to which
+  connections may be established via WebRTC. The syntax for the directive’s name and value is
+  described by the following ABNF:</p>
+<pre>directive-name  = "webrtc-src"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+</pre>
+    <div class="example" id="example-a2d17f68">
+     <a class="self-link" href="#example-a2d17f68"></a> Given a page with the following Content Security Policy: 
+<pre>Content-Security-Policy: <a data-link-type="dfn" href="#webrtc-src" id="ref-for-webrtc-src">webrtc-src</a> example.com
+</pre>
+     <p>Connections for the following code will fail, as the URL provided for the TURN server does not
+    match <code>webrtc-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> pc <span class="o">=</span> <span class="k">new</span> RTCPeerConnection<span class="p">({</span>
+    <span class="s2">"iceServers"</span><span class="o">:</span><span class="p">[</span>
+      <span class="p">{</span>
+        <span class="s2">"urls"</span><span class="o">:</span> <span class="p">[</span><span class="s2">"turn:not-example.com:19305?transport=udp"</span><span class="p">],</span><span class="s2">"username"</span><span class="o">:</span><span class="s2">""</span><span class="p">,</span><span class="s2">"credential"</span><span class="o">:</span><span class="s2">""</span>
+      <span class="p">}</span>
+    <span class="p">]</span>
+  <span class="p">});</span>
+  pc<span class="p">.</span>createOffer<span class="p">().</span>then<span class="p">((</span>sdp<span class="p">)</span> <span class="p">=></span> pc<span class="p">.</span>setLocalDescription<span class="p">(</span>sdp<span class="p">);</span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+</pre>
+    </div>
+    <h5 class="heading settled algorithm" data-algorithm="webrtc-src Preconnect Check" data-level="6.1.13.1" id="webrtc-src-pre-connect"><span class="secno">6.1.13.1. </span><span class="content"> <code>webrtc-src</code> Preconnect Check </span><a class="self-link" href="#webrtc-src-pre-connect"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-connect-check" id="ref-for-directive-pre-connect-check③">pre-connect check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-host" id="ref-for-concept-host④">host</a> (<var>host</var>), a port (<var>port</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin④">origin</a> (<var>origin</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+     <li data-md="">
+      <p>Let <var>url</var> be a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url②">url</a> whose <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a> is <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme②">scheme</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host②">host</a> is <var>host</var>, and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port②">port</a> is <var>port</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>url</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>, and <var>origin</var> is "<code>Matches</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Blocked</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.14" id="directive-worker-src"><span class="secno">6.1.14. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <div class="example" id="example-3567d8b2">
      <a class="self-link" href="#example-3567d8b2"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③">worker-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
-    provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
+    provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source list</a>:</p>
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
   blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
@@ -3983,9 +4103,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.14.1" id="worker-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -3994,15 +4114,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol start="4">
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.14.2" id="worker-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4011,7 +4131,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4025,7 +4145,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -4033,28 +4153,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   returns "<code>Allowed</code>" if <var>base</var> may be used as the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element②">base</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href①">href</a></code> attribute, and "<code>Blocked</code>" otherwise:</p>
     <ol>
      <li data-md="">
-      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">csp list</a>:</p>
+      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">csp list</a>:</p>
       <ol>
        <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
        <li data-md="">
-        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is
+        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑥">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
         <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
          <li data-md="">
-          <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global
+          <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global
   object</a>, <var>policy</var>, and "<a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri"><code>base-uri</code></a>".</p>
          <li data-md="">
-          <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑨">resource</a> to "<code>inline</code>".</p>
+          <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①⓪">resource</a> to "<code>inline</code>".</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> is "<code>enforce</code>",
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is "<code>enforce</code>",
   return "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -4108,7 +4228,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4121,7 +4241,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4137,7 +4257,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑨">CSP list</a>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
+        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
          <li data-md="">
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
@@ -4151,7 +4271,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4174,12 +4294,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md="">
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is not "<code>enforce</code>", then
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑤">destination</a> is one of
@@ -4187,7 +4307,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4201,16 +4321,16 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md="">
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code>, then abort this algorithm.</p>
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code>, then abort this algorithm.</p>
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4233,7 +4353,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑥">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4248,7 +4368,7 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string (<var>type</var>, "<code>form-submission</code> or
@@ -4262,7 +4382,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4282,7 +4402,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
-    <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
+    <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>)
@@ -4309,7 +4429,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4321,14 +4441,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-db2876b7"><a class="self-link" href="#issue-db2876b7"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <section class="wip">
      <h4 class="heading settled" data-level="6.3.3" id="directive-navigation-to"><span class="secno">6.3.3. </span><span class="content"><code>navigation-to</code></span><a class="self-link" href="#directive-navigation-to"></a></h4>
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigation-to">navigation-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
     a document can navigate by any means (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code>, <code>window.location</code>, <code>window.open</code>, etc.). The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigation-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
 </pre>
      <p class="issue" id="issue-86f8d392"><a class="self-link" href="#issue-86f8d392"></a> Should we use <code>ancestor-source-list</code> (basically, origins as opposed to
     paths?) It doesn’t appear that blocking navigation targets is any worse than
@@ -4345,7 +4465,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   Likewise, <var>type</var> is unused, as all navigation requests are treated
   identically.</p>
       <li data-md="">
-       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
+       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       <li data-md="">
        <p>Return "<code>Allowed</code>".</p>
@@ -4401,8 +4521,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>), this
-  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>), this
+  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
      <li data-md="">
@@ -4419,7 +4539,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.1.2" id="match-nonce-to-source-list"><span class="secno">6.6.1.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4438,17 +4558,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.1.3" id="match-request-to-source-list"><span class="secno">6.6.1.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑥">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.1.4" id="match-response-to-source-list"><span class="secno">6.6.1.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑦">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.1.5" id="match-url-to-source-list"><span class="secno">6.6.1.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑤">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4474,10 +4594,10 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.1.6" id="match-url-to-source-expression"><span class="secno">6.6.1.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑥">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
   returns "<code>Matches</code>" if <var>url</var> matches <var>expression</var>, and "<code>Does Not Match</code>"
   otherwise.</p>
-    <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
+    <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑦">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
   meaning depending on that bit of context.</p>
     <ol>
      <li data-md="">
@@ -4485,9 +4605,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   the following conditions is met:</p>
       <ol>
        <li data-md="">
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
        <li data-md="">
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme③">scheme</a>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> This logic means that in order to allow a resource from a non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme③">network scheme</a>,
   it has to be either explicitly specified (e.g. <code>default-src * data: custom-scheme-1: custom-scheme-2:</code>),
@@ -4496,7 +4616,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source②"><code>scheme-source</code></a> or <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source②"><code>host-source</code></a> grammar:</p>
       <ol>
        <li data-md="">
-        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md="">
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source③"><code>scheme-source</code></a> grammar,
   return "<code>Matches</code>".</p>
@@ -4507,7 +4627,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md="">
         <p>If <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> is <code>null</code>, return "<code>Does Not Match</code>".</p>
        <li data-md="">
-        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>,
+        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme④">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a>,
   return "<code>Does Not Match</code>".</p>
         <p class="note" role="note"><span>Note:</span> As with <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part④"><code>scheme-part</code></a> above, we allow schemeless <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source④"><code>host-source</code></a> expressions to be upgraded from insecure
   schemes to secure schemes.</p>
@@ -4516,7 +4636,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md="">
         <p>Let <var>port-part</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part①"><code>port-part</code></a> if present, and <code>null</code> otherwise.</p>
        <li data-md="">
-        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port③">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md="">
         <p>If <var>expression</var> contains a non-empty <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part①"><code>path-part</code></a>, and <var>redirect count</var> is 0, then:</p>
         <ol>
@@ -4537,13 +4657,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin②">origin</a></p>
        <li data-md="">
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
-  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
+  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>s, and
   one or more of the following conditions is met:</p>
         <ol>
          <li data-md="">
-          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
+          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
          <li data-md="">
-          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>http</code>"</p>
+          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a> is "<code>http</code>"</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Like the <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑤"><code>scheme-part</code></a> logic above, the "<code>'self'</code>"
@@ -4556,7 +4676,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.1.7" id="match-schemes"><span class="secno">6.6.1.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①④">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
   to <code>script-src http: https:</code>, <code>script-src http://example.com</code> to <code>script-src http://example.com https://example.com</code>, and <code>connect-src ws:</code> to <code>connect-src ws: wss:</code>.</p>
@@ -4582,7 +4702,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.1.8" id="match-hosts"><span class="secno">6.6.1.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
   string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part②"><code>host-part</code></a> could
-  potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a>. For example, we say that
+  potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host③">host</a>. For example, we say that
   "www.example.com" <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match①">host-part matches</a> "www.example.com".</p>
     <p>More formally, two <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑨">ASCII strings</a> (<var>A</var> and <var>B</var>) are said to <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match②"><code>host-part</code> match</a> if the
   following algorithm returns "<code>Matches</code>":</p>
@@ -4617,7 +4737,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.1.9" id="match-ports"><span class="secno">6.6.1.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
-  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
+  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port④">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⑤">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
      <li data-md="">
       <p>If <var>port A</var> is empty:</p>
@@ -4654,7 +4774,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Let <var>exact match</var> be <code>false</code> if the final character of <var>path A</var> is the U+002F
   SOLIDUS character (<code>/</code>), and <code>true</code> otherwise.</p>
      <li data-md="">
-      <p>Let <var>path list A</var> and <var>path list B</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split①">strictly splitting</a> <var>path A</var> and <var>path B</var> respestively on the U+002F SOLIDUS character (<code>/</code>).</p>
+      <p>Let <var>path list A</var> and <var>path list B</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split①">strictly splitting</a> <var>path A</var> and <var>path B</var> respectively on the U+002F SOLIDUS character (<code>/</code>).</p>
      <li data-md="">
       <p>If <var>path list A</var> has more items than <var>path list B</var>, return
   "<code>Does Not Match</code>".</p>
@@ -4687,7 +4807,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
     <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑦">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
     <ol>
      <li data-md="">
       <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑥">destination</a>, and execute
@@ -4808,9 +4928,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
     <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.2.2" id="allow-all-inline"><span class="secno">6.6.2.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
-    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③"><code>'unsafe-inline'</code></a>, and does not override that
+    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
-    <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
+    <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
   algorithm returns "<code>Allows</code>" if all inline content of a given <var>type</var> is
   allowed and "<code>Does Not Allow</code>" otherwise.</p>
     <ol>
@@ -4834,16 +4954,16 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   Otherwise, return "<code>Does Not Allow</code>".</p>
     </ol>
     <div class="example" id="example-8c103cdb">
-     <a class="self-link" href="#example-8c103cdb"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
+     <a class="self-link" href="#example-8c103cdb"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑨">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
 <pre>'unsafe-inline' http://a.com http://b.com
 'unsafe-inline'
 </pre>
-     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑨">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior①">allow all inline behavior</a> due to
+     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②⓪">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior①">allow all inline behavior</a> due to
     the presence of nonces and/or hashes, or absence of '<code>unsafe-inline</code>':</p>
 <pre>'sha512-321cba' 'nonce-abc'
 http://example.com 'unsafe-inline' 'nonce-abc'
 </pre>
-     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②⓪">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior②">allow all inline behavior</a> when <var>type</var> is
+     <p><a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">Source lists</a> that do not <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior②">allow all inline behavior</a> when <var>type</var> is
      '<code>script</code>' or '<code>script attribute</code>' due to the presence of
      '<code>strict-dynamic</code>', but <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior③">allow all inline behavior</a> otherwise:</p>
 <pre>'unsafe-inline' 'strict-dynamic'
@@ -4851,7 +4971,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.2.3" id="match-element-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②②">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <ol>
@@ -4934,7 +5054,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5027,17 +5147,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
-  policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context②">opener browsing context</a>. The goal is to ensure that a page can’t
-  bypass its policy by embedding a frame or opening a new window containg
+  policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context②">opener browsing context</a>. The goal is to ensure that a page can’t
+  bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-7a5b0df0">
      <a class="self-link" href="#example-7a5b0df0"></a> If this would not happen a page could execute inline scripts even without <code>unsafe-inline</code> in the page’s execution context by simply embedding a <code>srcdoc</code> <code>iframe</code>. 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">"&lt;script>alert(1);&lt;/script>"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 </pre>
     </div>
-    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
-  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document④">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context③">opener browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> or vice-versa.</p>
+    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> which
+  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> is a
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document④">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context③">opener browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-3c6e0109">
      <a class="self-link" href="#example-3c6e0109"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -5199,7 +5319,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5275,7 +5395,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src④"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.14 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5407,23 +5527,23 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-documenturi">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li>
-    effective directive
-    <ul>
-     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.6.1.11</span>
-    </ul>
-   <li>
     effectiveDirective
     <ul>
      <li><a href="#dom-securitypolicyviolationevent-effectivedirective">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-effectivedirective">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
+    </ul>
+   <li>
+    effective directive
+    <ul>
+     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.6.1.11</span>
     </ul>
    <li><a href="#violation-element">element</a><span>, in §2.4</span>
    <li><a href="#embedding-document">embedding document</a><span>, in §4.2</span>
    <li><a href="#dom-securitypolicyviolationeventdisposition-enforce">enforce</a><span>, in §5.1</span>
    <li><a href="#dom-securitypolicyviolationeventdisposition-enforce">"enforce"</a><span>, in §5.1</span>
    <li><a href="#enforced">enforced</a><span>, in §4.2</span>
-   <li><a href="#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)</a><span>, in §4.3</span>
+   <li><a href="#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)</a><span>, in §4.4</span>
    <li><a href="#fetch-directives">Fetch directives</a><span>, in §6.1</span>
    <li><a href="#font-src">font-src</a><span>, in §6.1.4</span>
    <li><a href="#form-action">form-action</a><span>, in §6.3.1</span>
@@ -5479,6 +5599,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-port-part">port-part</a><span>, in §2.3.1</span>
    <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.1.9</span>
    <li><a href="#directive-post-request-check">post-request check</a><span>, in §2.3</span>
+   <li><a href="#directive-pre-connect-check">pre-connect check</a><span>, in §2.3</span>
    <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.9</span>
    <li><a href="#directive-pre-navigation-check">pre-navigation check</a><span>, in §2.3</span>
    <li><a href="#directive-pre-request-check">pre-request check</a><span>, in §2.3</span>
@@ -5556,7 +5677,8 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
+   <li><a href="#webrtc-src">webrtc-src</a><span>, in §6.1.13</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.14</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -5810,6 +5932,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://url.spec.whatwg.org/#url">URL</a>
      <li><a href="https://url.spec.whatwg.org/#concept-base-url">base url</a>
      <li><a href="https://url.spec.whatwg.org/#default-port">default port</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-host">host</a>
      <li><a href="https://url.spec.whatwg.org/#dom-url-host">host <small>(for URL)</small></a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-host">host <small>(for url)</small></a>
      <li><a href="https://url.spec.whatwg.org/#concept-ipv6">ipv6 address</a>
@@ -5819,6 +5942,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="https://url.spec.whatwg.org/#dom-url-port">port <small>(for URL)</small></a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-port">port <small>(for url)</small></a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url">url</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-parser">url parser</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-serializer">url serializer</a>
     </ul>
@@ -6023,89 +6147,95 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-content-security-policy-object④">(2)</a>
     <li><a href="#ref-for-content-security-policy-object⑤">2.2.2. 
     Parse a serialized CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a>
-    <li><a href="#ref-for-content-security-policy-object①①">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①②">(2)</a> <a href="#ref-for-content-security-policy-object①③">(3)</a> <a href="#ref-for-content-security-policy-object①④">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object①⑤">2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a>
+    <li><a href="#ref-for-content-security-policy-object①②">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①③">(2)</a> <a href="#ref-for-content-security-policy-object①④">(3)</a> <a href="#ref-for-content-security-policy-object①⑤">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object①⑥">2.4.1. 
     Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑥">2.4.2. 
+    <li><a href="#ref-for-content-security-policy-object①⑦">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑦">3. 
-    Policy Delivery </a> <a href="#ref-for-content-security-policy-object①⑧">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object①⑨">4.1. 
+    <li><a href="#ref-for-content-security-policy-object①⑧">3. 
+    Policy Delivery </a> <a href="#ref-for-content-security-policy-object①⑨">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object②⓪">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-content-security-policy-object②⓪">4.2. 
-    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②①">(2)</a> <a href="#ref-for-content-security-policy-object②②">(3)</a> <a href="#ref-for-content-security-policy-object②③">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object②④">4.2.1. 
+    <li><a href="#ref-for-content-security-policy-object②①">4.2. 
+    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②②">(2)</a> <a href="#ref-for-content-security-policy-object②③">(3)</a> <a href="#ref-for-content-security-policy-object②④">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object②⑤">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object②⑤">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object②⑥">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑦">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object②⑥">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object②⑦">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object②⑧">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object②⑧">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object②⑨">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object②⑨">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object③①">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③①">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object③②">6.1.2.3. 
+    connect-src Preconnect Check </a>
+    <li><a href="#ref-for-content-security-policy-object③③">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③②">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object③④">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③③">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.3.3. 
+    default-src Preconnect Check </a>
+    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③④">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object④①">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object④②">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object④③">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④①">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object④④">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④②">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④③">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④④">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.10. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.10. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.13.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.13.1. 
+    webrtc-src Preconnect Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.14.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.13.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.14.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤④">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑥④">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -6150,16 +6280,18 @@ rest of Google’s CSP Cabal.</p>
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-policy-disposition①⑤">4.3.1. 
+    Should an RTC connection to (host,port) be blocked for global? </a>
+    <li><a href="#ref-for-policy-disposition①⑥">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-policy-disposition①⑥">5.2. 
+    <li><a href="#ref-for-policy-disposition①⑦">5.2. 
     Obtain the deprecated serialization of violation </a>
-    <li><a href="#ref-for-policy-disposition①⑦">6.2.1.1. 
+    <li><a href="#ref-for-policy-disposition①⑧">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-policy-disposition①⑧">6.2.3.1. 
+    <li><a href="#ref-for-policy-disposition①⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-policy-disposition①⑨">6.2.3.2. 
+    <li><a href="#ref-for-policy-disposition②⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-policy-disposition②⓪">6.3.2.2. 
+    <li><a href="#ref-for-policy-disposition②①">6.3.2.2. 
 		Relation to X-Frame-Options </a>
    </ul>
   </aside>
@@ -6245,35 +6377,37 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directives⑦">4.1. 
     Integration with Fetch </a>
     <li><a href="#ref-for-directives⑧">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directives⑨">(2)</a> <a href="#ref-for-directives①⓪">(3)</a>
-    <li><a href="#ref-for-directives①①">5.3. 
-    Report a violation </a> <a href="#ref-for-directives①②">(2)</a> <a href="#ref-for-directives①③">(3)</a>
-    <li><a href="#ref-for-directives①④">6. 
+    Should an RTC connection to (host,port) be blocked for global? </a> <a href="#ref-for-directives⑨">(2)</a> <a href="#ref-for-directives①⓪">(3)</a> <a href="#ref-for-directives①①">(4)</a>
+    <li><a href="#ref-for-directives①②">4.4.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directives①③">(2)</a> <a href="#ref-for-directives①④">(3)</a>
+    <li><a href="#ref-for-directives①⑤">5.3. 
+    Report a violation </a> <a href="#ref-for-directives①⑥">(2)</a> <a href="#ref-for-directives①⑦">(3)</a>
+    <li><a href="#ref-for-directives①⑧">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-directives①⑤">6.1.1.1. 
+    <li><a href="#ref-for-directives①⑨">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-directives①⑥">6.1.1.2. 
+    <li><a href="#ref-for-directives②⓪">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-directives①⑦">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directives①⑧">(2)</a> <a href="#ref-for-directives①⑨">(3)</a> <a href="#ref-for-directives②⓪">(4)</a>
-    <li><a href="#ref-for-directives②①">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directives②②">(2)</a> <a href="#ref-for-directives②③">(3)</a> <a href="#ref-for-directives②④">(4)</a>
-    <li><a href="#ref-for-directives②⑤">6.1.11.1. 
+    <li><a href="#ref-for-directives②①">6.1.3.1. 
+    default-src Pre-request check </a> <a href="#ref-for-directives②②">(2)</a> <a href="#ref-for-directives②③">(3)</a> <a href="#ref-for-directives②④">(4)</a>
+    <li><a href="#ref-for-directives②⑤">6.1.3.2. 
+    default-src Post-request check </a> <a href="#ref-for-directives②⑥">(2)</a> <a href="#ref-for-directives②⑦">(3)</a> <a href="#ref-for-directives②⑧">(4)</a>
+    <li><a href="#ref-for-directives②⑨">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directives②⑥">6.1.11.2. 
+    <li><a href="#ref-for-directives③⓪">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-directives②⑦">6.2.1.1. 
-    Is base allowed for document? </a> <a href="#ref-for-directives②⑧">(2)</a>
-    <li><a href="#ref-for-directives②⑨">6.2.2.2. 
+    <li><a href="#ref-for-directives③①">6.2.1.1. 
+    Is base allowed for document? </a> <a href="#ref-for-directives③②">(2)</a>
+    <li><a href="#ref-for-directives③③">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directives③⓪">6.3.2.2. 
+    <li><a href="#ref-for-directives③④">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-directives③①">6.6.1.1. 
+    <li><a href="#ref-for-directives③⑤">6.6.1.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directives③②">6.6.1.3. 
+    <li><a href="#ref-for-directives③⑥">6.6.1.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-directives③③">6.6.1.4. 
+    <li><a href="#ref-for-directives③⑦">6.6.1.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6290,22 +6424,24 @@ rest of Google’s CSP Cabal.</p>
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-directive-name⑥">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑦">(2)</a>
-    <li><a href="#ref-for-directive-name⑧">6.1.1.1. 
-    child-src Pre-request check </a> <a href="#ref-for-directive-name⑨">(2)</a>
-    <li><a href="#ref-for-directive-name①⓪">6.1.1.2. 
-    child-src Post-request check </a> <a href="#ref-for-directive-name①①">(2)</a>
-    <li><a href="#ref-for-directive-name①②">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directive-name①③">(2)</a> <a href="#ref-for-directive-name①④">(3)</a> <a href="#ref-for-directive-name①⑤">(4)</a>
-    <li><a href="#ref-for-directive-name①⑥">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directive-name①⑦">(2)</a> <a href="#ref-for-directive-name①⑧">(3)</a> <a href="#ref-for-directive-name①⑨">(4)</a>
-    <li><a href="#ref-for-directive-name②⓪">6.1.11.1. 
+    Should an RTC connection to (host,port) be blocked for global? </a> <a href="#ref-for-directive-name⑦">(2)</a> <a href="#ref-for-directive-name⑧">(3)</a> <a href="#ref-for-directive-name⑨">(4)</a>
+    <li><a href="#ref-for-directive-name①⓪">4.4.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name①①">(2)</a>
+    <li><a href="#ref-for-directive-name①②">6.1.1.1. 
+    child-src Pre-request check </a> <a href="#ref-for-directive-name①③">(2)</a>
+    <li><a href="#ref-for-directive-name①④">6.1.1.2. 
+    child-src Post-request check </a> <a href="#ref-for-directive-name①⑤">(2)</a>
+    <li><a href="#ref-for-directive-name①⑥">6.1.3.1. 
+    default-src Pre-request check </a> <a href="#ref-for-directive-name①⑦">(2)</a> <a href="#ref-for-directive-name①⑧">(3)</a> <a href="#ref-for-directive-name①⑨">(4)</a>
+    <li><a href="#ref-for-directive-name②⓪">6.1.3.2. 
+    default-src Post-request check </a> <a href="#ref-for-directive-name②①">(2)</a> <a href="#ref-for-directive-name②②">(3)</a> <a href="#ref-for-directive-name②③">(4)</a>
+    <li><a href="#ref-for-directive-name②④">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directive-name②①">6.1.11.2. 
+    <li><a href="#ref-for-directive-name②⑤">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-directive-name②②">6.2.1.1. 
+    <li><a href="#ref-for-directive-name②⑥">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-name②③">6.6.1.11. 
+    <li><a href="#ref-for-directive-name②⑦">6.6.1.11. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -6318,7 +6454,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-value③">2.3.1. Source Lists</a>
     <li><a href="#ref-for-directive-value④">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-value⑤">4.3.1. 
+    <li><a href="#ref-for-directive-value⑤">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-value⑥">(2)</a>
     <li><a href="#ref-for-directive-value⑦">5.3. 
     Report a violation </a> <a href="#ref-for-directive-value⑧">(2)</a>
@@ -6330,70 +6466,76 @@ rest of Google’s CSP Cabal.</p>
     connect-src Pre-request check </a>
     <li><a href="#ref-for-directive-value①②">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①③">6.1.3.1. 
+    <li><a href="#ref-for-directive-value①③">6.1.2.3. 
+    connect-src Preconnect Check </a>
+    <li><a href="#ref-for-directive-value①④">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①④">6.1.3.2. 
+    <li><a href="#ref-for-directive-value①⑤">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑤">6.1.4.1. 
+    <li><a href="#ref-for-directive-value①⑥">6.1.3.3. 
+    default-src Preconnect Check </a>
+    <li><a href="#ref-for-directive-value①⑦">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑥">6.1.4.2. 
+    <li><a href="#ref-for-directive-value①⑧">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑦">6.1.5.1. 
+    <li><a href="#ref-for-directive-value①⑨">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑧">6.1.5.2. 
+    <li><a href="#ref-for-directive-value②⓪">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑨">6.1.6.1. 
+    <li><a href="#ref-for-directive-value②①">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⓪">6.1.6.2. 
+    <li><a href="#ref-for-directive-value②②">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②①">6.1.7.1. 
+    <li><a href="#ref-for-directive-value②③">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②②">6.1.7.2. 
+    <li><a href="#ref-for-directive-value②④">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②③">6.1.8.1. 
+    <li><a href="#ref-for-directive-value②⑤">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②④">6.1.8.2. 
+    <li><a href="#ref-for-directive-value②⑥">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑤">6.1.9.1. 
+    <li><a href="#ref-for-directive-value②⑦">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑥">6.1.9.2. 
+    <li><a href="#ref-for-directive-value②⑧">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑦">6.1.10.1. 
+    <li><a href="#ref-for-directive-value②⑨">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑧">6.1.10.2. 
+    <li><a href="#ref-for-directive-value③⓪">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑨">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-value③⓪">(2)</a> <a href="#ref-for-directive-value③①">(3)</a> <a href="#ref-for-directive-value③②">(4)</a> <a href="#ref-for-directive-value③③">(5)</a>
-    <li><a href="#ref-for-directive-value③④">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-value③⑤">(2)</a> <a href="#ref-for-directive-value③⑥">(3)</a>
-    <li><a href="#ref-for-directive-value③⑦">6.1.11.3. 
-    script-src Inline Check </a> <a href="#ref-for-directive-value③⑧">(2)</a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.12.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.12.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
-    <li><a href="#ref-for-directive-value④③">6.1.12.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.11.1. 
+    script-src Pre-request check </a> <a href="#ref-for-directive-value③②">(2)</a> <a href="#ref-for-directive-value③③">(3)</a> <a href="#ref-for-directive-value③④">(4)</a> <a href="#ref-for-directive-value③⑤">(5)</a>
+    <li><a href="#ref-for-directive-value③⑥">6.1.11.2. 
+    script-src Post-request check </a> <a href="#ref-for-directive-value③⑦">(2)</a> <a href="#ref-for-directive-value③⑧">(3)</a>
+    <li><a href="#ref-for-directive-value③⑨">6.1.11.3. 
+    script-src Inline Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
+    <li><a href="#ref-for-directive-value④①">6.1.12.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
+    <li><a href="#ref-for-directive-value④③">6.1.12.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value④④">(2)</a>
+    <li><a href="#ref-for-directive-value④⑤">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.13.1. 
+    <li><a href="#ref-for-directive-value④⑥">6.1.13.1. 
+    webrtc-src Preconnect Check </a>
+    <li><a href="#ref-for-directive-value④⑦">6.1.14.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.1.13.2. 
+    <li><a href="#ref-for-directive-value④⑧">6.1.14.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.2.1. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.2.2. 
+    <li><a href="#ref-for-directive-value⑤①">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.3.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤③">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤①">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤④">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤③">6.3.3.1. 
+    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.1. 
       navigation-to Pre-Navigation Check </a>
    </ul>
   </aside>
@@ -6450,7 +6592,7 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     worker-src Pre-request Check </a>
     <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
     Directives Defined in Other Documents </a>
@@ -6492,7 +6634,7 @@ rest of Google’s CSP Cabal.</p>
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     worker-src Post-request Check </a>
     <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
     plugin-types Post-Request Check </a>
@@ -6567,6 +6709,19 @@ rest of Google’s CSP Cabal.</p>
     frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="directive-pre-connect-check">
+   <b><a href="#directive-pre-connect-check">#directive-pre-connect-check</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-directive-pre-connect-check">4.3.1. 
+    Should an RTC connection to (host,port) be blocked for global? </a>
+    <li><a href="#ref-for-directive-pre-connect-check①">6.1.2.3. 
+    connect-src Preconnect Check </a>
+    <li><a href="#ref-for-directive-pre-connect-check②">6.1.3.3. 
+    default-src Preconnect Check </a>
+    <li><a href="#ref-for-directive-pre-connect-check③">6.1.13.1. 
+    webrtc-src Preconnect Check </a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="source-lists">
    <b><a href="#source-lists">#source-lists</a></b><b>Referenced in:</b>
    <ul>
@@ -6580,19 +6735,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
-    <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-source-lists①②">6.6.1.2. 
+    <li><a href="#ref-for-source-lists①⓪">6.1.13. webrtc-src</a>
+    <li><a href="#ref-for-source-lists①①">6.1.14. worker-src</a>
+    <li><a href="#ref-for-source-lists①②">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-source-lists①③">6.6.1.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-source-lists①③">6.6.1.3. 
+    <li><a href="#ref-for-source-lists①④">6.6.1.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-source-lists①④">6.6.1.4. 
+    <li><a href="#ref-for-source-lists①⑤">6.6.1.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-source-lists①⑤">6.6.1.5. 
+    <li><a href="#ref-for-source-lists①⑥">6.6.1.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-source-lists①⑥">6.6.2.2. 
-    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑦">(2)</a> <a href="#ref-for-source-lists①⑧">(3)</a> <a href="#ref-for-source-lists①⑨">(4)</a> <a href="#ref-for-source-lists②⓪">(5)</a>
-    <li><a href="#ref-for-source-lists②①">6.6.2.3. 
+    <li><a href="#ref-for-source-lists①⑦">6.6.2.2. 
+    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑧">(2)</a> <a href="#ref-for-source-lists①⑨">(3)</a> <a href="#ref-for-source-lists②⓪">(4)</a> <a href="#ref-for-source-lists②①">(5)</a>
+    <li><a href="#ref-for-source-lists②②">6.6.2.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -6601,7 +6757,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-source-expression">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-source-expression①">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-source-expression②">4.3.1. 
+    <li><a href="#ref-for-source-expression②">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
     <li><a href="#ref-for-source-expression③">6.1.11.1. 
     script-src Pre-request check </a> <a href="#ref-for-source-expression④">(2)</a> <a href="#ref-for-source-expression⑤">(3)</a> <a href="#ref-for-source-expression⑥">(4)</a>
@@ -6626,10 +6782,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigation-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. webrtc-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.3.3. navigation-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -6757,7 +6914,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-unsafe-eval">
    <b><a href="#grammardef-unsafe-eval">#grammardef-unsafe-eval</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-unsafe-eval">4.3.1. 
+    <li><a href="#ref-for-grammardef-unsafe-eval">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
@@ -6791,7 +6948,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-report-sample">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-grammardef-report-sample①">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-grammardef-report-sample②">4.3.1. 
+    <li><a href="#ref-for-grammardef-report-sample②">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
@@ -6920,12 +7077,14 @@ rest of Google’s CSP Cabal.</p>
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-violation-resource⑥">4.3.1. 
+    Should an RTC connection to (host,port) be blocked for global? </a>
+    <li><a href="#ref-for-violation-resource⑦">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-violation-resource⑦">5.2. 
+    <li><a href="#ref-for-violation-resource⑧">5.2. 
     Obtain the deprecated serialization of violation </a>
-    <li><a href="#ref-for-violation-resource⑧">5.3. 
+    <li><a href="#ref-for-violation-resource⑨">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-violation-resource⑨">6.2.1.1. 
+    <li><a href="#ref-for-violation-resource①⓪">6.2.1.1. 
     Is base allowed for document? </a>
    </ul>
   </aside>
@@ -7018,7 +7177,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-sample①">2.4. Violations</a>
     <li><a href="#ref-for-violation-sample②">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-violation-sample③">4.3.1. 
+    <li><a href="#ref-for-violation-sample③">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
     <li><a href="#ref-for-violation-sample④">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -7062,13 +7221,15 @@ rest of Google’s CSP Cabal.</p>
     Retrieve the CSP list of an object </a> <a href="#ref-for-global-object-csp-list①①">(2)</a> <a href="#ref-for-global-object-csp-list①②">(3)</a> <a href="#ref-for-global-object-csp-list①③">(4)</a>
     <li><a href="#ref-for-global-object-csp-list①④">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-global-object-csp-list①⑤">4.3. Integration with ECMAScript</a>
-    <li><a href="#ref-for-global-object-csp-list①⑥">4.3.1. 
+    <li><a href="#ref-for-global-object-csp-list①⑤">4.3.1. 
+    Should an RTC connection to (host,port) be blocked for global? </a>
+    <li><a href="#ref-for-global-object-csp-list①⑥">4.4. Integration with ECMAScript</a>
+    <li><a href="#ref-for-global-object-csp-list①⑦">4.4.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-global-object-csp-list①⑦">6.2.1.1. 
+    <li><a href="#ref-for-global-object-csp-list①⑧">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-global-object-csp-list①⑧">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list①⑨">(2)</a> <a href="#ref-for-global-object-csp-list②⓪">(3)</a> <a href="#ref-for-global-object-csp-list②①">(4)</a> <a href="#ref-for-global-object-csp-list②②">(5)</a>
+    <li><a href="#ref-for-global-object-csp-list①⑨">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②⓪">(2)</a> <a href="#ref-for-global-object-csp-list②①">(3)</a> <a href="#ref-for-global-object-csp-list②②">(4)</a> <a href="#ref-for-global-object-csp-list②③">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enforced">
@@ -7344,12 +7505,18 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="webrtc-src">
+   <b><a href="#webrtc-src">#webrtc-src</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-webrtc-src">6.1.13. webrtc-src</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.1. child-src</a>
     <li><a href="#ref-for-worker-src①">6.1.3. default-src</a> <a href="#ref-for-worker-src②">(2)</a>
-    <li><a href="#ref-for-worker-src③">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker-src③">6.1.14. worker-src</a>
     <li><a href="#ref-for-worker-src④">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.src.html
+++ b/index.src.html
@@ -557,6 +557,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       arguments, and is executed during [[#should-block-navigation-response]].
       It returns "`Allowed`" unless otherwise specified.
 
+  8.  A <dfn for="directive" export>pre-connect check</dfn>, which takes a [=/host=], a [=/policy=], and
+      an [=origin=], and is executed during [[#should-block-rtc-connection]]. It returns "`Allowed`"
+      unless otherwise specified.
+
   <h4 id="framework-directive-source-list">Source Lists</h4>
 
   Many <a>directives</a>' <a>values</a> consist of <dfn export>source lists</dfn>: <a>sets</a>
@@ -1370,7 +1374,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     in |target| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a for="/">request</a> (|navigation request|),, a string (|type|, either
+  Given a <a for="/">request</a> (|navigation request|), a string (|type|, either
   "`form-submission`" or "`other`"), a <a>response</a> |navigation
   response|, and two <a>browsing contexts</a> (|source| and |target|), this algorithm
   returns "`Blocked`" if the active policy blocks the navigation, and "`Allowed`"
@@ -1403,6 +1407,52 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
             5.  If |policy|'s <a for="policy">disposition</a> is "`enforce`", then
                 set |result| to "`Blocked`".
+
+    3.  Return |result|.
+  </ol>
+
+  <h3 id="webrtc-integration">Integration with WebRTC</h3>
+
+  Mostly TODO. The general idea is that WebRTC should call into [[#should-block-rtc-connection]],
+  passing in enough detail for CSP to return a "`Blocked`"/"`Allowed`" decision, and react
+  accordingly.
+
+  <h4 id="should-block-rtc-connection">
+    Should an RTC connection to (|host|,|port|) be blocked for |global|?
+  </h4>
+
+  Given a [=/host=] (|host|), a port (|port|), and a [=/global object=] (|global|), this algorithm returns "`Blocked`"
+  if the active policy for |global| blocks a connection to |host|, and "`Allowed`" otherwise:
+
+  <ol class="algorithm">
+    1.  Let |result| be "`Allowed`".
+
+    2.  For each |policy| in |global|'s [=global object/CSP list=]:
+
+          1.  Let |directive| be `null`.
+
+          2.  If |policy| contains a [=directive=] whose [=directive/name=] is "`webrtc-src`", then
+              set |directive| to that [=directive=].
+
+              Otherwise if |policy| contains a [=directive=] whose [=directive/name=] is
+              "`connect-src`", then set |directive| to that directive.
+
+              Otherwise if |policy| contains a [=directive=] whose [=directive/name=] is
+              "`default-src`", then set |directive| to that directive.
+
+          3.  If |directive| is not `null`, and the result of executing |directive|'s
+              [=pre-connect check=] on |host|, |policy|, and |global|'s [=/origin=] is
+              "`Blocked`":
+
+              1.  Let |violation| be the result of executing [[#create-violation-for-global]] on
+                  |global|, |policy|, and |directive|'s [=directive/name=].
+
+              2.  Set |violation|'s <a for="violation">resource</a> to |host|.
+
+              3.  Execute [[#report-violation]] on |violation|.
+
+              4.  If |policy|'s <a for="policy">disposition</a> is "`enforce`", then
+                  set |result| to "`Blocked`".
 
     3.  Return |result|.
   </ol>
@@ -1968,6 +2018,25 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   3.  Return "`Allowed`".
 
+  <h5 algorithm id="connect-src-pre-connect">
+    `connect-src` Preconnect Check
+  </h5>
+
+  This directive's <a for="directive">pre-connect check</a> is as follows:
+
+  Given a [=/host=] (|host|), a port (|port|), an [=/origin=] (|origin|) and a [=/policy=]
+  (|policy|):
+
+  1.  Assert: |policy| is unused.
+
+  2.  Let |url| be a [=/url=] whose [=url/scheme=] is |origin|'s [=origin/scheme=], [=url/host=]
+      is |host|, and [=url/port=] is |port|.
+
+  3.  If the result of executing [[#match-url-to-source-list]] on |url|, this directive's
+      [=directive/value=], and |origin| is "`Matches`", return "`Allowed`".
+
+  4.  Return "`Blocked`".
+
   <h4 id="directive-default-src">`default-src`</h4>
 
   The <dfn export>default-src</dfn> directive serves as a fallback for the other
@@ -2098,6 +2167,25 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       <a for="directive">name</a> is |name| on |request|, |response|, and
       |policy|, using this directive's <a for="directive">value</a> for the
       comparison.
+
+  <h5 algorithm id="default-src-pre-connect">
+    `default-src` Preconnect Check
+  </h5>
+
+  This directive's <a for="directive">pre-connect check</a> is as follows:
+
+  Given a [=/host=] (|host|), a port (|port|), an [=/origin=] (|origin|) and a [=/policy=]
+  (|policy|):
+
+  1.  Assert: |policy| is unused.
+
+  2.  Let |url| be a [=/url=] whose [=url/scheme=] is |origin|'s [=origin/scheme=], [=url/host=]
+      is |host|, and [=url/port=] is |port|.
+
+  3.  If the result of executing [[#match-url-to-source-list]] on |url|, this directive's
+      [=directive/value=], and |origin| is "`Matches`", return "`Allowed`".
+
+  4.  Return "`Blocked`".
 
   <h4 id="directive-font-src">`font-src`</h4>
 
@@ -2894,6 +2982,60 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
+
+  <h4 id="directive-webrtc-src">`webrtc-src`</h4>
+
+  The <dfn export>webrtc-src</dfn> directive restricts the set of servers or peers to which
+  connections may be established via WebRTC. The syntax for the directive's name and value is
+  described by the following ABNF:
+
+  <pre>
+    directive-name  = "webrtc-src"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  <div class="example">
+    Given a page with the following Content Security Policy:
+
+    <pre>
+      Content-Security-Policy: <a>webrtc-src</a> example.com
+    </pre>
+
+    Connections for the following code will fail, as the URL provided for the TURN server does not
+    match `webrtc-src`'s <a>source list</a>:
+
+    <pre highlight="html">
+      &lt;script&gt;
+        var pc = new RTCPeerConnection({
+          "iceServers":[
+            {
+              "urls": ["turn:not-example.com:19305?transport=udp"],"username":"","credential":""
+            }
+          ]
+        });
+        pc.createOffer().then((sdp) => pc.setLocalDescription(sdp);
+      &lt;/script&gt;
+    </pre>
+  </div>
+
+  <h5 algorithm id="webrtc-src-pre-connect">
+    `webrtc-src` Preconnect Check
+  </h5>
+
+  This directive's <a for="directive">pre-connect check</a> is as follows:
+
+  Given a [=/host=] (|host|), a port (|port|), an [=/origin=] (|origin|) and a [=/policy=]
+  (|policy|):
+
+  1.  Assert: |policy| is unused.
+
+  2.  Let |url| be a [=/url=] whose [=url/scheme=] is |origin|'s [=origin/scheme=], [=url/host=]
+      is |host|, and [=url/port=] is |port|.
+
+  3.  If the result of executing [[#match-url-to-source-list]] on |url|, this directive's
+      [=directive/value=], and |origin| is "`Matches`", return "`Allowed`".
+
+  4.  Return "`Blocked`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 


### PR DESCRIPTION
The 'webrtc-src' directive is a proposal for handling WebRTC connections. This patch
isn't exactly finished, but it should at least give a concrete proposal that we can
discuss in https://github.com/w3c/webappsec-csp/issues/92.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/287.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (b509df0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/287/32d3db1...b509df0.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (b509df0)">Diff</a>