### PR TITLE
Fix a typo and grammatical error in prefetch-src

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2442,7 +2442,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <h4 id="directive-prefetch-src">`prefetch-src`</h4>
 
-  The <dfn export>prefetch-src</dfn> directive restrictes the URLs from which resources may be
+  The <dfn export>prefetch-src</dfn> directive restricts the URLs from which resources may be
   prefetched or prerendered. The syntax for the directive's name and value is described by the
   following ABNF:
 
@@ -2458,7 +2458,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       Content-Security-Policy: <a>prefetch-src</a> https://example.com/
     </pre>
 
-    Fetches for the following code will return network errors, as the URLs provided does not match
+    Fetches for the following code will return network errors, as the URLs provided do not match
     `prefetch-src`'s <a>source list</a>:
 
     <pre highlight="html">


### PR DESCRIPTION
No subject line necessary.  :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/april/webappsec-csp/pull/288.html" title="Last updated on Jan 17, 2018, 8:18 PM GMT (ff4c919)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/288/32d3db1...april:ff4c919.html" title="Last updated on Jan 17, 2018, 8:18 PM GMT (ff4c919)">Diff</a>