### PR TITLE
Fixed incorrect quotes in strict-dynamic section

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4486,7 +4486,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       s.src = 'https://othercdn.not-example.net/dependency.js';
       document.head.appendChild(s);
 
-      document.write('&lt;scr' + 'ipt src='/sadness.js'&gt;&lt;/scr' + 'ipt&gt;');
+      document.write('&lt;scr' + 'ipt src="/sadness.js"&gt;&lt;/scr' + 'ipt&gt;');
     </pre>
 
     `dependency.js` will load, as the <{script}> element created by


### PR DESCRIPTION
I should have noticed both #305 and this bug at once.