### PR TITLE
Wrote necessary spec changes for 'unsafe-hashed-attributes'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,11 @@ Possible extra rowspan handling
 		}
 	}
 </style>
+<<<<<<< HEAD
   <meta content="Bikeshed version 807fa228f70b24dc6f3ebea36719f85c4b567bb8" name="generator">
+=======
+  <meta content="Bikeshed version 60c7cf64c0efdd39a8c0261dfad14adb1da62902" name="generator">
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
   <meta content="d37f31c13c55cafa5470b082ec93b4668039fc24" name="document-revision">
 <style>
@@ -1504,7 +1508,11 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-12">12 June 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-05">5 June 2018</time></span></h2>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1830,7 +1838,7 @@ of security-relevant policy decisions.</p>
      <ol class="toc">
       <li><a href="#multiple-policies"><span class="secno">8.1</span> <span class="content"> The effect of multiple policies </span></a>
       <li><a href="#strict-dynamic-usage"><span class="secno">8.2</span> <span class="content"> Usage of "<code>'strict-dynamic'</code>" </span></a>
-      <li><a href="#unsafe-hashed-attributes-usage"><span class="secno">8.3</span> <span class="content"> Usage of "<code>'unsafe-hashed-attributes'</code>" </span></a>
+      <li><a href="#unsafe-hashes-usage"><span class="secno">8.3</span> <span class="content"> Usage of "<code>'unsafe-hashes'</code>" </span></a>
       <li><a href="#external-hash"><span class="secno">8.4</span> <span class="content"> Allowing external JavaScript via hashes </span></a>
      </ol>
     <li>
@@ -1967,12 +1975,18 @@ of security-relevant policy decisions.</p>
       <p>The <code>'strict-dynamic'</code> source expression will now allow script which
   executes on a page to load more script via non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script">script</a></code> elements. Details are in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
      <li data-md="">
+<<<<<<< HEAD
       <div class="wip">
         The <code>'unsafe-hashed-attributes'</code> source expression will now allow event
     handlers and style attributes to match hash source expressions. Details
     in <a href="#unsafe-hashed-attributes-usage">§8.3 Usage of "'unsafe-hashed-attributes'"</a>. 
        <p class="issue" id="issue-2a777f3d"><a class="self-link" href="#issue-2a777f3d"></a> <code>unsafe-hashed-attributes</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a></p>
       </div>
+=======
+      <p>The <code>'unsafe-hashes'</code> source expression will now allow event
+  handlers, style attributes and <code>javascript:</code> navigation targets to match
+  hashes. Details in <a href="#unsafe-hashes-usage">§8.3 Usage of "'unsafe-hashes'"</a>.</p>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li data-md="">
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
@@ -2110,7 +2124,8 @@ of security-relevant policy decisions.</p>
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
-  type string, and a source string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
+  type string, and a source string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
+    by Content Security Policy?</a> for <code>javascript:</code> requests. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
@@ -2173,7 +2188,7 @@ of security-relevant policy decisions.</p>
 
 ; Keywords:
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-keyword-source">keyword-source</dfn> = "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-self">'self'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-inline">'unsafe-inline'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-eval">'unsafe-eval'</dfn>"
-                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-hashed-attributes">'unsafe-hashed-attributes'</dfn>" /
+                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-hashes">'unsafe-hashes'</dfn>" /
                  / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-report-sample">'report-sample'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</dfn>"
 
 ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
@@ -2543,7 +2558,11 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   navigate fetch</a> algorithm, and <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response">process a navigate response</a> algorithm to
   apply directive’s navigation checks, as well as inline checks for
+<<<<<<< HEAD
   navigations to <code>javascript:</code>.</p>
+=======
+  navigations to <code>javascript:</code> URLs.</p>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
       <p class="issue" id="issue-ed7a45a9"><a class="self-link" href="#issue-ed7a45a9"></a> W3C’s HTML is not based on Fetch, and does not
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a></p>
     </ol>
@@ -2651,7 +2670,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   definition of a particular type of behavior (script execution, style
   application, event handlers, etc.), and "<code>Blocked</code>" otherwise:</p>
     <p class="note" role="note"><span>Note:</span> The valid values for <var>type</var> are "<code>script</code>", "<code>script attribute</code>",
-  "<code>style</code>", and "<code>style attribute</code>".</p>
+  "<code>style</code>", "<code>style attribute</code>", and "<code>navigation</code>".</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
@@ -2670,8 +2689,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>, <var>policy</var>,
-  and "<code>style-src</code>" if <var>type</var> is "<code>style</code>" or "<code>style-attribute</code>",
-  or "<code>script-src</code>" otherwise.</p>
+  and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
          <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource②">resource</a> to "<code>inline</code>".</p>
          <li data-md="">
@@ -2709,7 +2727,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>source</var>, <var>target</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
+  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
          <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">URL</a>.</p>
@@ -2730,10 +2748,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>For each <var>directive</var> in <var>policy</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>source</var>, and <var>target</var>, skip to the next <var>directive</var>.</p>
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <code>null</code>,
+  "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>,
+  skip to the next <var>directive</var>.</p>
            <li data-md="">
             <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
+  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
            <li data-md="">
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">URL</a>.</p>
@@ -2768,7 +2788,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md="">
-          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
+          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a>.</p>
           <p class="note" role="note"><span>Note:</span> We use <code>null</code> for the global object, as no global exists:
   we haven’t processed the navigation to create a Document yet.</p>
          <li data-md="">
@@ -2793,10 +2813,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a>.</p>
+  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a>.</p>
          <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
          <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md="">
@@ -2829,9 +2849,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md="">
           <p>Let <var>source-list</var> be <code>null</code>.</p>
          <li data-md="">
-          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a> is "<code>script-src</code>", then
+          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is "<code>script-src</code>", then
   set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
-          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is
+          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is
   "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
          <li data-md="">
           <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression②">source expression</a> which is
@@ -3064,7 +3084,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
              <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
              <dd data-md="">
               <p>"<code>POST</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">url</a>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
              <dd data-md="">
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url③">url</a></p>
              <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
@@ -3214,10 +3234,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>name</var> is not <code>frame-src</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
@@ -3228,10 +3248,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>name</var> is not <code>frame-src</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
@@ -3369,13 +3389,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
@@ -3387,13 +3407,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is "<code>script-src</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
@@ -3802,15 +3822,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       </ul>
       <p class="note" role="note"><span>Note:</span> If a user agent implements non-standard sinks like <code>setImmediate()</code> or <code>execScript()</code>, they SHOULD also be gated on "<code>unsafe-eval</code>".</p>
      <li data-md="">
-      <p>Navigation to <code>javascript:</code> URLs MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. These navigations
-  will only execute script if every policy allows inline script, as per #3 above.</p>
+      <p>Navigation to <code>javascript:</code> URLs MUST pass through <a href="#script-src-inline">§6.1.11.3 script-src Inline Check</a>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑧">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
@@ -3873,7 +3892,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> is "<code>worker-src</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If <code>worker-src</code> is present, we’ll defer to it when handling worker requests.</p>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑨">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
@@ -3898,35 +3917,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script attribute</code>" or "<code>script</code>":</p>
+      <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>":</p>
       <ol>
        <li data-md="">
-        <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
+        <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
        <li data-md="">
         <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
-      <p>If <var>type</var> is "<code>navigation</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>Let <var>unsafe-inline flag</var> be <code>false</code>.</p>
-       <li data-md="">
-        <p>For each <var>expression</var> in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>:</p>
-        <ol>
-         <li data-md="">
-          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤"><code>hash-source</code></a> grammar, return "<code>Blocked</code>".</p>
-         <li data-md="">
-          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Blocked</code>".</p>
-         <li data-md="">
-          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>", set <var>unsafe-inline flag</var> to <code>true</code>.</p>
-        </ol>
-       <li data-md="">
-        <p>If <var>unsafe-inline flag</var> is <code>false</code>, return "<code>Blocked</code>".</p>
-      </ol>
-      <p class="note" role="note"><span>Note:</span> Navigating to a <code>javascript:</code> URL is allowed only in the presence
-  of "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline②"><code>'unsafe-inline'</code></a>" that isn’t overridden by a nonce,
-  hash, or "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic④"><code>'strict-dynamic'</code></a>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3958,7 +3956,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
   implicitly by not specifying a <code>style-src</code> (or <code>default-src</code>) directive,
-  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source④">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑥">hash-source</a> that matches
+  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> that matches
   the inline block.</p>
      <li data-md="">
       <p>The following CSS algorithms are gated on the <code>unsafe-eval</code> source
@@ -3987,10 +3985,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4007,10 +4005,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <ol>
        <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4024,7 +4022,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>type</var> is "<code>style</code>" or "<code>style attribute</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4065,7 +4063,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol start="4">
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4082,7 +4080,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4109,9 +4107,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
        <li data-md="">
-        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> is
+        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②④">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
@@ -4192,7 +4190,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4222,7 +4220,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4258,7 +4256,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4281,7 +4279,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4333,7 +4331,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4380,7 +4378,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4428,13 +4426,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④">keyword-source</a>, return "<code>Allowed</code>".</p>
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
   wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4452,15 +4450,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a>, return "<code>Allowed</code>".</p>
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
   already checked the navigation in <a href="#navigate-to-pre-navigate">§6.3.3.1 navigate-to Pre-Navigation Check</a>.</p>
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4545,7 +4543,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> grammar,
+        <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source④"><code>nonce-source</code></a> grammar,
   and <var>nonce</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑤"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
       </ol>
      <li data-md="">
@@ -4801,7 +4799,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
     <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②④">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑤">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
     <ol>
      <li data-md="">
       <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑥">destination</a>, and execute
@@ -4887,7 +4885,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h4 class="heading settled" data-level="6.6.2" id="matching-elements"><span class="secno">6.6.2. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.2.1" id="is-element-nonceable"><span class="secno">6.6.2.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
-  a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑥"><code>nonce-source</code></a> expression can match the element (as discussed
+  a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
     <ol>
@@ -4922,7 +4920,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
     <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.2.2" id="allow-all-inline"><span class="secno">6.6.2.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
-    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑥"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③"><code>'unsafe-inline'</code></a>, and does not override that
+    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
     <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
   algorithm returns "<code>Allows</code>" if all inline content of a given <var>type</var> is
@@ -4934,13 +4932,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑦"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑦"><code>hash-source</code></a> grammar, return "<code>Does Not Allow</code>".</p>
+        <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑥"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑥"><code>hash-source</code></a> grammar, return "<code>Does Not Allow</code>".</p>
        <li data-md="">
-        <p>If <var>type</var> is "<code>script</code>" or "<code>script attribute</code>" and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑦">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑤"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
+        <p>If <var>type</var> is "<code>script</code>" or "<code>script attribute</code>" and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
         <p class="note" role="note"><span>Note:</span> <code>'strict-dynamic'</code> only applies to scripts, not other resource
   types. Usage is explained in more detail in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
        <li data-md="">
-        <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②⓪">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline④"><code>'unsafe-inline'</code></a>",
+        <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②⓪">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑥"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline②"><code>'unsafe-inline'</code></a>",
   set <var>allow all inline</var> to <code>true</code>.</p>
       </ol>
      <li data-md="">
@@ -4968,12 +4966,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
+    <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
+  is embedded. See the integration points in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
     <ol>
-     <li data-md="">
-      <p class="assertion">Assert: <var>source</var> contains the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑦">script</a></code> element’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#dom-script-text" id="ref-for-dom-script-text">text</a></code> IDL attribute, the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a></code> element’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-textcontent" id="ref-for-dom-node-textcontent">textContent</a></code> IDL attribute, or the value of one of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑧">script</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes" id="ref-for-event-handler-idl-attributes">event handler IDL attribute</a>.</p>
-      <p class="note" role="note"><span>Note:</span> This means that <var>source</var> will be interpreted with the encoding
-  of the page in which it is embedded. See the integration points
-  in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
      <li data-md="">
       <p>If <a href="#allow-all-inline">§6.6.2.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
   return "<code>Matches</code>".</p>
@@ -4984,29 +4979,29 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
          <li data-md="">
-          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧"><code>nonce-source</code></a> grammar,
+          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑦"><code>nonce-source</code></a> grammar,
   and <var>element</var> has a <code class="idl"><a data-link-type="idl">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
         </ol>
       </ol>
-      <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑨">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element②">style</a></code>, not to
-  attributes of either element.</p>
+      <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑦">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a></code>, not to
+  attributes of either element or to <code>javascript:</code> navigations.</p>
      <li data-md="">
-      <p>Let <var>hashes match attributes</var> be <code>false</code>.</p>
+      <p>Let <var>unsafe-hashes flag</var> be <code>false</code>.</p>
      <li data-md="">
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②①">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑨"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-hashed-attributes" id="ref-for-grammardef-unsafe-hashed-attributes"><code>'unsafe-hashed-attributes'</code></a>",
-  set <var>hashes match attributes</var> to <code>true</code>. Break out of the loop.</p>
+        <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②①">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑦"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes"><code>'unsafe-hashes'</code></a>",
+  set <var>unsafe-hashes flag</var> to <code>true</code>. Break out of the loop.</p>
       </ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>hashes match attributes</var> is <code>true</code>:</p>
+      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>unsafe-hashes flag</var> is <code>true</code>:</p>
       <ol>
        <li data-md="">
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
          <li data-md="">
-          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧"><code>hash-source</code></a> grammar:</p>
+          <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑦"><code>hash-source</code></a> grammar:</p>
           <ol>
            <li data-md="">
             <p>Let <var>algorithm</var> be <code>null</code>.</p>
@@ -5035,9 +5030,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
           </ol>
         </ol>
       </ol>
-      <p class="note" role="note"><span>Note:</span> Hashes apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element③">style</a></code>. If the
-  "<a data-link-type="grammar" href="#grammardef-unsafe-hashed-attributes" id="ref-for-grammardef-unsafe-hashed-attributes①"><code>'unsafe-hashed-attributes'</code></a>" source expression is present,
-  they will also apply to event handlers and style attributes.</p>
+      <p class="note" role="note"><span>Note:</span> Hashes apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑧">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element②">style</a></code>. If the
+  "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes①"><code>'unsafe-hashes'</code></a>" source expression is present,
+  they will also apply to event handlers, style attributes and <code>javascript:</code> navigations.</p>
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
@@ -5048,7 +5043,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5057,12 +5052,12 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   not using a nonce, as nonces override the restrictions in the directive in
   which they are present. An attacker who can gain access to the nonce can
   execute whatever script they like, whenever they like. That said, nonces
-  provide a substantial improvement over <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤">'unsafe-inline'</a> when
-  layering a content security policy on top of old code. When considering <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑥">'unsafe-inline'</a>, authors are encouraged to consider nonces
+  provide a substantial improvement over <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline③">'unsafe-inline'</a> when
+  layering a content security policy on top of old code. When considering <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline④">'unsafe-inline'</a>, authors are encouraged to consider nonces
   (or hashes) instead.</p>
     <h3 class="heading settled" data-level="7.2" id="security-nonce-stealing"><span class="secno">7.2. </span><span class="content">Nonce Stealing</span><a class="self-link" href="#security-nonce-stealing"></a></h3>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
-  example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> element:</p>
+  example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑨">script</a></code> element:</p>
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, [INJECTION POINT]<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
@@ -5071,11 +5066,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="p">></span>
 <span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
-    <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①②">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
+    <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
   second <code>src</code> attribute which is helpfully discarded as duplicate by the parser.</p>
     <p>The <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> algorithm attempts to mitigate this specific
-  attack by walking through <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①③">script</a></code> element attributes, looking for the
+  attack by walking through <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element③">style</a></code> element attributes, looking for the
   string "<code>&lt;script</code>" or "<code>&lt;style</code>" in their names or values.</p>
     <h3 class="heading settled" data-level="7.3" id="security-nonce-retargeting"><span class="secno">7.3. </span><span class="content">Nonce Retargeting</span><a class="self-link" href="#security-nonce-retargeting"></a></h3>
     <p>Nonces bypass <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑤">host-source</a> expressions, enabling developers to load code from any
@@ -5198,7 +5193,7 @@ Content-Security-Policy: connect-src http://example.com/;
   kinds of bypasses which such policies can enable, and though CSP is capable of mitigating these
   bypasses via exhaustive declaration of specific resources, those lists end up being brittle,
   awkward, and difficult to implement and maintain.</p>
-    <p>The "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥"><code>'strict-dynamic'</code></a>" source expression aims to make Content
+    <p>The "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic④"><code>'strict-dynamic'</code></a>" source expression aims to make Content
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
@@ -5206,15 +5201,15 @@ Content-Security-Policy: connect-src http://example.com/;
   two main effects:</p>
     <ol>
      <li data-md="">
-      <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑦"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①⓪">keyword-source</a>s will be
+      <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
-      <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑨">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①⓪">nonce-source</a> expressions
+      <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
      <li data-md="">
-      <p>Script requests which are triggered by non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted③">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①④">script</a></code> elements are allowed.</p>
+      <p>Script requests which are triggered by non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted③">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①②">script</a></code> elements are allowed.</p>
     </ol>
-    <p>The first change allows you to deploy "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑦"><code>'strict-dynamic'</code></a> in a
+    <p>The first change allows you to deploy "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑤"><code>'strict-dynamic'</code></a> in a
   backwards compatible way, without requiring user-agent sniffing: the policy <code>'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'</code> will act like <code>'unsafe-inline' https:</code> in browsers that support CSP1, <code>https: 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV'</code> in browsers that support CSP2, and <code>'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' 'strict-dynamic'</code> in browsers that
   support CSP3.</p>
     <p>The second allows scripts which are given access to the page via nonces or
@@ -5222,7 +5217,11 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
+<<<<<<< HEAD
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑧">'strict-dynamic'</a>
+=======
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5238,31 +5237,35 @@ document<span class="p">.</span>head<span class="p">.</span>appendChild<span cla
 
 document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&lt;scr'</span> <span class="o">+</span> <span class="s1">'ipt src="/sadness.js">&lt;/scr'</span> <span class="o">+</span> <span class="s1">'ipt>'</span><span class="p">);</span>
 </pre>
-     <p><code>dependency.js</code> will load, as the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑤">script</a></code> element created by <code>createElement()</code> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted④">"parser-inserted"</a>.</p>
-     <p><code>sadness.js</code> will <em>not</em> load, however, as <code>document.write()</code> produces <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑥">script</a></code> elements which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted⑤">"parser-inserted"</a>.</p>
+     <p><code>dependency.js</code> will load, as the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①③">script</a></code> element created by <code>createElement()</code> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted④">"parser-inserted"</a>.</p>
+     <p><code>sadness.js</code> will <em>not</em> load, however, as <code>document.write()</code> produces <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①④">script</a></code> elements which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted⑤">"parser-inserted"</a>.</p>
     </div>
-    <section class="wip">
-     <h3 class="heading settled" data-level="8.3" id="unsafe-hashed-attributes-usage"><span class="secno">8.3. </span><span class="content"> Usage of "<code>'unsafe-hashed-attributes'</code>" </span><a class="self-link" href="#unsafe-hashed-attributes-usage"></a></h3>
+    <section>
+     <h3 class="heading settled" data-level="8.3" id="unsafe-hashes-usage"><span class="secno">8.3. </span><span class="content"> Usage of "<code>'unsafe-hashes'</code>" </span><a class="self-link" href="#unsafe-hashes-usage"></a></h3>
      <p><em>This section is not normative.</em></p>
-     <p class="issue" id="issue-0e25e974"><a class="self-link" href="#issue-0e25e974"></a> Work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a></p>
      <p>Legacy websites and websites with legacy dependencies might find it difficult
     to entirely externalize event handlers. These sites could enable such handlers
     by allowing <code>'unsafe-inline'</code>, but that’s a big hammer with a lot of
     associated risk (and cannot be used in conjunction with nonces or hashes).</p>
-     <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashed-attributes" id="ref-for-grammardef-unsafe-hashed-attributes②"><code>'unsafe-hashed-attributes'</code></a>" source expression aims to make
+     <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes②"><code>'unsafe-hashes'</code></a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.</p>
+<<<<<<< HEAD
      <div class="example" id="example-9e76aa47">
       <a class="self-link" href="#example-9e76aa47"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
+=======
+     <div class="example" id="example-5d2d17c6">
+      <a class="self-link" href="#example-5d2d17c6"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
       resembling a reasonable schedule: 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
-      "<code>'unsafe-hashed-attributes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashed-attributes" id="ref-for-grammardef-unsafe-hashed-attributes③">'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+      "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
-     <p>The capabilities <code>'unsafe-hashed-attributes'</code> provides is useful for legacy sites, but should be
+     <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
     avoided for modern sites. In particular, note that hashes allow a particular script to execute,
     but do not ensure that it executes in the way a developer intends. If an interesting capability
     is exposed as an inline event handler (say <code>&lt;a onclick="transferAllMyMoney()">Transfer&lt;/a></code>),
@@ -5275,22 +5278,27 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <p>In <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>, hash <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①⓪">source expressions</a> could only match inlined
     script, but now that Subresource Integrity is widely deployed, we can expand
     the scope to enable externalized JavaScript as well.</p>
+<<<<<<< HEAD
      <p>If multiple sets of integrity metadata are specified for a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑦">script</a></code>, the
     request will match a policy’s <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source①⓪">hash-source</a>s if and only if <em>each</em> item in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑧">script</a></code>'s integrity metadata matches the policy.</p>
+=======
+     <p>If multiple sets of integrity metadata are specified for a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑤">script</a></code>, the
+    request will match a policy’s <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑨">hash-source</a>s if and only if <em>each</em> item in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑥">script</a></code>'s integrity metadata matches the policy.</p>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <div class="example" id="example-af80f2fd">
       <a class="self-link" href="#example-af80f2fd"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
       that ensures that the content matches their expectations. They do so by
       setting the following policy: 
 <pre>Content-Security-Policy: script-src 'sha256-abc123' 'sha512-321cba'
 </pre>
-      <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑨">script</a></code> elements would be
+      <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑦">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
-      <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script②⓪">script</a></code> elements would not execute because they
+      <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑧">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
@@ -5657,7 +5665,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
-   <li><a href="#grammardef-unsafe-hashed-attributes">'unsafe-hashed-attributes'</a><span>, in §2.3.1</span>
+   <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-inline">'unsafe-inline'</a><span>, in §2.3.1</span>
    <li><a href="#violation-url">url</a><span>, in §2.4</span>
    <li><a href="#directive-value">value</a><span>, in §2.3</span>
@@ -5679,7 +5687,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy⑥">8.2. 
     Usage of "'strict-dynamic'" </a>
     <li><a href="#ref-for-header-content-security-policy⑦">8.3. 
+<<<<<<< HEAD
       Usage of "'unsafe-hashed-attributes'" </a>
+=======
+      Usage of "'unsafe-hashes'" </a>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-serialized-policy">
@@ -5841,6 +5853,7 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
+<<<<<<< HEAD
   <aside class="dfn-panel" data-for="term-for-dom-node-textcontent">
    <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">https://dom.spec.whatwg.org/#dom-node-textcontent</a><b>Referenced in:</b>
    <ul>
@@ -5848,6 +5861,8 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a>
    </ul>
   </aside>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <aside class="dfn-panel" data-for="term-for-sec-function-objects">
    <a href="https://tc39.github.io/ecma262#sec-function-objects">https://tc39.github.io/ecma262#sec-function-objects</a><b>Referenced in:</b>
    <ul>
@@ -6652,6 +6667,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-embed-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
+<<<<<<< HEAD
   <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
@@ -6659,6 +6675,8 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a>
    </ul>
   </aside>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <aside class="dfn-panel" data-for="term-for-fallback-base-url">
    <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url</a><b>Referenced in:</b>
    <ul>
@@ -6967,12 +6985,21 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script⑤">6.6.2.1. 
     Is element nonceable? </a> <a href="#ref-for-script⑥">(2)</a>
     <li><a href="#ref-for-script⑦">6.6.2.3. 
+<<<<<<< HEAD
     Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a> <a href="#ref-for-script⑨">(3)</a> <a href="#ref-for-script①⓪">(4)</a>
     <li><a href="#ref-for-script①①">7.2. Nonce Stealing</a> <a href="#ref-for-script①②">(2)</a> <a href="#ref-for-script①③">(3)</a>
     <li><a href="#ref-for-script①④">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-script①⑤">(2)</a> <a href="#ref-for-script①⑥">(3)</a>
     <li><a href="#ref-for-script①⑦">8.4. 
       Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑧">(2)</a> <a href="#ref-for-script①⑨">(3)</a> <a href="#ref-for-script②⓪">(4)</a>
+=======
+    Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a>
+    <li><a href="#ref-for-script⑨">7.2. Nonce Stealing</a> <a href="#ref-for-script①⓪">(2)</a> <a href="#ref-for-script①①">(3)</a>
+    <li><a href="#ref-for-script①②">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script①③">(2)</a> <a href="#ref-for-script①④">(3)</a>
+    <li><a href="#ref-for-script①⑤">8.4. 
+      Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑥">(2)</a> <a href="#ref-for-script①⑦">(3)</a> <a href="#ref-for-script①⑧">(4)</a>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-set-the-frozen-base-url">
@@ -7000,6 +7027,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.2.3. 
+<<<<<<< HEAD
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a> <a href="#ref-for-the-style-element③">(3)</a>
    </ul>
   </aside>
@@ -7008,6 +7036,10 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-dom-script-text">6.6.2.3. 
     Does element match source list for type and source? </a>
+=======
+    Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
+    <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
@@ -7575,7 +7607,10 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
      <li><span class="dfn-paneled" id="term-for-concept-shadow-including-root" style="color:initial">shadow-including root</span>
      <li><span class="dfn-paneled" id="term-for-dom-event-target" style="color:initial">target</span>
+<<<<<<< HEAD
      <li><span class="dfn-paneled" id="term-for-dom-node-textcontent" style="color:initial">textContent</span>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
     </ul>
    <li>
     <a data-link-type="biblio">[ECMA262]</a> defines the following terms:
@@ -7651,7 +7686,10 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-document-2" style="color:initial">document</span>
      <li><span class="dfn-paneled" id="term-for-parse-error-duplicate-attribute" style="color:initial">duplicate-attribute</span>
      <li><span class="dfn-paneled" id="term-for-the-embed-element" style="color:initial">embed</span>
+<<<<<<< HEAD
      <li><span class="dfn-paneled" id="term-for-event-handler-idl-attributes" style="color:initial">event handler idl attribute</span>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li><span class="dfn-paneled" id="term-for-fallback-base-url" style="color:initial">fallback base url</span>
      <li><span class="dfn-paneled" id="term-for-forced-sandboxing-flag-set" style="color:initial">forced sandboxing flag set</span>
      <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
@@ -7692,7 +7730,10 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-setinterval" style="color:initial">setInterval()</span>
      <li><span class="dfn-paneled" id="term-for-dom-settimeout" style="color:initial">setTimeout()</span>
      <li><span class="dfn-paneled" id="term-for-the-style-element" style="color:initial">style</span>
+<<<<<<< HEAD
      <li><span class="dfn-paneled" id="term-for-dom-script-text" style="color:initial">text</span>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
      <li><span class="dfn-paneled" id="term-for-attr-embed-type" style="color:initial">type</span>
      <li><span class="dfn-paneled" id="term-for-update-a-style-block" style="color:initial">update a style block</span>
@@ -7944,7 +7985,10 @@ rest of Google’s CSP Cabal.</p>
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
+<<<<<<< HEAD
    <div class="issue"> <code>unsafe-hashed-attributes</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a><a href="#issue-2a777f3d"> ↵ </a></div>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    <div class="issue"> <code>disown-opener</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/194">&lt;https://github.com/w3c/webappsec-csp/issues/194></a><a href="#issue-f67725cb"> ↵ </a></div>
    <div class="issue"> Is this kind of thing specified anywhere? I didn’t see anything
   that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-ee968c9a"> ↵ </a></div>
@@ -7982,7 +8026,10 @@ rest of Google’s CSP Cabal.</p>
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-4592ac7e"> ↵ </a></div>
+<<<<<<< HEAD
    <div class="issue"> Work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a><a href="#issue-0e25e974"> ↵ </a></div>
+=======
+>>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   </div>
   <aside class="dfn-panel" data-for="content-security-policy">
    <b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
@@ -8274,29 +8321,31 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-name">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-directive-name①">(2)</a>
     <li><a href="#ref-for-directive-name②">2.3. Directives</a>
-    <li><a href="#ref-for-directive-name③">4.2.5. 
+    <li><a href="#ref-for-directive-name③">4.2.4. 
+    Should element’s inline type behavior be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-directive-name④">4.2.5. 
     Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-directive-name④">(2)</a>
-    <li><a href="#ref-for-directive-name⑤">4.2.6. 
+    by Content Security Policy? </a> <a href="#ref-for-directive-name⑤">(2)</a>
+    <li><a href="#ref-for-directive-name⑥">4.2.6. 
     Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a> <a href="#ref-for-directive-name⑥">(2)</a>
-    <li><a href="#ref-for-directive-name⑦">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑧">(2)</a>
-    <li><a href="#ref-for-directive-name⑨">6.1.1.1. 
-    child-src Pre-request check </a> <a href="#ref-for-directive-name①⓪">(2)</a>
-    <li><a href="#ref-for-directive-name①①">6.1.1.2. 
-    child-src Post-request check </a> <a href="#ref-for-directive-name①②">(2)</a>
-    <li><a href="#ref-for-directive-name①③">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directive-name①④">(2)</a> <a href="#ref-for-directive-name①⑤">(3)</a> <a href="#ref-for-directive-name①⑥">(4)</a>
-    <li><a href="#ref-for-directive-name①⑦">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directive-name①⑧">(2)</a> <a href="#ref-for-directive-name①⑨">(3)</a> <a href="#ref-for-directive-name②⓪">(4)</a>
-    <li><a href="#ref-for-directive-name②①">6.1.11.1. 
+    in target be blocked by Content Security Policy? </a> <a href="#ref-for-directive-name⑦">(2)</a>
+    <li><a href="#ref-for-directive-name⑧">4.3.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑨">(2)</a>
+    <li><a href="#ref-for-directive-name①⓪">6.1.1.1. 
+    child-src Pre-request check </a> <a href="#ref-for-directive-name①①">(2)</a>
+    <li><a href="#ref-for-directive-name①②">6.1.1.2. 
+    child-src Post-request check </a> <a href="#ref-for-directive-name①③">(2)</a>
+    <li><a href="#ref-for-directive-name①④">6.1.3.1. 
+    default-src Pre-request check </a> <a href="#ref-for-directive-name①⑤">(2)</a> <a href="#ref-for-directive-name①⑥">(3)</a> <a href="#ref-for-directive-name①⑦">(4)</a>
+    <li><a href="#ref-for-directive-name①⑧">6.1.3.2. 
+    default-src Post-request check </a> <a href="#ref-for-directive-name①⑨">(2)</a> <a href="#ref-for-directive-name②⓪">(3)</a> <a href="#ref-for-directive-name②①">(4)</a>
+    <li><a href="#ref-for-directive-name②②">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-directive-name②②">6.1.11.2. 
+    <li><a href="#ref-for-directive-name②③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-directive-name②③">6.2.1.1. 
+    <li><a href="#ref-for-directive-name②④">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-name②④">6.6.1.11. 
+    <li><a href="#ref-for-directive-name②⑤">6.6.1.11. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -8358,36 +8407,36 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-value③④">6.1.11.2. 
     script-src Post-request check </a> <a href="#ref-for-directive-value③⑤">(2)</a> <a href="#ref-for-directive-value③⑥">(3)</a>
     <li><a href="#ref-for-directive-value③⑦">6.1.11.3. 
-    script-src Inline Check </a> <a href="#ref-for-directive-value③⑧">(2)</a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.12.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.12.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
-    <li><a href="#ref-for-directive-value④③">6.1.12.3. 
+    script-src Inline Check </a>
+    <li><a href="#ref-for-directive-value③⑧">6.1.12.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑨">(2)</a>
+    <li><a href="#ref-for-directive-value④⓪">6.1.12.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value④①">(2)</a>
+    <li><a href="#ref-for-directive-value④②">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.13.1. 
+    <li><a href="#ref-for-directive-value④③">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.1.13.2. 
+    <li><a href="#ref-for-directive-value④④">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑤">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.2.1. 
+    <li><a href="#ref-for-directive-value④⑥">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⑦">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.3.1. 
+    <li><a href="#ref-for-directive-value④⑧">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.2. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤①">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤①">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤③">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤④">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑤">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑥">(2)</a>
+    <li><a href="#ref-for-directive-value⑤②">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤③">(2)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8719,17 +8768,15 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-keyword-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-keyword-source①">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-keyword-source②">6.1.11.3. 
-    script-src Inline Check </a> <a href="#ref-for-grammardef-keyword-source③">(2)</a>
-    <li><a href="#ref-for-grammardef-keyword-source④">6.3.3.1. 
+    <li><a href="#ref-for-grammardef-keyword-source②">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source⑤">6.3.3.2. 
+    <li><a href="#ref-for-grammardef-keyword-source③">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source⑥">6.6.2.2. 
-    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-keyword-source⑦">(2)</a> <a href="#ref-for-grammardef-keyword-source⑧">(3)</a>
-    <li><a href="#ref-for-grammardef-keyword-source⑨">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-keyword-source④">6.6.2.2. 
+    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-keyword-source⑤">(2)</a> <a href="#ref-for-grammardef-keyword-source⑥">(3)</a>
+    <li><a href="#ref-for-grammardef-keyword-source⑦">6.6.2.3. 
     Does element match source list for type and source? </a>
-    <li><a href="#ref-for-grammardef-keyword-source①⓪">8.2. 
+    <li><a href="#ref-for-grammardef-keyword-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8748,12 +8795,10 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-inline">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-grammardef-unsafe-inline①">6.1.11.3. 
-    script-src Inline Check </a> <a href="#ref-for-grammardef-unsafe-inline②">(2)</a>
-    <li><a href="#ref-for-grammardef-unsafe-inline③">6.6.2.2. 
-    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
-    <li><a href="#ref-for-grammardef-unsafe-inline⑤">7.1. Nonce Reuse</a> <a href="#ref-for-grammardef-unsafe-inline⑥">(2)</a>
-    <li><a href="#ref-for-grammardef-unsafe-inline⑦">8.2. 
+    <li><a href="#ref-for-grammardef-unsafe-inline①">6.6.2.2. 
+    Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-unsafe-inline②">(2)</a>
+    <li><a href="#ref-for-grammardef-unsafe-inline③">7.1. Nonce Reuse</a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
+    <li><a href="#ref-for-grammardef-unsafe-inline⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8771,21 +8816,19 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
     <li><a href="#ref-for-grammardef-strict-dynamic②">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-grammardef-strict-dynamic③">6.1.11.3. 
-    script-src Inline Check </a> <a href="#ref-for-grammardef-strict-dynamic④">(2)</a>
-    <li><a href="#ref-for-grammardef-strict-dynamic⑤">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-strict-dynamic③">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-strict-dynamic⑥">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-grammardef-strict-dynamic⑦">(2)</a> <a href="#ref-for-grammardef-strict-dynamic⑧">(3)</a>
+    <li><a href="#ref-for-grammardef-strict-dynamic④">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-grammardef-strict-dynamic⑤">(2)</a> <a href="#ref-for-grammardef-strict-dynamic⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-unsafe-hashed-attributes">
-   <b><a href="#grammardef-unsafe-hashed-attributes">#grammardef-unsafe-hashed-attributes</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="grammardef-unsafe-hashes">
+   <b><a href="#grammardef-unsafe-hashes">#grammardef-unsafe-hashes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-unsafe-hashed-attributes">6.6.2.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashed-attributes①">(2)</a>
-    <li><a href="#ref-for-grammardef-unsafe-hashed-attributes②">8.3. 
-      Usage of "'unsafe-hashed-attributes'" </a> <a href="#ref-for-grammardef-unsafe-hashed-attributes③">(2)</a>
+    <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.2.3. 
+    Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashes①">(2)</a>
+    <li><a href="#ref-for-grammardef-unsafe-hashes②">8.3. 
+      Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-report-sample">
@@ -8812,19 +8855,17 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.11.3. 
-    script-src Inline Check </a>
-    <li><a href="#ref-for-grammardef-nonce-source④">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.1.2. 
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source④">6.6.1.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.2.1. 
+    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.2.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑧">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.2.3. 
     Does element match source list for type and source? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑨">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-grammardef-nonce-source①⓪">8.2. 
+    <li><a href="#ref-for-grammardef-nonce-source⑧">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-grammardef-nonce-source⑨">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8847,16 +8888,14 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
     <li><a href="#ref-for-grammardef-hash-source③">6.1.11.1. 
     script-src Pre-request check </a> <a href="#ref-for-grammardef-hash-source④">(2)</a>
-    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.11.3. 
-    script-src Inline Check </a>
-    <li><a href="#ref-for-grammardef-hash-source⑥">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source⑥">6.6.2.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-hash-source⑧">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.2.3. 
     Does element match source list for type and source? </a>
-    <li><a href="#ref-for-grammardef-hash-source⑨">8.2. 
+    <li><a href="#ref-for-grammardef-hash-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
-    <li><a href="#ref-for-grammardef-hash-source①⓪">8.4. 
+    <li><a href="#ref-for-grammardef-hash-source⑨">8.4. 
       Allowing external JavaScript via hashes </a>
    </ul>
   </aside>
@@ -9342,7 +9381,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script-src⑤">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
     <li><a href="#ref-for-script-src⑦">8.3. 
-      Usage of "'unsafe-hashed-attributes'" </a>
+      Usage of "'unsafe-hashes'" </a>
     <li><a href="#ref-for-script-src⑧">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.html
+++ b/index.html
@@ -1211,13 +1211,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-<<<<<<< HEAD
-  <meta content="Bikeshed version 807fa228f70b24dc6f3ebea36719f85c4b567bb8" name="generator">
-=======
-  <meta content="Bikeshed version 60c7cf64c0efdd39a8c0261dfad14adb1da62902" name="generator">
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
+  <meta content="Bikeshed version 6abc9f98f620481a5031cd9b44944d60af9b79b9" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="287259b358ab5857c1567658a23de288919a2fb8" name="document-revision">
+  <meta content="16e22b394558d5ed9b81d5558a4d36a89f3b283b" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1508,15 +1504,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-12">12 June 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-05">5 June 2018</time></span></h2>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-06">6 June 2018</time></span></h2>
->>>>>>> Added "navigation" to the types that check for strict-dynamic
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-22">22 June 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1979,18 +1967,9 @@ of security-relevant policy decisions.</p>
       <p>The <code>'strict-dynamic'</code> source expression will now allow script which
   executes on a page to load more script via non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script">script</a></code> elements. Details are in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
      <li data-md="">
-<<<<<<< HEAD
-      <div class="wip">
-        The <code>'unsafe-hashed-attributes'</code> source expression will now allow event
-    handlers and style attributes to match hash source expressions. Details
-    in <a href="#unsafe-hashed-attributes-usage">§8.3 Usage of "'unsafe-hashed-attributes'"</a>. 
-       <p class="issue" id="issue-2a777f3d"><a class="self-link" href="#issue-2a777f3d"></a> <code>unsafe-hashed-attributes</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a></p>
-      </div>
-=======
       <p>The <code>'unsafe-hashes'</code> source expression will now allow event
   handlers, style attributes and <code>javascript:</code> navigation targets to match
   hashes. Details in <a href="#unsafe-hashes-usage">§8.3 Usage of "'unsafe-hashes'"</a>.</p>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li data-md="">
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
@@ -2562,11 +2541,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   navigate fetch</a> algorithm, and <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response">process a navigate response</a> algorithm to
   apply directive’s navigation checks, as well as inline checks for
-<<<<<<< HEAD
-  navigations to <code>javascript:</code>.</p>
-=======
   navigations to <code>javascript:</code> URLs.</p>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
       <p class="issue" id="issue-ed7a45a9"><a class="self-link" href="#issue-ed7a45a9"></a> W3C’s HTML is not based on Fetch, and does not
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a></p>
     </ol>
@@ -5222,11 +5197,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<<<<<<< HEAD
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑧">'strict-dynamic'</a>
-=======
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5255,13 +5226,8 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes②"><code>'unsafe-hashes'</code></a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.</p>
-<<<<<<< HEAD
-     <div class="example" id="example-9e76aa47">
-      <a class="self-link" href="#example-9e76aa47"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
-=======
      <div class="example" id="example-5d2d17c6">
       <a class="self-link" href="#example-5d2d17c6"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
       resembling a reasonable schedule: 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
 </pre>
@@ -5283,13 +5249,8 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <p>In <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>, hash <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①⓪">source expressions</a> could only match inlined
     script, but now that Subresource Integrity is widely deployed, we can expand
     the scope to enable externalized JavaScript as well.</p>
-<<<<<<< HEAD
-     <p>If multiple sets of integrity metadata are specified for a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑦">script</a></code>, the
-    request will match a policy’s <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source①⓪">hash-source</a>s if and only if <em>each</em> item in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑧">script</a></code>'s integrity metadata matches the policy.</p>
-=======
      <p>If multiple sets of integrity metadata are specified for a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑤">script</a></code>, the
     request will match a policy’s <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑨">hash-source</a>s if and only if <em>each</em> item in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑥">script</a></code>'s integrity metadata matches the policy.</p>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <div class="example" id="example-af80f2fd">
       <a class="self-link" href="#example-af80f2fd"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
       that ensures that the content matches their expectations. They do so by
@@ -5692,11 +5653,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy⑥">8.2. 
     Usage of "'strict-dynamic'" </a>
     <li><a href="#ref-for-header-content-security-policy⑦">8.3. 
-<<<<<<< HEAD
-      Usage of "'unsafe-hashed-attributes'" </a>
-=======
       Usage of "'unsafe-hashes'" </a>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-serialized-policy">
@@ -5858,16 +5815,6 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-<<<<<<< HEAD
-  <aside class="dfn-panel" data-for="term-for-dom-node-textcontent">
-   <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">https://dom.spec.whatwg.org/#dom-node-textcontent</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-node-textcontent">6.6.2.3. 
-    Does element match source list for type and source? </a>
-   </ul>
-  </aside>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <aside class="dfn-panel" data-for="term-for-sec-function-objects">
    <a href="https://tc39.github.io/ecma262#sec-function-objects">https://tc39.github.io/ecma262#sec-function-objects</a><b>Referenced in:</b>
    <ul>
@@ -6672,16 +6619,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-embed-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-<<<<<<< HEAD
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-event-handler-idl-attributes">6.6.2.3. 
-    Does element match source list for type and source? </a>
-   </ul>
-  </aside>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <aside class="dfn-panel" data-for="term-for-fallback-base-url">
    <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url</a><b>Referenced in:</b>
    <ul>
@@ -6990,21 +6927,12 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script⑤">6.6.2.1. 
     Is element nonceable? </a> <a href="#ref-for-script⑥">(2)</a>
     <li><a href="#ref-for-script⑦">6.6.2.3. 
-<<<<<<< HEAD
-    Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a> <a href="#ref-for-script⑨">(3)</a> <a href="#ref-for-script①⓪">(4)</a>
-    <li><a href="#ref-for-script①①">7.2. Nonce Stealing</a> <a href="#ref-for-script①②">(2)</a> <a href="#ref-for-script①③">(3)</a>
-    <li><a href="#ref-for-script①④">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script①⑤">(2)</a> <a href="#ref-for-script①⑥">(3)</a>
-    <li><a href="#ref-for-script①⑦">8.4. 
-      Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑧">(2)</a> <a href="#ref-for-script①⑨">(3)</a> <a href="#ref-for-script②⓪">(4)</a>
-=======
     Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a>
     <li><a href="#ref-for-script⑨">7.2. Nonce Stealing</a> <a href="#ref-for-script①⓪">(2)</a> <a href="#ref-for-script①①">(3)</a>
     <li><a href="#ref-for-script①②">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-script①③">(2)</a> <a href="#ref-for-script①④">(3)</a>
     <li><a href="#ref-for-script①⑤">8.4. 
       Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑥">(2)</a> <a href="#ref-for-script①⑦">(3)</a> <a href="#ref-for-script①⑧">(4)</a>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-set-the-frozen-base-url">
@@ -7032,19 +6960,8 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.2.3. 
-<<<<<<< HEAD
-    Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a> <a href="#ref-for-the-style-element③">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-script-text">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#dom-script-text">https://html.spec.whatwg.org/multipage/scripting.html#dom-script-text</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-script-text">6.6.2.3. 
-    Does element match source list for type and source? </a>
-=======
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
@@ -7612,10 +7529,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
      <li><span class="dfn-paneled" id="term-for-concept-shadow-including-root" style="color:initial">shadow-including root</span>
      <li><span class="dfn-paneled" id="term-for-dom-event-target" style="color:initial">target</span>
-<<<<<<< HEAD
-     <li><span class="dfn-paneled" id="term-for-dom-node-textcontent" style="color:initial">textContent</span>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
     </ul>
    <li>
     <a data-link-type="biblio">[ECMA262]</a> defines the following terms:
@@ -7691,10 +7604,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-document-2" style="color:initial">document</span>
      <li><span class="dfn-paneled" id="term-for-parse-error-duplicate-attribute" style="color:initial">duplicate-attribute</span>
      <li><span class="dfn-paneled" id="term-for-the-embed-element" style="color:initial">embed</span>
-<<<<<<< HEAD
-     <li><span class="dfn-paneled" id="term-for-event-handler-idl-attributes" style="color:initial">event handler idl attribute</span>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li><span class="dfn-paneled" id="term-for-fallback-base-url" style="color:initial">fallback base url</span>
      <li><span class="dfn-paneled" id="term-for-forced-sandboxing-flag-set" style="color:initial">forced sandboxing flag set</span>
      <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
@@ -7735,10 +7644,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-setinterval" style="color:initial">setInterval()</span>
      <li><span class="dfn-paneled" id="term-for-dom-settimeout" style="color:initial">setTimeout()</span>
      <li><span class="dfn-paneled" id="term-for-the-style-element" style="color:initial">style</span>
-<<<<<<< HEAD
-     <li><span class="dfn-paneled" id="term-for-dom-script-text" style="color:initial">text</span>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
      <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
      <li><span class="dfn-paneled" id="term-for-attr-embed-type" style="color:initial">type</span>
      <li><span class="dfn-paneled" id="term-for-update-a-style-block" style="color:initial">update a style block</span>
@@ -7921,7 +7826,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 24 May 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 15 June 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -7990,10 +7895,6 @@ rest of Google’s CSP Cabal.</p>
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-<<<<<<< HEAD
-   <div class="issue"> <code>unsafe-hashed-attributes</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a><a href="#issue-2a777f3d"> ↵ </a></div>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
    <div class="issue"> <code>disown-opener</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/194">&lt;https://github.com/w3c/webappsec-csp/issues/194></a><a href="#issue-f67725cb"> ↵ </a></div>
    <div class="issue"> Is this kind of thing specified anywhere? I didn’t see anything
   that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-ee968c9a"> ↵ </a></div>
@@ -8031,10 +7932,6 @@ rest of Google’s CSP Cabal.</p>
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-4592ac7e"> ↵ </a></div>
-<<<<<<< HEAD
-   <div class="issue"> Work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/13">&lt;https://github.com/w3c/webappsec-csp/issues/13></a><a href="#issue-0e25e974"> ↵ </a></div>
-=======
->>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   </div>
   <aside class="dfn-panel" data-for="content-security-policy">
    <b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>

--- a/index.html
+++ b/index.html
@@ -1217,7 +1217,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version 60c7cf64c0efdd39a8c0261dfad14adb1da62902" name="generator">
 >>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="d37f31c13c55cafa5470b082ec93b4668039fc24" name="document-revision">
+  <meta content="287259b358ab5857c1567658a23de288919a2fb8" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1509,10 +1509,14 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
 <<<<<<< HEAD
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-12">12 June 2018</time></span></h2>
 =======
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-05">5 June 2018</time></span></h2>
 >>>>>>> Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes', reworked it to work with 'javascript:' navigations and removed WIP tags
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-06-06">6 June 2018</time></span></h2>
+>>>>>>> Added "navigation" to the types that check for strict-dynamic
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2670,7 +2674,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   definition of a particular type of behavior (script execution, style
   application, event handlers, etc.), and "<code>Blocked</code>" otherwise:</p>
     <p class="note" role="note"><span>Note:</span> The valid values for <var>type</var> are "<code>script</code>", "<code>script attribute</code>",
-  "<code>style</code>", "<code>style attribute</code>", and "<code>navigation</code>".</p>
+  "<code>style</code>", and "<code>style attribute</code>".</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
@@ -4934,7 +4938,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md="">
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑥"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑥"><code>hash-source</code></a> grammar, return "<code>Does Not Allow</code>".</p>
        <li data-md="">
-        <p>If <var>type</var> is "<code>script</code>" or "<code>script attribute</code>" and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
+        <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>"
+  and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
         <p class="note" role="note"><span>Note:</span> <code>'strict-dynamic'</code> only applies to scripts, not other resource
   types. Usage is explained in more detail in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
        <li data-md="">

--- a/index.src.html
+++ b/index.src.html
@@ -4034,8 +4034,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       1.  If |expression| matches the <a grammar>`nonce-source`</a> or
           <a grammar>`hash-source`</a> grammar, return "`Does Not Allow`".
 
-      2.  If |type| is "`script`" or "`script attribute`" and |expression|
-          matches the <a grammar>keyword-source</a>
+      2.  If |type| is "`script`", "`script attribute`" or "`navigation`"
+          and |expression| matches the <a grammar>keyword-source</a>
           "<a grammar>`'strict-dynamic'`</a>", return "`Does Not Allow`".
 
           Note: `'strict-dynamic'` only applies to scripts, not other resource

--- a/index.src.html
+++ b/index.src.html
@@ -338,13 +338,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       executes on a page to load more script via non-<a>"parser-inserted"</a>
       <{script}> elements. Details are in [[#strict-dynamic-usage]].
 
-  8.  <div class="wip">
-        The `'unsafe-hashed-attributes'` source expression will now allow event
-        handlers and style attributes to match hash source expressions. Details
-        in [[#unsafe-hashed-attributes-usage]].
-
-        ISSUE(w3c/webappsec-csp#13): `unsafe-hashed-attributes` is a work in progress.
-      </div>
+  8.  The `'unsafe-hashes'` source expression will now allow event
+      handlers, style attributes and `javascript:` navigation targets to match
+      hashes. Details in [[#unsafe-hashes-usage]].
 
   9.  The <a>source expression</a> matching has been changed to require explicit presence
       of any non-<a>network scheme</a>, rather than <a>local scheme</a>,
@@ -535,7 +531,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   4.  An <dfn for="directive" export>inline check</dfn>, which takes an {{Element}} a
       type string, and a source string as arguments, and is executed during
-      [[#should-block-inline]]. This algorithm returns "`Allowed`" unless
+      [[#should-block-inline]] and during [[#should-block-navigation-request]] for
+      `javascript:` requests. This algorithm returns "`Allowed`" unless
       otherwise specified.
 
   5.  An <dfn for="directive" export>initialization</dfn>, which takes a {{Document}}
@@ -608,7 +605,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
     ; Keywords:
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>"
-                     / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashed-attributes'</dfn>" /
+                     / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>" /
                      / "<dfn>'report-sample'</dfn>" / "<dfn>'unsafe-allow-redirects'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
@@ -1148,7 +1145,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       navigate fetch</a> algorithm, and [[#should-block-navigation-response]]
       is called during the <a>process a navigate response</a> algorithm to
       apply directive's navigation checks, as well as inline checks for
-      navigations to `javascript:`.
+      navigations to `javascript:` URLs.
 
       ISSUE(w3c/html#548): W3C's HTML is not based on Fetch, and does not
       have a <a>process a navigate response</a> algorithm into which to hook.
@@ -1284,8 +1281,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
             2.  Otherwise, let |violation| be the result of executing
                 [[#create-violation-for-global]] on the <a>current settings
                 object</a>'s <a for="environment settings object">global object</a>, |policy|,
-                and "`style-src`" if |type| is "`style`" or "`style-attribute`",
-                or "`script-src`" otherwise.
+                and |directive|'s <a for="directive">name</a>.
 
             3.  Set |violation|'s <a for="violation">resource</a> to "`inline`".
 
@@ -1347,8 +1343,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
             1.  For each |directive| in |policy|:
 
                 1.  If |directive|'s <a for="directive">inline check</a>
-                    returns "`Allowed`" when executed upon |navigation request|,
-                    |type|, |source|, and |target|, skip to the next |directive|.
+                    returns "`Allowed`" when executed upon `null`,
+                    "`navigation`" and |navigation request|'s <a for="request">url</a>,
+                    skip to the next |directive|.
 
                 2.  Otherwise, let |violation| be the result of executing
                     [[#create-violation-for-global]] on |source|'s <a>relevant global
@@ -2656,8 +2653,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       Note: If a user agent implements non-standard sinks like `setImmediate()`
       or `execScript()`, they SHOULD also be gated on "`unsafe-eval`".
 
-  5.  Navigation to `javascript:` URLs MUST pass through [[#should-block-inline]]. These navigations
-      will only execute script if every policy allows inline script, as per #3 above.
+  5.  Navigation to `javascript:` URLs MUST pass through [[#script-src-inline]].
 
   <h5 algorithm id="script-src-pre-request">
     `script-src` Pre-request check
@@ -2774,37 +2770,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
 
-  1.  If |type| is "`script attribute`" or "`script`":
+  1.  If |type| is "`script`", "`script attribute`" or "`navigation`":
 
-      1.  Assert: |element| is not `null`.
+      1.  Assert: |element| is not `null` or |type| is "`navigation`".
 
       2.  If the result of executing [[#match-element-to-source-list]] on
           |element|, this directive's <a for="directive">value</a>, |type|,
           and |source|, is "`Does Not Match`", return "`Blocked`".
 
-  2.  If |type| is "`navigation`":
-
-      1.  Let |unsafe-inline flag| be `false`.
-
-      2.  For each |expression| in this directive's
-          <a for="directive">value</a>:
-
-          1.  If |expression| matches the <a grammar>`nonce-source`</a> or
-              <a grammar>`hash-source`</a> grammar, return "`Blocked`".
-
-          2.  If |expression| matches the <a grammar>keyword-source</a>
-              "<a grammar>`'strict-dynamic'`</a>", return "`Blocked`".
-
-          3.  If |expression| matches the <a grammar>keyword-source</a>
-              "<a grammar>`'unsafe-inline'`</a>", set |unsafe-inline flag| to `true`.
-
-      3.  If |unsafe-inline flag| is `false`, return "`Blocked`".
-
-      Note: Navigating to a `javascript:` URL is allowed only in the presence
-      of "<a grammar>`'unsafe-inline'`</a>" that isn't overridden by a nonce,
-      hash, or "<a grammar>`'strict-dynamic'`</a>".
-
-  3.  Return "`Allowed`".
+  2.  Return "`Allowed`".
 
   <h4 id="directive-style-src">`style-src`</h4>
 
@@ -4112,19 +4086,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   (|type|), and a string (|source|), this algorithm returns "`Matches`" or
   "`Does Not Match`".
 
-  1.  Assert: |source| contains the value of a <{script}> element's
-      {{HTMLScriptElement/text}} IDL attribute, the value of a <{style}>
-      element's {{Node/textContent}} IDL attribute, or the value of one of a
-      <{script}> element's <a>event handler IDL attribute</a>.
+  Note: |source| will be interpreted with the encoding of the page in which it
+  is embedded. See the integration points in [[#html-integration]] for more detail.
 
-      Note: This means that |source| will be interpreted with the encoding
-      of the page in which it is embedded. See the integration points
-      in [[#html-integration]] for more detail.
-
-  2.  If [[#allow-all-inline]] returns "`Allows`" given |list| and |type|,
+  1.  If [[#allow-all-inline]] returns "`Allows`" given |list| and |type|,
       return "`Matches`".
 
-  3.  If |type| is "`script`" or "`style`", and [[#is-element-nonceable]]
+  2.  If |type| is "`script`" or "`style`", and [[#is-element-nonceable]]
       returns "`Nonceable`" when executed upon |element|:
 
       1.  For each |expression| in |list|:
@@ -4135,18 +4103,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
               <a grammar>`base64-value`</a> part, return "`Matches`".
 
       Note: Nonces only apply to inline <{script}> and inline <{style}>, not to
-      attributes of either element.
+      attributes of either element or to `javascript:` navigations.
 
-  4.  Let |hashes match attributes| be `false`.
+  3.  Let |unsafe-hashes flag| be `false`.
 
-  5.  For each |expression| in |list|:
+  4.  For each |expression| in |list|:
 
       1.  If |expression| is an <a>ASCII case-insensitive</a> match for the
           <a grammar>`keyword-source`</a>
-          "<a grammar>`'unsafe-hashed-attributes'`</a>",
-          set |hashes match attributes| to `true`. Break out of the loop.
+          "<a grammar>`'unsafe-hashes'`</a>",
+          set |unsafe-hashes flag| to `true`. Break out of the loop.
 
-  6.  If |type| is "`script`" or "`style`", or |hashes match attributes| is
+  5.  If |type| is "`script`" or "`style`", or |unsafe-hashes flag| is
       `true`:
 
       1.  For each |expression| in |list|:
@@ -4183,10 +4151,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                       "`Matches`".
 
       Note: Hashes apply to inline <{script}> and inline <{style}>. If the
-      "<a grammar>`'unsafe-hashed-attributes'`</a>" source expression is present,
-      they will also apply to event handlers and style attributes.
+      "<a grammar>`'unsafe-hashes'`</a>" source expression is present,
+      they will also apply to event handlers, style attributes and `javascript:`
+      navigations.
 
-  7.  Return "`Does Not Match`".
+  6.  Return "`Does Not Match`".
 </section>
 
 <!-- Big text: Security -->
@@ -4240,7 +4209,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   second `src` attribute which is helpfully discarded as duplicate by the parser.
 
   The [[#is-element-nonceable]] algorithm attempts to mitigate this specific
-  attack by walking through <{script}> element attributes, looking for the
+  attack by walking through <{script}> or <{style}> element attributes, looking for the
   string "<code>&lt;script</code>" or "<code>&lt;style</code>" in their names or values.
 
   <h3 id="security-nonce-retargeting">Nonce Retargeting</h3>
@@ -4496,21 +4465,19 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     <{script}> elements which are <a>"parser-inserted"</a>.
   </div>
 
-  <section class="wip">
-    <h3 id="unsafe-hashed-attributes-usage">
-      Usage of "`'unsafe-hashed-attributes'`"
+  <section>
+    <h3 id="unsafe-hashes-usage">
+      Usage of "`'unsafe-hashes'`"
     </h3>
 
     <em>This section is not normative.</em>
-
-    ISSUE(w3c/webappsec-csp#13): Work in progress.
 
     Legacy websites and websites with legacy dependencies might find it difficult
     to entirely externalize event handlers. These sites could enable such handlers
     by allowing `'unsafe-inline'`, but that's a big hammer with a lot of
     associated risk (and cannot be used in conjunction with nonces or hashes).
 
-    The "<a grammar>`'unsafe-hashed-attributes'`</a>" source expression aims to make
+    The "<a grammar>`'unsafe-hashes'`</a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.
 
@@ -4523,14 +4490,14 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       </pre>
 
       Rather than reducing security by specifying "`'unsafe-inline'`", they decide to use
-      "`'unsafe-hashed-attributes'`" along with a hash source expression, as follows:
+      "`'unsafe-hashes'`" along with a hash source expression, as follows:
 
       <pre>
-        <a>Content-Security-Policy</a>:  <a>script-src</a> <a grammar>'unsafe-hashed-attributes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+        <a>Content-Security-Policy</a>:  <a>script-src</a> <a grammar>'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
       </pre>
     </div>
 
-    The capabilities `'unsafe-hashed-attributes'` provides is useful for legacy sites, but should be
+    The capabilities `'unsafe-hashes'` provides is useful for legacy sites, but should be
     avoided for modern sites. In particular, note that hashes allow a particular script to execute,
     but do not ensure that it executes in the way a developer intends. If an interesting capability
     is exposed as an inline event handler (say `<a onclick="transferAllMyMoney()">Transfer</a>`),


### PR DESCRIPTION
Renamed 'unsafe-hashed-attributes' to 'unsafe-hashes'
Reworked it to work with 'javascript:' navigations
Removed WIP tags

Hopefully this explainer has been seen enough that this PR won't surprise anyone:
https://docs.google.com/document/d/1_nYS4gWYO2Oh8rYDyPglXIKNsgCRVhmjHqWlTAHst7c/edit?usp=sharing


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/311.html" title="Last updated on Jun 22, 2018, 3:37 PM GMT (a394547)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/311/778fe06...andypaicu:a394547.html" title="Last updated on Jun 22, 2018, 3:37 PM GMT (a394547)">Diff</a>