### PR TITLE
Refactored fetch directives for readability and logic.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
+  <meta content="Bikeshed version a816d78e14132d4d4d2ee44ccaf1b8bc90ac75d5" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="86643a535c7102bc8ef9e024596ca9ceb8928cae" name="document-revision">
+  <meta content="4cc65c7755553badce60368e5aa57fc96065349f" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1448,64 +1448,64 @@ pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-11">11 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-08-17">17 August 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1517,7 +1517,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-csp/commits/master/index.src.html">https://github.com/w3c/webappsec-csp/commits/master/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BCSP3%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[CSP3] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BCSP3%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[CSP3] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="56384"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
      <dt>Participate:
@@ -1891,7 +1891,7 @@ of security-relevant policy decisions.</p>
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
     <p><em>This section is not normative.</em></p>
-    <p>This document defines <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="content-security-policy">Content Security Policy</dfn> (CSP), a tool
+    <p>This document defines <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="content-security-policy">Content Security Policy</dfn> (CSP), a tool
   which developers can use to lock down their applications in various ways,
   mitigating the risk of content injection vulnerabilities such as cross-site scripting, and
   reducing the privilege with which their applications execute.</p>
@@ -1918,28 +1918,28 @@ of security-relevant policy decisions.</p>
     <h3 class="heading settled" data-level="1.2" id="goals"><span class="secno">1.2. </span><span class="content">Goals</span><a class="self-link" href="#goals"></a></h3>
     <p>Content Security Policy aims to do to a few related things:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Mitigate the risk of content-injection attacks by giving developers
   fairly granular control over</p>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>The resources which can be requested (and subsequently embedded or
   executed) on behalf of a specific <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker">Worker</a></code></p>
-       <li data-md="">
+       <li data-md>
         <p>The execution of inline script</p>
-       <li data-md="">
+       <li data-md>
         <p>Dynamic code execution (via <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-eval-x" id="ref-for-sec-eval-x">eval()</a></code> and similar constructs)</p>
-       <li data-md="">
+       <li data-md>
         <p>The application of inline style</p>
       </ul>
-     <li data-md="">
+     <li data-md>
       <p>Mitigate the risk of attacks which require a resource to be embedded
   in a malicious context (the "Pixel Perfect" attack described in <a data-link-type="biblio" href="#biblio-timing">[TIMING]</a>, for example) by giving developers granular control over the
   origins which can embed a given resource.</p>
-     <li data-md="">
+     <li data-md>
       <p>Provide a policy framework which allows developers to reduce the privilege
   of their applications.</p>
-     <li data-md="">
+     <li data-md>
       <p>Provide a reporting mechanism which allows developers to detect flaws
   being exploited in the wild.</p>
     </ol>
@@ -1947,61 +1947,61 @@ of security-relevant policy decisions.</p>
     <p>This document describes an evolution of the Content Security Policy Level 2
   specification <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>. The following is a high-level overview of the changes:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>The specification has been rewritten from the ground up in terms of the <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> specification, which should make it simpler to integrate CSP’s
   requirements and restrictions with other specifications (and with
   Service Workers in particular).</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>child-src</code> model has been substantially altered:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>The <code>frame-src</code> directive, which was deprecated in CSP Level
  2, has been undeprecated, but continues to defer to <code>child-src</code> if
  not present (which defers to <code>default-src</code> in turn).</p>
-       <li data-md="">
+       <li data-md>
         <p>A <code>worker-src</code> directive has been added, deferring to <code>child-src</code> if not present (which likewise defers to <code>script-src</code> and
  eventually <code>default-src</code>).</p>
-       <li data-md="">
+       <li data-md>
         <p>Dedicated workers now always inherit their creator’s policy.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>The URL matching algorithm now treats insecure schemes and ports as
   matching their secure variants. That is, the source expression <code>http://example.com:80</code> will match both <code>http://example.com:80</code> and <code>https://example.com:443</code>.</p>
       <p>Likewise, <code>'self'</code> now matches <code>https:</code> and <code>wss:</code> variants of the page’s
   origin, even on pages whose scheme is <code>http</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Violation reports generated from inline script or style will now report
   "<code>inline</code>" as the blocked resource. Likewise, blocked <code>eval()</code> execution
   will report "<code>eval</code>" as the blocked resource.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>manifest-src</code> directive has been added.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>report-uri</code> directive is deprecated in favor of the new <code>report-to</code> directive, which relies on <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a> as infrastructure.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>'strict-dynamic'</code> source expression will now allow script which
   executes on a page to load more script via non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script">script</a></code> elements. Details are in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>'unsafe-hashes'</code> source expression will now allow event
   handlers, style attributes and <code>javascript:</code> navigation targets to match
   hashes. Details in <a href="#unsafe-hashes-usage">§8.3 Usage of "'unsafe-hashes'"</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
   unless that non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme①">network scheme</a> is the same as the scheme of protected resource,
   as described in <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Hash-based source expressions may now match external scripts if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①">script</a></code> element that triggers the request specifies a set of integrity
   metadata which is listed in the current policy. Details in <a href="#external-hash">§8.4 Allowing external JavaScript via hashes</a>.</p>
-     <li data-md="">
+     <li data-md>
       <div class="wip">
         The <a data-link-type="dfn" href="#disown-opener" id="ref-for-disown-opener"><code>disown-opener</code></a> directive ensures that a resource can’t be opened
     in such a way as to give another browsing context control over its contents. 
        <p class="issue" id="issue-f67725cb"><a class="self-link" href="#issue-f67725cb"></a> <code>disown-opener</code> is a work in progress. <a href="https://github.com/w3c/webappsec-csp/issues/194">&lt;https://github.com/w3c/webappsec-csp/issues/194></a></p>
       </div>
-     <li data-md="">
+     <li data-md>
       <p>The <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to"><code>navigate-to</code></a> directive gives a resource control over the endpoints
   to which it can initiate navigation.</p>
-     <li data-md="">
+     <li data-md>
       <p>Reports generated for inline violations will contain a <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample">sample</a> attribute if the relevant directive contains the <a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample"><code>'report-sample'</code></a> expression.</p>
     </ol>
    </section>
@@ -2013,90 +2013,90 @@ of security-relevant policy decisions.</p>
     <p>This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
     <h3 class="heading settled" data-level="2.2" id="framework-policy"><span class="secno">2.2. </span><span class="content">Policies</span><a class="self-link" href="#framework-policy"></a></h3>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
   and restricted behaviors, and may be applied to a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope">WorkerGlobalScope</a></code>, or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope">WorkletGlobalScope</a></code> as described in <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>.</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-directive-set">directive set</dfn>, which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-directive-set">directive set</dfn>, which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered
   set</a> of <a data-link-type="dfn" href="#directives" id="ref-for-directives">directives</a> that define the policy’s implications when applied.</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-disposition">disposition</dfn>, which is either
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-disposition">disposition</dfn>, which is either
   "<code>enforce</code>" or "<code>report</code>".</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-source">source</dfn>, which is either "<code>header</code>"
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-source">source</dfn>, which is either "<code>header</code>"
   or "<code>meta</code>".</p>
-    <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="csp-list">CSP list</dfn>.</p>
-    <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export="" id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
+    <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="csp-list">CSP list</dfn>.</p>
+    <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
   series of <a data-link-type="dfn" href="#serialized-directive" id="ref-for-serialized-directive">serialized directives</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy">serialized-policy</dfn> = <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a> ";" [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3①">OWS</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive①">serialized-directive</a> ] )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> = <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a> ";" [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3①">OWS</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive①">serialized-directive</a> ] )
                     ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3②">OWS</a> is defined in section 3.2.3 of RFC 7230
 </pre>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
   series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp">serialized CSPs</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
+<pre><dfn data-dfn-type="grammar" data-export id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
                     ; The '#' rule is defined in section 7 of RFC 7230
 </pre>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP" data-level="2.2.1" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a serialized CSP </span><a class="self-link" href="#parse-serialized-policy"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
   following steps.</p>
     <p>This algorithm returns a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③">Content Security Policy object</a>. If <var>serialized</var> could not be
   parsed, the object’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set">directive set</a> will be empty.</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>Let <var>policy</var> be a new <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④">policy</a> with an empty <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①">directive set</a>, a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source②">source</a> of <var>source</var>, and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①">disposition</a> of <var>disposition</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting</a> <var>serialized</var> on
   the U+003B SEMICOLON character (<code>;</code>):</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace" id="ref-for-strip-leading-and-trailing-ascii-whitespace">Strip leading and trailing ASCII whitespace</a> from <var>token</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>token</var> is an empty string, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
         <p>In this case, the user agent SHOULD notify developers that a duplicate directive was
   ignored. A console warning might be appropriate, for example.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>directive value</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>token</var> on
   ASCII whitespace</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>directive</var> be a new <a data-link-type="dfn" href="#directives" id="ref-for-directives②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①">name</a> is <var>directive name</var>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value">value</a> is <var>directive value</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>directive</var> to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set③">directive set</a>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>policy</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP list" data-level="2.2.2" id="parse-serialized-policy-list"><span class="secno">2.2.2. </span><span class="content"> Parse a serialized CSP list </span><a class="self-link" href="#parse-serialized-policy-list"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source③">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②">disposition</a> (<var>disposition</var>), execute the following
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source③">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②">disposition</a> (<var>disposition</var>), execute the following
   steps.</p>
     <p>This algorithm returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤">Content Security Policy objects</a>. If <var>list</var> cannot be
   parsed, the returned list will be empty.</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>Let <var>policies</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>list</var> on commas</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp">parsing</a> <var>token</var>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source④">source</a> of <var>source</var>, and <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition③">disposition</a> of <var>disposition</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set④">directive set</a> is empty, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">Append</a> <var>policy</var> to <var>policies</var>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>policies</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.3" id="framework-directives"><span class="secno">2.3. </span><span class="content">Directives</span><a class="self-link" href="#framework-directives"></a></h3>
-    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>), each of which controls a specific behavior. The directives
+    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>), each of which controls a specific behavior. The directives
   defined in this document are described in detail in <a href="#csp-directives">§6 Content Security Policy Directives</a>.</p>
-    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is a
+    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is a
   non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3③">RWS</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-directive-value">directive-value</dfn>      = *( %x09 / %x20-%x2B / %x2D-%x3A / %x3C-%7E )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3③">RWS</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( %x09 / %x20-%x2B / %x2D-%x3A / %x3C-%7E )
                        ; Directive values may contain whitespace and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1②">VCHAR</a> characters,
                        ; excluding ";" and ","
 
@@ -2105,99 +2105,99 @@ of security-relevant policy decisions.</p>
 </pre>
     <p><a data-link-type="dfn" href="#directives" id="ref-for-directives④">Directives</a> have a number of associated algorithms:</p>
     <ol>
-     <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
+     <li data-md>
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
   during <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
-     <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
+     <li data-md>
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
+     <li data-md>
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md="">
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
+     <li data-md>
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
   type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a>, and a source string as arguments,
   and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a> for <code>javascript:</code> requests. This
   algorithm returns "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md="">
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+     <li data-md>
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
-     <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
+     <li data-md>
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md="">
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
+     <li data-md>
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing contexts</a>, a check type string ("<code>source</code>"
   or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
-    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
-  executed. Each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> represents one of the following types of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="source expression" id="source-expression">source
+    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
+  executed. Each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> represents one of the following types of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="source expression" id="source-expression">source
   expression</dfn>:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Keywords such as <a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none"><code>'none'</code></a> and <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> (which match nothing and the current
   URL’s origin, respectively)</p>
-     <li data-md="">
+     <li data-md>
       <p>Serialized URLs such as <code>https://example.com/path/to/file.js</code> (which matches a specific file) or <code>https://example.com/</code> (which matches everything on that origin)</p>
-     <li data-md="">
+     <li data-md>
       <p>Schemes such as <code>https:</code> (which matches any resource having
   the specified scheme)</p>
-     <li data-md="">
+     <li data-md>
       <p>Hosts such as <code>example.com</code> (which matches any resource on
   the host, regardless of scheme) or <code>*.example.com</code> (which
   matches any resource on the host’s subdomains (and any of
   its subdomains' subdomains, and so on))</p>
-     <li data-md="">
+     <li data-md>
       <p>Nonces such as <code>'nonce-ch4hvvbHDpv7xCSvXCs3BrNggHdTzxUA'</code> (which can match
   specific elements on a page)</p>
-     <li data-md="">
+     <li data-md>
       <p>Digests such as <code>'sha256-abcd...'</code> (which can match specific
   elements on a page)</p>
     </ol>
-    <p>A <dfn data-dfn-type="dfn" data-export="" id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
+    <p>A <dfn data-dfn-type="dfn" data-export id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
   whitespace-delimited series of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①">source expressions</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑤">RWS</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-none">'none'</dfn>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑤">RWS</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
                          / <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source">nonce-source</a> / <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source">hash-source</a>
 
 ; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-scheme-source">scheme-source</dfn> = <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part">scheme-part</a> ":"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-scheme-source">scheme-source</dfn> = <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part">scheme-part</a> ":"
 
 ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-source">host-source</dfn> = [ <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part①">scheme-part</a> "://" ] <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part">host-part</a> [ ":" <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part">port-part</a> ] [ <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part">path-part</a> ]
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-scheme-part">scheme-part</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1">scheme</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-source">host-source</dfn> = [ <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part①">scheme-part</a> "://" ] <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part">host-part</a> [ ":" <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part">port-part</a> ] [ <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part">path-part</a> ]
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-scheme-part">scheme-part</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1">scheme</a>
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1①">scheme</a> is defined in section 3.1 of RFC 3986.
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-part">host-part</dfn>   = "*" / [ "*." ] 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char">host-char</a> *( "." 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char①">host-char</a> )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑥">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">DIGIT</a> / "-"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "*"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-part">host-part</dfn>   = "*" / [ "*." ] 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char">host-char</a> *( "." 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char①">host-char</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑥">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">DIGIT</a> / "-"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "*"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a>
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3①">path-absolute</a> is defined in section 3.3 of RFC 3986.
 
 ; Keywords:
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-keyword-source">keyword-source</dfn> = "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-self">'self'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-inline">'unsafe-inline'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-eval">'unsafe-eval'</dfn>"
-                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-hashes">'unsafe-hashes'</dfn>" /
-                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-report-sample">'report-sample'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</dfn>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-keyword-source">keyword-source</dfn> = "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-self">'self'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-inline">'unsafe-inline'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-eval">'unsafe-eval'</dfn>"
+                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-hashes">'unsafe-hashes'</dfn>" /
+                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-report-sample">'report-sample'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</dfn>"
 
 ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
 
 ; Nonces: 'nonce-[nonce goes here]'
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-nonce-source">nonce-source</dfn>  = "'nonce-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a> "'"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-nonce-source">nonce-source</dfn>  = "'nonce-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a> "'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
 
 ; Digests: 'sha256-[digest goes here]'
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-hash-source">hash-source</dfn>    = "'" <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm">hash-algorithm</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value①">base64-value</a> "'"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-hash-algorithm">hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-source">hash-source</dfn>    = "'" <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm">hash-algorithm</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value①">base64-value</a> "'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-algorithm">hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
 </pre>
     <p>The <a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char②">host-char</a> production intentionally contains only ASCII
   characters; internationalized domain names cannot be entered directly as part
@@ -2212,31 +2212,31 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   reduce the complexity for the server-side operator (encodings, etc), but the user agent
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="violation">violation</dfn> represents an action or resource which goes against the
   set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-global-object">global object</dfn>, which
   is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
   which the global object was instantiated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation③">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-resource">resource</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation③">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-resource">resource</dfn>, which is
   either <code>null</code>, "<code>inline</code>", "<code>eval</code>", or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①">URL</a></code>. It represents the resource
   which violated the policy.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
   enforcement caused the violation.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-source-file">source file</dfn>, which is
   either <code>null</code> or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url③">URL</a></code>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑨">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-line-number">line number</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑨">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-line-number">line number</dfn>, which is
   a non-negative integer.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①⓪">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-column-number">column number</dfn>, which
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①⓪">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-column-number">column number</dfn>, which
   is a non-negative integer.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-element">element</dfn>, which is either <code>null</code> or an element.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-sample">sample</dfn>,
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-element">element</dfn>, which is either <code>null</code> or an element.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-sample">sample</dfn>,
   which is a string. It is the empty string unless otherwise specified.</p>
     <p class="note" role="note"><span>Note:</span> A <a data-link-type="dfn" href="#violation" id="ref-for-violation①③">violation</a>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample①">sample</a> will be populated with the first 40
   characters of an inline script, event handler, or style that caused an violation. Violations
@@ -2244,10 +2244,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
   object</a> is <var>global</var>, <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy">policy</a> is <var>policy</var>, <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive">effective directive</a> is <var>directive</var>, and <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource">resource</a> is <code>null</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the user agent is currently executing script, and can extract a source
   file’s URL, line number, and column number from the <var>global</var>, set <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file">source file</a>, <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number">line
   number</a>, and <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number">column number</a> accordingly.</p>
@@ -2256,15 +2256,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p class="note" role="note"><span>Note:</span> User agents need to ensure that the <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file①">source file</a> is the URL requested by
   the page, pre-redirects. If that’s not possible, user agents need to strip the URL down to an
   origin to avoid unintentional leakage.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①">Window</a></code> object, set <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer">referrer</a> to <var>global</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#dom-document-2" id="ref-for-dom-document-2">document</a></code>'s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer" id="ref-for-dom-document-referrer">referrer</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status">status</a> to the HTTP status code
   for the resource associated with <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object②">global
   object</a>.</p>
       <p class="issue" id="issue-d43ce829"><a class="self-link" href="#issue-d43ce829"></a> How, exactly, do we get the status code? We don’t actually store it
   anywhere.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, policy, and directive" data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-request"></a></h4>
@@ -2272,13 +2272,13 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global">global object</a>, <var>policy</var>, and <var>directive</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①">resource</a> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a>.</p>
       <p class="note" role="note"><span>Note:</span> We use <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a>, and <em>not</em> its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>, as the latter might contain information
   about redirect targets to which the page MUST NOT be given access.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>violation</var>.</p>
     </ol>
    </section>
@@ -2289,7 +2289,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
+    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a>
 </pre>
@@ -2307,7 +2307,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>When the user agent receives a <code>Content-Security-Policy</code> header field, it
   MUST <a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#parse-serialized-policy" id="ref-for-parse-serialized-policy">parse</a> and <a data-link-type="dfn" href="#enforced" id="ref-for-enforced">enforce</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp④">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a>, <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <h3 class="heading settled" data-level="3.2" id="cspro-header"><span class="secno">3.2. </span><span class="content"> The <code>Content-Security-Policy-Report-Only</code> HTTP Response Header Field </span><a class="self-link" href="#cspro-header"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
+    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
 </pre>
@@ -2334,7 +2334,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv①">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<code>Content-Security-Policy</code>". For example:</p>
     <div class="example" id="example-5b9d2837">
      <a class="self-link" href="#example-5b9d2837"></a> 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">meta</span> <span class="na">http-equiv</span><span class="o">=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content</span><span class="o">=</span><span class="s">"script-src 'self'"</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>meta</c-> <c- e>http-equiv</c-><c- o>=</c-><c- s>"Content-Security-Policy"</c-> <c- e>content</c-><c- o>=</c-><c- s>"script-src 'self'"</c-><c- p>></c->
 </pre>
     </div>
     <p>Implementation details can be found in HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy" id="ref-for-attr-meta-http-equiv-content-security-policy">Content Security Policy
@@ -2367,12 +2367,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   or allowed, and about whether a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> should be replaced
   with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> is called as part of step #5 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check">pre-request checks</a> to be executed against each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑦">request</a> before it hits the network,
   and against each redirect that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑧">request</a> might go through on its
   way to reaching a resource.</p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> is called as part of step #13 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
@@ -2382,10 +2382,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   user agent needs to <a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#parse-serialized-policy" id="ref-for-parse-serialized-policy②">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a> has an associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list">CSP list</a> which
   contains any policy objects delivered in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#set-response-csp-list">§4.1.1 Set response’s CSP list</a> is called in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithms.</p>
       <p class="note" role="note"><span>Note:</span> These two calls should ensure that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑨">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list①">CSP list</a> is set, regardless of how the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⓪">response</a> is created. If we hit the network (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch①">HTTP-network
   fetch</a>, then we parse the policy before we handle the <code>Set-Cookie</code> header. If we get a response from a Service Worker (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch①">HTTP fetch</a>,
@@ -2396,16 +2396,16 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①①">response</a> (<var>response</var>), this algorithm evaluates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list①">header list</a> for <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑥">serialized CSP</a> values, and
   populates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list③">CSP list</a> accordingly:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>Set <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list④">CSP list</a> to the empty list.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>policies</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑤">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑤">disposition</a> of "<code>enforce</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Append to <var>policies</var> the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list①">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values①">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑥">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑥">disposition</a> of "<code>report</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>policies</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Insert <var>policy</var> into <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑤">CSP list</a>.</p>
       </ol>
     </ol>
@@ -2413,45 +2413,45 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑨">request</a> (<var>request</var>), this algorithm reports violations based
   on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>’s "report only" policies.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>violates</var>.</p>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should request be blocked by Content Security Policy?" data-level="4.1.3" id="should-block-request"><span class="secno">4.1.3. </span><span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-request"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⓪">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code> and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>’s Content Security Policy.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>violates</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should response to request be blocked by Content
@@ -2459,22 +2459,22 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     Security Policy? </span><a class="self-link" href="#should-block-response"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①②">response</a> (<var>response</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①①">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code>, and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>’s Content Security Policy.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①">post-request check</a> is "<code>Blocked</code>", then:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>directive</var>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑨">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
@@ -2483,19 +2483,19 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p class="note" role="note"><span>Note:</span> This portion of the check verifies that the page can load the
   response. That is, that a Service Worker hasn’t substituted a file which
   would violate the page’s CSP.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑥">CSP list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check①">response check</a> on <var>request</var>, <var>response</var>,
   and <var>policy</var> is "<code>Blocked</code>", then:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>directive</var>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⓪">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
@@ -2503,36 +2503,36 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       </ol>
       <p class="note" role="note"><span>Note:</span> This portion of the check allows policies delivered with the
   response to determine whether the response is allowed to be delivered.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
-     <li data-md="">
-      <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑥">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a> as the <code>object</code>.</p>
-     <li data-md="">
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
+      <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑥">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a> as the <code>object</code>.</p>
+     <li data-md>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
+     <li data-md>
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithms in order to
   bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during handling of inline event
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
-     <li data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
-     <li data-md="">
+     <li data-md>
+      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
+     <li data-md>
       <p>HTML populates each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata">cryptographic nonce
   metadata</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata">parser metadata</a> with relevant data from the
   elements responsible for resource loading.</p>
@@ -2540,17 +2540,17 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   Fetch in W3C’s HTML. <a href="https://github.com/whatwg/html/issues/198">&lt;https://github.com/whatwg/html/issues/198></a></p>
       <p class="issue" id="issue-5599665e"><a class="self-link" href="#issue-5599665e"></a> Stylesheet loading is not yet integrated with
   Fetch in WHATWG’s HTML. <a href="https://github.com/whatwg/html/issues/968">&lt;https://github.com/whatwg/html/issues/968></a></p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#allow-base-for-document">§6.2.1.1 Is base allowed for document?</a> is called during <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element">base</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url">set the frozen
   base URL</a> algorithm to ensure that the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href">href</a></code> attribute’s value
   is valid.</p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy" id="ref-for-should-plugin-element-be-blocked-a-priori-by-content-security-policy">§6.2.2.2 Should plugin element be blocked a priori by Content
     Security Policy?:</a> is called during the processing of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element">embed</a></code>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet"><code>applet</code></a> elements to determine whether they may trigger a fetch.</p>
       <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
       <p class="issue" id="issue-5faf83e6"><a class="self-link" href="#issue-5faf83e6"></a> This hook is missing from W3C’s HTML. <a href="https://github.com/w3c/html/issues/547">&lt;https://github.com/w3c/html/issues/547></a></p>
-     <li data-md="">
+     <li data-md>
       <p><a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch" id="ref-for-process-a-navigate-fetch">process a
   navigate fetch</a> algorithm, and <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
@@ -2564,22 +2564,22 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> (<var>document</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①④">response</a> (<var>response</var>), the
   user agent performs the following steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>documents</var> be an empty list.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>document</var> has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a> (<var>embedding</var>), then add <var>embedding</var> to <var>documents</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>document</var> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context">opener browsing context</a>, then add its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a> to <var>documents</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>doc</var> in <var>documents</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>For each <var>policy</var> in <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
           </ol>
         </ol>
@@ -2588,15 +2588,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Execute <var>directive</var>’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization">initialization</a> algorithm on <var>document</var> and <var>response</var>.</p>
         </ol>
       </ol>
@@ -2605,41 +2605,41 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⓪">global object</a> (<var>global</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), the user agent performs the following steps in order
   to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list④">CSP list</a>:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>owners</var> be an empty list.</p>
-       <li data-md="">
+       <li data-md>
         <p>Add each of the items in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set" id="ref-for-concept-WorkerGlobalScope-owner-set">owner set</a> to <var>owners</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>owner</var> in <var>owners</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>.</p>
           </ol>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑧">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑦">CSP list</a>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope③">WorkletGlobalScope</a></code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>owner</var> be <var>global</var>’s <a data-link-type="dfn" href="https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document" id="ref-for-workletglobalscope-owner-document">owner document</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑧">CSP list</a>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑨">CSP list</a>.</p>
         </ol>
       </ol>
@@ -2647,15 +2647,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h4 class="heading settled algorithm" data-algorithm="Retrieve the CSP list of an object" data-level="4.2.3" id="get-csp-of-object"><span class="secno">4.2.3. </span><span class="content"> Retrieve the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⓪">CSP list</a> of an <var>object</var> </span><a class="self-link" href="#get-csp-of-object"></a></h4>
     <p>To obtain <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①①">CSP list</a>:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑤">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②">Window</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated <code>Document</code></a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑥">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①②">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope④">WorkletGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①③">CSP list</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should element’s inline type behavior be blocked by Content Security Policy?" data-level="4.2.4" id="should-block-inline"><span class="secno">4.2.4. </span><span class="content"> Should <var>element</var>’s inline <var>type</var> behavior be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-inline"></a></h4>
@@ -2666,40 +2666,40 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p class="note" role="note"><span>Note:</span> The valid values for <var>type</var> are "<code>script</code>", "<code>script attribute</code>",
   "<code>style</code>", and "<code>style attribute</code>".</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①①">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①④">CSP list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑥">directive set</a>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check">inline check</a> returns
   "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>,
   skip to the next <var>directive</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>, <var>policy</var>,
   and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource②">resource</a> to "<code>inline</code>".</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element">element</a> to <var>element</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> the
   expression "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample①"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample②">sample</a> to the substring of <var>source</var> containing its first 40
   characters.</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①①">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation request of type from source in target be blocked
@@ -2709,57 +2709,57 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
   the navigation, and "<code>Allowed</code>" otherwise:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑦">CSP list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>source</var>, <var>target</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global
   object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">URL</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①②">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑧">CSP List</a>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>For each <var>directive</var> in <var>policy</var>:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <code>null</code>,
   "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>,
   skip to the next <var>directive</var>.</p>
-           <li data-md="">
+           <li data-md>
             <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global
   object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">URL</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①③">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation response to navigation request of type from source
@@ -2770,55 +2770,55 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   returns "<code>Blocked</code>" if the active policy blocks the navigation, and "<code>Allowed</code>"
   otherwise:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑨">CSP list</a>:</p>
       <p class="note" role="note"><span>Note:</span> Some directives (like <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors">frame-ancestors</a>) allow a <var>response</var>’s <a data-link-type="dfn" href="#content-security-policy" id="ref-for-content-security-policy">Content Security Policy</a> to act on the navigation.</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a>.</p>
           <p class="note" role="note"><span>Note:</span> We use <code>null</code> for the global object, as no global exists:
   we haven’t processed the navigation to create a Document yet.</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑤">resource</a> to <var>navigation
   response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">URL</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①④">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document③">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑨">CSP List</a>:</p>
       <p class="note" role="note"><span>Note:</span> Some directives in the <var>source</var> context (like <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to①">navigate-to</a>)
   need the <var>response</var> before acting on the navigation.</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global
   object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="4.3" id="ecma-integration"><span class="secno">4.3. </span><span class="content">Integration with ECMAScript</span><a class="self-link" href="#ecma-integration"></a></h3>
@@ -2826,48 +2826,48 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
   operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a> to determine whether such compilation ought to be blocked.</p>
-    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport="" id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
+    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm" id="ref-for-realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a string (<var>source</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>" if not:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>globals</var> be a list containing <var>callerRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global">global object</a> and <var>calleeRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global①">global object</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>global</var> in <var>globals</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>source-list</var> be <code>null</code>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is "<code>script-src</code>", then
   set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
           <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is
   "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression②">source expression</a> which is
   an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>",
   then:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>global</var>, <var>policy</var>, and "<code>script-src</code>".</p>
-           <li data-md="">
+           <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑦">resource</a> to "<code>inline</code>".</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>source-list</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contains</a> the expression
   "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample②"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample③">sample</a> to
   the substring of <var>source</var> containing its first 40 characters.</p>
-           <li data-md="">
+           <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
   "<code>Blocked</code>".</p>
           </ol>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>result</var> is "<code>Blocked</code>", throw an <code>EvalError</code> exception.</p>
       </ol>
     </ol>
@@ -2877,43 +2877,43 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
   with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
-<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></dfn> {
-  <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-report"><code>"report"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-securitypolicyviolationeventdisposition"><code><c- g>SecurityPolicyViolationEventDisposition</c-></code></dfn> {
+  <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-enforce"><code><c- s>"enforce"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-report"><code><c- s>"report"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
 };
 
-[<dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="constructor" data-export="" data-lt="SecurityPolicyViolationEvent(type, eventInitDict)|SecurityPolicyViolationEvent(type)" id="dom-securitypolicyviolationevent-securitypolicyviolationevent"><code>Constructor</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="securitypolicyviolationevent"><code>SecurityPolicyViolationEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event">Event</a> {
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-documenturi"><code>documentURI</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-referrer"><code>referrer</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-blockeduri"><code>blockedURI</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-violateddirective"><code>violatedDirective</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-effectivedirective"><code>effectiveDirective</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-originalpolicy"><code>originalPolicy</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-sourcefile"><code>sourceFile</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-sample"><code>sample</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" id="dom-securitypolicyviolationevent-disposition"><code>disposition</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned short" id="dom-securitypolicyviolationevent-statuscode"><code>statusCode</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-securitypolicyviolationevent-linenumber"><code>lineNumber</code></dfn>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-securitypolicyviolationevent-columnnumber"><code>columnNumber</code></dfn>;
+[<dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="constructor" data-export data-lt="SecurityPolicyViolationEvent(type, eventInitDict)|SecurityPolicyViolationEvent(type)" id="dom-securitypolicyviolationevent-securitypolicyviolationevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit"><c- n>SecurityPolicyViolationEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="securitypolicyviolationevent"><code><c- g>SecurityPolicyViolationEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event"><c- n>Event</c-></a> {
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-documenturi"><code><c- g>documentURI</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-referrer"><code><c- g>referrer</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-blockeduri"><code><c- g>blockedURI</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-violateddirective"><code><c- g>violatedDirective</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-effectivedirective"><code><c- g>effectiveDirective</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-originalpolicy"><code><c- g>originalPolicy</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-sourcefile"><code><c- g>sourceFile</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-sample"><code><c- g>sample</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition"><c- n>SecurityPolicyViolationEventDisposition</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="SecurityPolicyViolationEventDisposition" id="dom-securitypolicyviolationevent-disposition"><code><c- g>disposition</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned short" id="dom-securitypolicyviolationevent-statuscode"><code><c- g>statusCode</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned long" id="dom-securitypolicyviolationevent-linenumber"><code><c- g>lineNumber</c-></code></dfn>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned long" id="dom-securitypolicyviolationevent-columnnumber"><code><c- g>columnNumber</c-></code></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-securitypolicyviolationeventinit"><code>SecurityPolicyViolationEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit">EventInit</a> {
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-documenturi"><code>documentURI</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-documenturi"></a></dfn>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-referrer"><code>referrer</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-referrer"></a></dfn> = "";
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-blockeduri"><code>blockedURI</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-blockeduri"></a></dfn> = "";
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-violateddirective"><code>violatedDirective</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-violateddirective"></a></dfn>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-effectivedirective"><code>effectiveDirective</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-effectivedirective"></a></dfn>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-originalpolicy"><code>originalPolicy</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-originalpolicy"></a></dfn>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-sourcefile"><code>sourceFile</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sourcefile"></a></dfn> = "";
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-sample"><code>sample</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sample"></a></dfn> = "";
-    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①">SecurityPolicyViolationEventDisposition</a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="SecurityPolicyViolationEventDisposition " id="dom-securitypolicyviolationeventinit-disposition"><code>disposition</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-disposition"></a></dfn>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned short " id="dom-securitypolicyviolationeventinit-statuscode"><code>statusCode</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-statuscode"></a></dfn>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-linenumber"><code>lineNumber</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-linenumber"></a></dfn> = 0;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-columnnumber"><code>columnNumber</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-columnnumber"></a></dfn> = 0;
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-securitypolicyviolationeventinit"><code><c- g>SecurityPolicyViolationEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit"><c- n>EventInit</c-></a> {
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-documenturi"><code><c- g>documentURI</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-documenturi"></a></dfn>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-referrer"><code><c- g>referrer</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-referrer"></a></dfn> = "";
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-blockeduri"><code><c- g>blockedURI</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-blockeduri"></a></dfn> = "";
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-violateddirective"><code><c- g>violatedDirective</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-violateddirective"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-effectivedirective"><code><c- g>effectiveDirective</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-effectivedirective"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-originalpolicy"><code><c- g>originalPolicy</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-originalpolicy"></a></dfn>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-sourcefile"><code><c- g>sourceFile</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sourcefile"></a></dfn> = "";
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-sample"><code><c- g>sample</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sample"></a></dfn> = "";
+    <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①"><c- n>SecurityPolicyViolationEventDisposition</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="SecurityPolicyViolationEventDisposition " id="dom-securitypolicyviolationeventinit-disposition"><code><c- g>disposition</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-disposition"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①"><c- b>unsigned</c-> <c- b>short</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned short " id="dom-securitypolicyviolationeventinit-statuscode"><code><c- g>statusCode</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-statuscode"></a></dfn>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-linenumber"><code><c- g>lineNumber</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-linenumber"></a></dfn> = 0;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-columnnumber"><code><c- g>columnNumber</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-columnnumber"></a></dfn> = 0;
 };
 </pre>
     <h3 class="heading settled" data-level="5.2" id="deprecated-serialize-violation"><span class="secno">5.2. </span><span class="content"> Obtain the deprecated serialization of <var>violation</var> </span><a class="self-link" href="#deprecated-serialize-violation"></a></h3>
@@ -2921,36 +2921,36 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   string representation of the violation, suitable for submission to a reporting
   endpoint associated with the deprecated <a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri"><code>report-uri</code></a> directive.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>object</var> be a new JavaScript object with properties initialized as
   follows:</p>
       <dl>
-       <dt data-md="">"<code>document-uri</code>"
-       <dd data-md="">
+       <dt data-md>"<code>document-uri</code>"
+       <dd data-md>
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url">url</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md="">"<code>referrer</code>"
-       <dd data-md="">
+       <dt data-md>"<code>referrer</code>"
+       <dd data-md>
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer①">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer①">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md="">"<code>blocked-uri</code>"
-       <dd data-md="">
+       <dt data-md>"<code>blocked-uri</code>"
+       <dd data-md>
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer②">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑧">resource</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md="">"<code>effective-directive</code>"
-       <dd data-md="">
+       <dt data-md>"<code>effective-directive</code>"
+       <dd data-md>
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive①">effective directive</a></p>
-       <dt data-md="">"<code>violated-directive</code>"
-       <dd data-md="">
+       <dt data-md>"<code>violated-directive</code>"
+       <dd data-md>
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive②">effective directive</a></p>
-       <dt data-md="">"<code>original-policy</code>"
-       <dd data-md="">
+       <dt data-md>"<code>original-policy</code>"
+       <dd data-md>
         <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑦">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy①">policy</a></p>
-       <dt data-md="">"<code>disposition</code>"
-       <dd data-md="">
+       <dt data-md>"<code>disposition</code>"
+       <dd data-md>
         <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
-       <dt data-md="">"<code>status-code</code>"
-       <dd data-md="">
+       <dt data-md>"<code>status-code</code>"
+       <dd data-md>
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status①">status</a></p>
-       <dt data-md="">"<code>script-sample</code>"
-       <dd data-md="">
+       <dt data-md>"<code>script-sample</code>"
+       <dd data-md>
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample④">sample</a></p>
         <p class="note" role="note"><span>Note:</span> The name <code>script-sample</code> was chosen for compatibility with an earlier iteration of
   this feature which has shipped in Firefox since its initial implementation of CSP. Despite
@@ -2958,97 +2958,97 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   data contained in a <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent">SecurityPolicyViolationEvent</a></code> object, and in reports generated via
   the new <a data-link-type="dfn" href="#report-to" id="ref-for-report-to"><code>report-to</code></a> directive, is named in a more encompassing fashion: <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample">sample</a></code>.</p>
       </dl>
-     <li data-md="">
+     <li data-md>
       <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file②">source file</a> is not <code>null</code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>object</var>’s "<code>source-file</code>" property to the result of executing
   the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer③">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file③">source
   file</a>, with the <code>exclude fragment</code> flag set.</p>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>object</var>’s "<code>line-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number①">line number</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>object</var>’s "<code>column-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number①">column number</a>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: If <var>object</var>’s "<code>blocked-uri</code>" property is not "<code>inline</code>", then its "<code>sample</code>"
   property is the empty string.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-json.stringify" id="ref-for-sec-json.stringify">JSON.stringify()</a></code> on <var>object</var>.</p>
     </ol>
     <h3 class="heading settled algorithm" data-algorithm="Report a violation" data-level="5.3" id="report-violation"><span class="secno">5.3. </span><span class="content"> Report a <var>violation</var> </span><a class="self-link" href="#report-violation"></a></h3>
     <p>Given a <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑧">violation</a> (<var>violation</var>), this algorithm reports it to the endpoint specified in <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy③">policy</a>, and fires a <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent①">SecurityPolicyViolationEvent</a></code> at <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element①">element</a>, or at <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object③">global object</a> as described below:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>global</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object④">global object</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>target</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element②">element</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task">Queue a task</a> to run the following steps:</p>
       <p class="note" role="note"><span>Note:</span> We "queue a task" here to ensure that the event targeting and dispatch
   happens after JavaScript completes execution of the task responsible for a
   given violation (which might manipulate the DOM).</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>target</var> is not <code>null</code>, and <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③">Window</a></code>, and <var>target</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-root" id="ref-for-concept-shadow-including-root">shadow-including root</a> is not <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window①">associated <code>Document</code></a>, set <var>target</var> to <code>null</code>.</p>
         <p class="note" role="note"><span>Note:</span> This ensures that we fire events only at elements <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#connected" id="ref-for-connected">connected</a> to <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy④">policy</a>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code>. If a
   violation is caused by an element which isn’t connected to that
   document, we’ll fire the event at the document rather than the element
   in order to ensure that the violation is visible to the document’s
   listeners.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>target</var> is <code>null</code>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>target</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑤">global object</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>target</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window④">Window</a></code>, set <var>target</var> to <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window②">associated <code>Document</code></a>.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">Fire an event</a> named <code>securitypolicyviolation</code> that uses the <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent②">SecurityPolicyViolationEvent</a></code> interface at <var>target</var> with
   its attributes initialized as follows:</p>
         <dl>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi">documentURI</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi">documentURI</a></code>
+         <dd data-md>
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer④">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url①">url</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-referrer" id="ref-for-dom-securitypolicyviolationevent-referrer">referrer</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-referrer" id="ref-for-dom-securitypolicyviolationevent-referrer">referrer</a></code>
+         <dd data-md>
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑤">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer②">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri">blockedURI</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri">blockedURI</a></code>
+         <dd data-md>
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑥">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑨">resource</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive③">effective directive</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective">violatedDirective</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective">violatedDirective</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive④">effective directive</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-originalpolicy" id="ref-for-dom-securitypolicyviolationevent-originalpolicy">originalPolicy</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-originalpolicy" id="ref-for-dom-securitypolicyviolationevent-originalpolicy">originalPolicy</a></code>
+         <dd data-md>
           <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑧">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑤">policy</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-disposition" id="ref-for-dom-securitypolicyviolationevent-disposition">disposition</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-disposition" id="ref-for-dom-securitypolicyviolationevent-disposition">disposition</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-disposition" id="ref-for-violation-disposition">disposition</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sourcefile" id="ref-for-dom-securitypolicyviolationevent-sourcefile">sourceFile</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sourcefile" id="ref-for-dom-securitypolicyviolationevent-sourcefile">sourceFile</a></code>
+         <dd data-md>
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑦">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file④">source file</a>, with the <code>exclude fragment</code> flag set if the <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑤">source file</a> it not <code>null</code> and the empty string otherwise.</p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode" id="ref-for-dom-securitypolicyviolationevent-statuscode">statusCode</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode" id="ref-for-dom-securitypolicyviolationevent-statuscode">statusCode</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status②">status</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber">lineNumber</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber">lineNumber</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number②">line number</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber">columnNumber</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber">columnNumber</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number②">column number</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample①">sample</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample①">sample</a></code>
+         <dd data-md>
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample⑤">sample</a></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles">bubbles</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles">bubbles</a></code>
+         <dd data-md>
           <p><code>true</code></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed" id="ref-for-dom-event-composed">composed</a></code>
-         <dd data-md="">
+         <dt data-md><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed" id="ref-for-dom-event-composed">composed</a></code>
+         <dd data-md>
           <p><code>true</code></p>
         </dl>
         <p class="note" role="note"><span>Note:</span> Both <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective①">effectiveDirective</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective①">violatedDirective</a></code> are the same value.
@@ -3057,66 +3057,66 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   can be captured on its way into, and will bubble its way out of a shadow
   tree. <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target" id="ref-for-dom-event-target">target</a></code>, et al will be automagically scoped correctly for
   the main tree.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑥">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑦">directive
   set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
   (<var>directive</var>):</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> named
   "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to①"><code>report-to</code></a>", skip the remaining substeps.</p>
-         <li data-md="">
+         <li data-md>
           <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①"> splitting a string on ASCII whitespace</a> with <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑦">value</a> as the <code>input</code>.</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Let <var>endpoint</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> with <var>token</var> as the input, and <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url②">url</a> as the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-base-url" id="ref-for-concept-base-url">base URL</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>endpoint</var> is not a valid URL, skip the remaining substeps.</p>
-           <li data-md="">
+           <li data-md>
             <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑤">request</a>, initialized as follows:</p>
             <dl>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
+             <dd data-md>
               <p>"<code>POST</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
+             <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url③">url</a></p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
+             <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑥">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a></p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
+             <dd data-md>
               <p>"<code>no-window</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>
+             <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑦">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant
   settings object</a></p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a>
+             <dd data-md>
               <p>"<code>report</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a>
+             <dd data-md>
               <p>""</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode" id="ref-for-concept-request-credentials-mode">credentials mode</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode" id="ref-for-concept-request-credentials-mode">credentials mode</a>
+             <dd data-md>
               <p>"<code>same-origin</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-keepalive-flag" id="ref-for-request-keepalive-flag">keepalive flag</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-keepalive-flag" id="ref-for-request-keepalive-flag">keepalive flag</a>
+             <dd data-md>
               <p>"<code>true</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list">header list</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list">header list</a>
+             <dd data-md>
               <p>A header list containing a single header whose name is
   "<code>Content-Type</code>", and value is "<code>application/csp-report</code>"</p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a>
+             <dd data-md>
               <p>The result of executing <a href="#deprecated-serialize-violation">§5.2 Obtain the deprecated serialization of violation</a> on <var>violation</var></p>
-             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a>
-             <dd data-md="">
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a>
+             <dd data-md>
               <p>"<code>error</code>"</p>
             </dl>
             <p class="note" role="note"><span>Note:</span> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> defaults to "<code>no-cors</code>"; the response is ignored entirely.</p>
-           <li data-md="">
+           <li data-md>
             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">Fetch</a> <var>request</var>. The result will be ignored.</p>
           </ol>
         </ol>
@@ -3126,31 +3126,31 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p class="note" role="note"><span>Note:</span> <code>report-uri</code> only takes effect if <code>report-to</code> is not present. That
   is, the latter overrides the former, allowing for backwards compatibility
   with browsers that don’t support the new mechanism.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑧">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑨">directive
   set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
   (<var>directive</var>):</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>group</var> be <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑧">value</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>settings object</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑧">global
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>.</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a>'s <a data-link-type="dfn" href="https://w3c.github.io/reporting/#queue-report" id="ref-for-queue-report">Queue <var>data</var> as <var>type</var> for <var>endpoint group</var> on <var>settings</var></a> algorithm with the
   following arguments:</p>
           <dl>
-           <dt data-md=""><var>data</var>
-           <dd data-md="">
+           <dt data-md><var>data</var>
+           <dd data-md>
             <p><var>violation</var></p>
-           <dt data-md=""><var>type</var>
-           <dd data-md="">
+           <dt data-md><var>type</var>
+           <dd data-md>
             <p>"CSP"</p>
-           <dt data-md=""><var>endpoint group</var>
-           <dd data-md="">
+           <dt data-md><var>endpoint group</var>
+           <dd data-md>
             <p><var>group</var></p>
-           <dt data-md=""><var>settings</var>
-           <dd data-md="">
+           <dt data-md><var>settings</var>
+           <dd data-md>
             <p><var>settings object</var></p>
           </dl>
         </ol>
@@ -3172,21 +3172,21 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   include directives that regulate sources of script and plugins. They can do
   so by including:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Both the <a data-link-type="dfn" href="#script-src" id="ref-for-script-src">script-src</a> and <a data-link-type="dfn" href="#object-src" id="ref-for-object-src">object-src</a> directives, or</p>
-     <li data-md="">
+     <li data-md>
       <p>a <a data-link-type="dfn" href="#default-src" id="ref-for-default-src">default-src</a> directive</p>
     </ul>
     <p>In either case, developers SHOULD NOT include either <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline"><code>'unsafe-inline'</code></a>, or <code>data:</code> as valid
   sources in their policies. Both enable XSS attacks by allowing code to be
   included directly in the document itself; they are best avoided completely.</p>
     <h3 class="heading settled" data-level="6.1" id="directives-fetch"><span class="secno">6.1. </span><span class="content"> Fetch Directives </span><a class="self-link" href="#directives-fetch"></a></h3>
-    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="fetch-directives">Fetch directives</dfn> control the locations from which certain resource
+    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="fetch-directives">Fetch directives</dfn> control the locations from which certain resource
   types may be loaded. For instance, <a data-link-type="dfn" href="#script-src" id="ref-for-script-src①">script-src</a> allows developers to allow
   trusted sources of script to execute on a page, while <a data-link-type="dfn" href="#font-src" id="ref-for-font-src">font-src</a> controls the
   sources of web fonts.</p>
     <h4 class="heading settled" data-level="6.1.1" id="directive-child-src"><span class="secno">6.1.1. </span><span class="content"><code>child-src</code></span><a class="self-link" href="#directive-child-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="child-src"><code>child-src</code></dfn> directive governs the creation of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="child-src"><code>child-src</code></dfn> directive governs the creation of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing
   contexts</a> (e.g. <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element">iframe</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame">frame</a></code> navigations) and Worker execution
   contexts. The syntax for the directive’s name and value is described by the
   following ABNF:</p>
@@ -3197,10 +3197,10 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   worker. More formally, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑦">requests</a> falling into one of the
   following categories:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>document</code>", and whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing
  context</a> (e.g. requests which will populate an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element①">iframe</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame①">frame</a></code> element)</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is either "<code>serviceworker</code>",
  "<code>sharedworker</code>", or "<code>worker</code>" (which are fed to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker①">run a worker</a> algorithm for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker">ServiceWorker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker">SharedWorker</a></code>, and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker①">Worker</a></code>,
  respectively).</p>
@@ -3211,21 +3211,21 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>child-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-><c- p>></c->
+  <c- a>var</c-> blockedWorker <c- o>=</c-> <c- k>new</c-> Worker<c- p>(</c-><c- u>"data:application/javascript,..."</c-><c- p>);</c->
+<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
@@ -3233,23 +3233,23 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
   using script interfaces. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "connect-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①">serialized-source-list</a>
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⓪">requests</a> which transmit or receive data from
-  other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping" id="ref-for-dom-a-ping">ping</a></code>. This directive <em>also</em> controls
+  other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute" id="ref-for-AElementPingAttribute">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
     <div class="example" id="example-e13881a4">
@@ -3267,50 +3267,50 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>connect-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">ping</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">></span>...
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">();</span>
-  xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://example.org/'</span><span class="p">);</span>
-  xhr<span class="p">.</span>send<span class="p">();</span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>a</c-> <c- e>ping</c-><c- o>=</c-><c- s>"https://example.org"</c-><c- p>></c->...
+<c- p>&lt;</c-><c- f>script</c-><c- p>></c->
+  <c- a>var</c-> xhr <c- o>=</c-> <c- k>new</c-> XMLHttpRequest<c- p>();</c->
+  xhr<c- p>.</c->open<c- p>(</c-><c- t>'GET'</c-><c- p>,</c-> <c- t>'https://example.org/'</c-><c- p>);</c->
+  xhr<c- p>.</c->send<c- p>();</c->
 
-  <span class="kd">var</span> ws <span class="o">=</span> <span class="k">new</span> WebSocket<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
+  <c- a>var</c-> ws <c- o>=</c-> <c- k>new</c-> WebSocket<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
 
-  <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
+  <c- a>var</c-> es <c- o>=</c-> <c- k>new</c-> EventSource<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
 
-  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+  navigator<c- p>.</c->sendBeacon<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>,</c-> <c- p>{</c-> <c- p>...</c-> <c- p>});</c->
+<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.3" id="directive-default-src"><span class="secno">6.1.3. </span><span class="content"><code>default-src</code></span><a class="self-link" href="#directive-default-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-src">default-src</dfn> directive serves as a fallback for the other <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives">fetch directives</a>. The syntax for the directive’s name and value is described by
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="default-src">default-src</dfn> directive serves as a fallback for the other <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives">fetch directives</a>. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "default-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list②">serialized-source-list</a>
@@ -3368,11 +3368,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
@@ -3380,11 +3380,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
   comparison.</p>
     </ol>
@@ -3392,16 +3392,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="font-src">font-src</dfn> directive restricts the URLs from which font resources
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="font-src">font-src</dfn> directive restricts the URLs from which font resources
   may be loaded. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "font-src"
@@ -3413,47 +3413,47 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>font-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists③">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
-  <span class="p">@</span><span class="k">font-face</span> <span class="p">{</span>
-    <span class="nt">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="o">;</span>
-    <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://example.org/font"</span><span class="o">);</span>
-  <span class="p">}</span>
-  <span class="nt">body</span> <span class="p">{</span>
-    <span class="k">font-family</span><span class="p">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
-  <span class="p">}</span>
-<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>style</c-><c- p>></c->
+  <c- p>@</c-><c- k>font-face</c-> <c- p>{</c->
+    <c- f>font-family</c-><c- o>:</c-> <c- u>"Example Font"</c-><c- o>;</c->
+    <c- f>src</c-><c- o>:</c-> <c- f>url</c-><c- o>(</c-><c- u>"https://example.org/font"</c-><c- o>);</c->
+  <c- p>}</c->
+  <c- f>body</c-> <c- p>{</c->
+    <c- k>font-family</c-><c- p>:</c-> <c- u>"Example Font"</c-><c- p>;</c->
+  <c- p>}</c->
+<c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.5" id="directive-frame-src"><span class="secno">6.1.5. </span><span class="content"><code>frame-src</code></span><a class="self-link" href="#directive-frame-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="frame-src">frame-src</dfn> directive restricts the URLs which may be loaded into <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing contexts</a>. The syntax for the directive’s name and value
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="frame-src">frame-src</dfn> directive restricts the URLs which may be loaded into <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing contexts</a>. The syntax for the directive’s name and value
   is described by the following ABNF:</p>
 <pre>directive-name  = "frame-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list④">serialized-source-list</a>
@@ -3464,40 +3464,40 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>frame-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists④">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>></c->
+<c- p>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.6" id="directive-img-src"><span class="secno">6.1.6. </span><span class="content"><code>img-src</code></span><a class="self-link" href="#directive-img-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="img-src">img-src</dfn> directive restricts the URLs from which image resources
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="img-src">img-src</dfn> directive restricts the URLs from which image resources
   may be loaded. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "img-src"
@@ -3511,39 +3511,39 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>img-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑤">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/img"</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>img</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/img"</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.7" id="directive-manifest-src"><span class="secno">6.1.7. </span><span class="content"><code>manifest-src</code></span><a class="self-link" href="#directive-manifest-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="manifest-src">manifest-src</dfn> directive restricts the URLs from which application
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="manifest-src">manifest-src</dfn> directive restricts the URLs from which application
   manifests may be loaded <a data-link-type="biblio" href="#biblio-appmanifest">[APPMANIFEST]</a>. The syntax for the directive’s name
   and value is described by the following ABNF:</p>
 <pre>directive-name  = "manifest-src"
@@ -3555,39 +3555,39 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>manifest-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑥">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"manifest"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://example.org/manifest"</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"manifest"</c-> <c- e>href</c-><c- o>=</c-><c- s>"https://example.org/manifest"</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.8" id="directive-media-src"><span class="secno">6.1.8. </span><span class="content"><code>media-src</code></span><a class="self-link" href="#directive-media-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="media-src">media-src</dfn> directive restricts the URLs from which video, audio,
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="media-src">media-src</dfn> directive restricts the URLs from which video, audio,
   and associated text track resources may be loaded. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "media-src"
@@ -3599,42 +3599,42 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>media-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑦">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">audio</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/audio"</span><span class="p">>&lt;/</span><span class="nt">audio</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">video</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/video"</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">track</span> <span class="na">kind</span><span class="o">=</span><span class="s">"subtitles"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/subtitles"</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">video</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>audio</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/audio"</c-><c- p>>&lt;/</c-><c- f>audio</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>video</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/video"</c-><c- p>></c->
+    <c- p>&lt;</c-><c- f>track</c-> <c- e>kind</c-><c- o>=</c-><c- s>"subtitles"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/subtitles"</c-><c- p>></c->
+<c- p>&lt;/</c-><c- f>video</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.9" id="directive-prefetch-src"><span class="secno">6.1.9. </span><span class="content"><code>prefetch-src</code></span><a class="self-link" href="#directive-prefetch-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
   prefetched or prerendered. The syntax for the directive’s name and value is described by the
   following ABNF:</p>
 <pre>directive-name  = "prefetch-src"
@@ -3645,40 +3645,40 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src②">prefetch-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return network errors, as the URLs provided do not match <code>prefetch-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prefetch"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prerender"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prefetch"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prerender"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
   and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.10" id="directive-object-src"><span class="secno">6.1.10. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="object-src">object-src</dfn> directive restricts the URLs from which plugin
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="object-src">object-src</dfn> directive restricts the URLs from which plugin
   content may be loaded. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "object-src"
@@ -3690,9 +3690,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">embed</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">embed</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">applet</span> <span class="na">archive</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">applet</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>embed</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>embed</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>applet</c-> <c- e>archive</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>applet</c-><c- p>></c->
 </pre>
     </div>
     <p>If plugin content is loaded without an associated URL (perhaps an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element①">object</a></code> element lacks a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data" id="ref-for-attr-object-data">data</a></code> attribute, but loads some default plugin based
@@ -3715,32 +3715,32 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.11" id="directive-script-src"><span class="secno">6.1.11. </span><span class="content"><code>script-src</code></span><a class="self-link" href="#directive-script-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src">script-src</dfn> directive restricts the locations from which scripts
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="script-src">script-src</dfn> directive restricts the locations from which scripts
   may be executed. This includes not only URLs loaded directly into <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script③">script</a></code> elements, but also things like inline script blocks and XSLT stylesheets <a data-link-type="biblio" href="#biblio-xslt">[XSLT]</a> which can trigger script execution. The syntax for the directive’s
   name and value is described by the following ABNF:</p>
 <pre>directive-name  = "script-src"
@@ -3748,74 +3748,74 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <p>The <code>script-src</code> directive governs five things:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script④">script</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. Their
   behavior will be blocked unless every policy allows inline script, either
   implicitly by not specifying a <code>script-src</code> (or <code>default-src</code>) directive,
   or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source②">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source②">hash-source</a> that matches
   the inline block.</p>
-     <li data-md="">
+     <li data-md>
       <p>The following JavaScript execution sinks are gated on the "<code>unsafe-eval</code>"
   source expression:</p>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-eval-x" id="ref-for-sec-eval-x①">eval()</a></code></p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-function-objects" id="ref-for-sec-function-objects">Function()</a></code></p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout" id="ref-for-dom-settimeout">setTimeout()</a></code> with an initial argument which is not callable.</p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval" id="ref-for-dom-setinterval">setInterval()</a></code> with an initial argument which is not callable.</p>
       </ul>
       <p class="note" role="note"><span>Note:</span> If a user agent implements non-standard sinks like <code>setImmediate()</code> or <code>execScript()</code>, they SHOULD also be gated on "<code>unsafe-eval</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Navigation to <code>javascript:</code> URLs MUST pass through <a href="#script-src-inline">§6.1.11.3 script-src Inline Check</a>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
@@ -3823,38 +3823,38 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Stylesheet requests originating from a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element①">link</a></code> element.</p>
-       <li data-md="">
+       <li data-md>
         <p>Stylesheet requests originating from the <a class="css" data-link-type="at-rule" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import" id="ref-for-at-ruledef-import"><code>@import</code></a> rule.</p>
-       <li data-md="">
+       <li data-md>
         <p>Stylesheet requests originating from a <code>Link</code> HTTP response header
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
   implicitly by not specifying a <code>style-src</code> (or <code>default-src</code>) directive,
   or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> that matches
   the inline block.</p>
-     <li data-md="">
+     <li data-md>
       <p>The following CSS algorithms are gated on the <code>unsafe-eval</code> source
   expression:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule" id="ref-for-insert-a-css-rule">insert a CSS rule</a></p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule" id="ref-for-parse-a-css-rule">parse a CSS rule</a>,</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block" id="ref-for-parse-a-css-declaration-block">parse a CSS declaration block</a></p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors" id="ref-for-parse-a-group-of-selectors">parse a group of selectors</a></p>
       </ol>
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
@@ -3864,50 +3864,50 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization①">initialization</a> algorithm is as follows:</p>
@@ -3915,7 +3915,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
     <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
@@ -3927,46 +3927,46 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
-  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
-  blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
-  navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://example.org/sw.js'</span><span class="p">);</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-><c- p>></c->
+  <c- a>var</c-> blockedWorker <c- o>=</c-> <c- k>new</c-> Worker<c- p>(</c-><c- u>"data:application/javascript,..."</c-><c- p>);</c->
+  blockedWorker <c- o>=</c-> <c- k>new</c-> SharedWorker<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
+  navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- t>'https://example.org/sw.js'</c-><c- p>);</c->
+<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.2" id="directives-document"><span class="secno">6.2. </span><span class="content"> Document Directives </span><a class="self-link" href="#directives-document"></a></h3>
     <p>The following directives govern the properties of a document or worker
   environment to which a policy applies.</p>
     <h4 class="heading settled" data-level="6.2.1" id="directive-base-uri"><span class="secno">6.2.1. </span><span class="content"><code>base-uri</code></span><a class="self-link" href="#directive-base-uri"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="base-uri">base-uri</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url④">URL</a></code>s which can be used in
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="base-uri">base-uri</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url④">URL</a></code>s which can be used in
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
@@ -3977,55 +3977,55 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑤">URL</a></code> (<var>base</var>), and a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①④">Document</a></code> (<var>document</var>), this algorithm
   returns "<code>Allowed</code>" if <var>base</var> may be used as the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element②">base</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href①">href</a></code> attribute, and "<code>Blocked</code>" otherwise:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">csp list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>source list</var> be <code>null</code>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
   set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global
   object</a>, <var>policy</var>, and "<a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri"><code>base-uri</code></a>".</p>
-         <li data-md="">
+         <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①⓪">resource</a> to "<code>inline</code>".</p>
-         <li data-md="">
+         <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is "<code>enforce</code>",
   return "<code>Blocked</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> We compare against the fallback base URL in order to deal correctly with things like <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document②">an iframe <code>srcdoc</code> <code>Document</code></a> which has been sandboxed into an opaque origin.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.2.2" id="directive-plugin-types"><span class="secno">6.2.2. </span><span class="content"><code>plugin-types</code></span><a class="self-link" href="#directive-plugin-types"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="plugin-types">plugin-types</dfn> directive restricts the set of plugins that
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="plugin-types">plugin-types</dfn> directive restricts the set of plugins that
   can be embedded into a document by limiting the types of resources which can
   be loaded. The directive’s syntax is described by the following ABNF grammar:</p>
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑥">RWS</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑥">RWS</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>
     <p>If a <code>plugin-types</code> directive is present, instantiation of an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element③">embed</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑤">object</a></code> element will fail if any of the following conditions hold:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>The element does not explicitly declare a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type">valid MIME type</a> via a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type" id="ref-for-attr-embed-type">type</a></code> attribute.</p>
-     <li data-md="">
+     <li data-md>
       <p>The declared type does not match one of the items in the directive’s
   value.</p>
-     <li data-md="">
+     <li data-md>
       <p>The fetched resource does not match the declared type.</p>
     </ol>
     <div class="example" id="example-5240cbd4">
@@ -4033,78 +4033,78 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types">plugin-types</a> application/pdf
 </pre>
      <p>Fetches for the following code will all return network errors:</p>
-<pre class="highlight"><span class="c">&lt;!-- No 'type' declaration --></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<pre class="highlight"><c- c>&lt;!-- No 'type' declaration --></c->
+<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
 
-<span class="c">&lt;!-- Non-matching 'type' declaration --></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<c- c>&lt;!-- Non-matching 'type' declaration --></c->
+<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/x-shockwave-flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
 
-<span class="c">&lt;!-- Non-matching resource --></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/pdf"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<c- c>&lt;!-- Non-matching resource --></c->
+<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/pdf"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
 </pre>
      <p>If the page allowed Flash content by sending the following header:</p>
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types①">plugin-types</a> application/x-shockwave-flash
 </pre>
      <p>Then the second item above would load successfully:</p>
-<pre class="highlight"><span class="c">&lt;!-- Matching 'type' declaration and resource --></span>
-<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<pre class="highlight"><c- c>&lt;!-- Matching 'type' declaration and resource --></c->
+<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/x-shockwave-flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is either "<code>object</code>"
   or "<code>embed</code>":</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>type</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">extracting a
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
   in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a>, return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
-    Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
+    Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①⓪">CSP list</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
   value if present, or "<code>null</code>" otherwise.</p>
-         <li data-md="">
+         <li data-md>
           <p>Return "<code>Blocked</code>" if any of the following are true:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p><var>type</var> is <code>null</code>.</p>
-           <li data-md="">
+           <li data-md>
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
   item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>.</p>
           </ol>
         </ol>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.2.3" id="directive-sandbox"><span class="secno">6.2.3. </span><span class="content"><code>sandbox</code></span><a class="self-link" href="#directive-sandbox"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sandbox">sandbox</dfn> directive specifies an HTML sandbox policy which the
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="sandbox">sandbox</dfn> directive specifies an HTML sandbox policy which the
   user agent will apply to a resource, just as though it had been included in
   an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element②">iframe</a></code> with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox" id="ref-for-attr-iframe-sandbox">sandbox</a></code> property.</p>
     <p>The directive’s syntax is described by the following ABNF grammar, with
@@ -4121,16 +4121,16 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>response</var> is unused.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is one of
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
   using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
@@ -4139,7 +4139,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
         <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed into
   unique origins, which seems like a pretty reasonable thing to do.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="sandbox Initialization" data-level="6.2.3.2" id="sandbox-init"><span class="secno">6.2.3.2. </span><span class="content"> <code>sandbox</code> Initialization </span><a class="self-link" href="#sandbox-init"></a></h5>
@@ -4148,19 +4148,19 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
   follows:</p>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>response</var> is unused.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code>, then abort this algorithm.</p>
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
      <h4 class="heading settled" data-level="6.2.4" id="directive-disown-opener"><span class="secno">6.2.4. </span><span class="content"><code>disown-opener</code></span><a class="self-link" href="#directive-disown-opener"></a></h4>
-     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="disown-opener"><code>disown-opener</code></dfn> directive ensures that a resource
+     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="disown-opener"><code>disown-opener</code></dfn> directive ensures that a resource
     will <a data-link-type="dfn">disown its opener</a> when navigated to. The directive’s syntax is
     described by the following ABNF grammar:</p>
 <pre>directive-name  = "disown-opener"
@@ -4180,16 +4180,16 @@ directive-value = ""
   follows:</p>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context" id="ref-for-responsible-browsing-context">responsible browsing context</a> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing
   context</a>, <a data-link-type="dfn">disown its opener</a>.</p>
     </ol>
     <p class="issue" id="issue-0ff12cdb"><a class="self-link" href="#issue-0ff12cdb"></a> What should this do in an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>? Anything?</p>
     <h3 class="heading settled" data-level="6.3" id="directives-navigation"><span class="secno">6.3. </span><span class="content"> Navigation Directives </span><a class="self-link" href="#directives-navigation"></a></h3>
     <h4 class="heading settled" data-level="6.3.1" id="directive-form-action"><span class="secno">6.3.1. </span><span class="content"><code>form-action</code></span><a class="self-link" href="#directive-form-action"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="form-action">form-action</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑥">URL</a></code>s which can be used
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="form-action">form-action</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑥">URL</a></code>s which can be used
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
@@ -4201,20 +4201,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>source</var>, <var>target</var>, and <var>policy</var> are unused in this algorithm, as <code>form-action</code> is concerned only with details of the outgoing request.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.3.2" id="directive-frame-ancestors"><span class="secno">6.3.2. </span><span class="content"><code>frame-ancestors</code></span><a class="self-link" href="#directive-frame-ancestors"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="frame-ancestors">frame-ancestors</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑦">URL</a></code>s which can
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="frame-ancestors">frame-ancestors</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑦">URL</a></code>s which can
   embed the resource using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame②">frame</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑤">iframe</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑥">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element④">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet④"><code>applet</code></a> element. Resources can use this directive to avoid many UI
   Redressing <a data-link-type="biblio" href="#biblio-uisecurity">[UISECURITY]</a> attacks, by avoiding the risk of being embedded into
   potentially hostile contexts.</p>
@@ -4222,8 +4222,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-ancestors"
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
@@ -4234,30 +4234,30 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>current</var> be <var>target</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>While <var>current</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context">parent browsing context</a> (<var>parent</var>):</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Set <var>current</var> to <var>parent</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
   executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled" data-level="6.3.2.2" id="frame-ancestors-and-frame-options"><span class="secno">6.3.2.2. </span><span class="content"> Relation to <code>X-Frame-Options</code> </span><a class="self-link" href="#frame-ancestors-and-frame-options"></a></h5>
@@ -4269,7 +4269,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
   a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">document</a> can initiate navigations by any means (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code>, <code>window.location</code>, <code>window.open</code>, etc.). This is an enforcement on what navigations this <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">document</a> initiates <code>not</code> on what this <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">document</a> is allowed to navigate to.
   If the <a data-link-type="dfn" href="#form-action" id="ref-for-form-action">form-action</a> directive is present, the <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to②">navigate-to</a> directive
   will not act on navigations that are form submissions.</p>
@@ -4296,21 +4296,21 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>source</var> and <var>target</var> are unused as 'navigate-to'
   is concerned with the details of the request.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
   wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
@@ -4318,25 +4318,25 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
   already checked the navigation in <a href="#navigate-to-pre-navigate">§6.3.3.1 navigate-to Pre-Navigation Check</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.4" id="directives-reporting"><span class="secno">6.4. </span><span class="content"> Reporting Directives </span><a class="self-link" href="#directives-reporting"></a></h3>
@@ -4353,7 +4353,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      </div>
     </div>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
 <pre>directive-name  = "report-uri"
 directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑨">RWS</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
 
@@ -4362,7 +4362,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>The directive has no effect in and of itself, but only gains meaning in
   combination with other directives.</p>
     <h4 class="heading settled" data-level="6.4.2" id="directive-report-to"><span class="secno">6.4.2. </span><span class="content"><code>report-to</code></span><a class="self-link" href="#directive-report-to"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="report-to"><code>report-to</code></dfn> directive defines a <a data-link-type="dfn" href="https://w3c.github.io/reporting/#group" id="ref-for-group">reporting
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-to"><code>report-to</code></dfn> directive defines a <a data-link-type="dfn" href="https://w3c.github.io/reporting/#group" id="ref-for-group">reporting
   group</a> to which violation reports ought to be sent <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a>. The
   directive’s behavior is defined in <a href="#report-violation">§5.3 Report a violation</a>. The directive’s name
   and value are described by the following ABNF:</p>
@@ -4374,11 +4374,11 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   modular extension by other specifications. At the time this document was
   produced, the following stable documents extend CSP:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines <code>block-all-mixed-content</code></p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[UPGRADE-INSECURE-REQUESTS]</a> defines <code>upgrade-insecure-requests</code></p>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="biblio" href="#biblio-sri">[SRI]</a> defines <code>require-sri-for</code></p>
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
@@ -4391,80 +4391,80 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>integrity sources</var> be the result of executing the algorithm
   defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
   the remaining substeps.</p>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
-         <li data-md="">
+         <li data-md>
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
   integrity match</var> to <code>false</code>.</p>
           </ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
   "<code>Allowed</code>".</p>
         </ol>
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
           <p>Otherwise, return "<code>Allowed</code>".</p>
           <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
@@ -4473,17 +4473,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>violates</var> be "<code>Does Not Violate</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
@@ -4491,18 +4491,18 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>source list</var> is not <code>null</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>nonce</var> is the empty string, return "<code>Does Not Match</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source④"><code>nonce-source</code></a> grammar,
   and <var>nonce</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑤"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
@@ -4520,25 +4520,25 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p class="assertion">Assert: <var>source list</var> is not <code>null</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>source list</var> is an empty list, return "<code>Does Not Match</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>source list</var> contains a single item which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑦">ASCII
   case-insensitive</a> match for the string "<code>'none'</code>", return "<code>Does Not Match</code>".</p>
       <p class="note" role="note"><span>Note:</span> An empty source list (that is, a directive without a value: <code>script-src</code>,
   as opposed to <code>script-src host1</code>) is equivalent to a source list containing <code>'none'</code>,
   and will not match any URL.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
   executed upon <var>url</var>, <var>expression</var>, <var>origin</var>, and <var>redirect count</var>, return
   "<code>Matches</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.2.6" id="match-url-to-source-expression"><span class="secno">6.6.2.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
@@ -4548,69 +4548,69 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
   meaning depending on that bit of context.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>expression</var> is the string "*", return "<code>Matches</code>" if one or more of
   the following conditions is met:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> This logic means that in order to allow a resource from a non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme③">network scheme</a>,
   it has to be either explicitly specified (e.g. <code>default-src * data: custom-scheme-1: custom-scheme-2:</code>),
   or the protected resource must be loaded from the same scheme.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source②"><code>scheme-source</code></a> or <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source②"><code>host-source</code></a> grammar:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a>, return "<code>Does Not Match</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source③"><code>scheme-source</code></a> grammar,
   return "<code>Matches</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source③"><code>host-source</code></a> grammar:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> is <code>null</code>, return "<code>Does Not Match</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>,
   return "<code>Does Not Match</code>".</p>
         <p class="note" role="note"><span>Note:</span> As with <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part④"><code>scheme-part</code></a> above, we allow schemeless <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source④"><code>host-source</code></a> expressions to be upgraded from insecure
   schemes to secure schemes.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part①"><code>host-part</code></a> does not <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match"><code>host-part</code> match</a> <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code>, return "<code>Does Not Match</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>port-part</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part①"><code>port-part</code></a> if present, and <code>null</code> otherwise.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>, return "<code>Does Not Match</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> contains a non-empty <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part①"><code>path-part</code></a>, and <var>redirect count</var> is 0, then:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Let <var>path</var> be the resulting of joining <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> on the U+002F SOLIDUS character (<code>/</code>).</p>
-         <li data-md="">
+         <li data-md>
           <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part②"><code>path-part</code></a> does not <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match"><code>path-part</code> match</a> <var>path</var>,
   return "<code>Does Not Match</code>".</p>
         </ol>
-       <li data-md="">
+       <li data-md>
         <p>Return "<code>Matches</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑧">ASCII case-insensitive</a> match for "<code>'self'</code>",
   return "<code>Matches</code>" if one or more of the following conditions is met:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin②">origin</a></p>
-       <li data-md="">
+       <li data-md>
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
   or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
   one or more of the following conditions is met:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
-         <li data-md="">
+         <li data-md>
           <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>http</code>"</p>
         </ol>
       </ol>
@@ -4620,35 +4620,35 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   particular scheme or a port that matches the origin of the protected
   resource, as this seems sufficient to deal with upgrades that can be
   reasonably expected to succeed.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
   to <code>script-src http: https:</code>, <code>script-src http://example.com</code> to <code>script-src http://example.com https://example.com</code>, and <code>connect-src ws:</code> to <code>connect-src ws: wss:</code>.</p>
     <p>More formally, two <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑥">ASCII strings</a> (<var>A</var> and <var>B</var>) are said to <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match③"><code>scheme-part</code> match</a> if the
   following algorithm returns "<code>Matches</code>":</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>If one of the following is true, return "<code>Matches</code>":</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑨">ASCII case-insensitive</a> match for <var>B</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⓪">ASCII case-insensitive</a> match for "<code>http</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①①">ASCII case-insensitive</a> match for "<code>https</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①②">ASCII case-insensitive</a> match for "<code>ws</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①③">ASCII case-insensitive</a> match for "<code>wss</code>", "<code>http</code>", or
   "<code>https</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①④">ASCII case-insensitive</a> match for "<code>wss</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑤">ASCII case-insensitive</a> match for "<code>https</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.2.8" id="match-hosts"><span class="secno">6.6.2.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
   string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part②"><code>host-part</code></a> could
   potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a>. For example, we say that
   "www.example.com" <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match①">host-part matches</a> "www.example.com".</p>
@@ -4657,21 +4657,21 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>A</var> matching <var>B</var> does not
   mean that <var>B</var> will match <var>A</var>. For example, <code>*.example.com</code> <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match③"><code>host-part</code> matches</a> <code>www.example.com</code>, but <code>www.example.com</code> does not <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match④"><code>host-part</code> match</a> <code>*.example.com</code>.</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>If the first character of <var>A</var> is an U+002A ASTERISK character (<code>*</code>):</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>remaining</var> be the result of removing the leading ("*") from <var>A</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>remaining</var> (including the leading U+002E FULL STOP character
   (<code>.</code>)) is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑥">ASCII case-insensitive</a> match for the rightmost
   characters of <var>B</var>, then return "<code>Matches</code>". Otherwise, return
   "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>A</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑦">ASCII case-insensitive</a> match for <var>B</var>, return
   "<code>Does Not Match</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>A</var> matches the <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.2.2" id="ref-for-section-3.2.2">IPv4address</a> rule from <a data-link-type="biblio" href="#biblio-rfc3986">[RFC3986]</a>, and
   is not "<code>127.0.0.1</code>"; or if <var>A</var> is an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-ipv6" id="ref-for-concept-ipv6">IPv6 address</a>, return
   "<code>Does Not Match</code>".</p>
@@ -4680,77 +4680,77 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   security properties of IP addresses in relation to named hosts,
   however, authors are encouraged to prefer the latter whenever
   possible.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
   strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>If <var>port A</var> is empty:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>port B</var> is the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port①">default port</a> for <var>scheme B</var>, return "<code>Matches</code>". Otherwise,
   return "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>port A</var> is equal to "*", return "<code>Matches</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>port A</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive③">case-sensitive</a> match for <var>port B</var>, return "<code>Matches</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>port B</var> is empty:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>port A</var> is the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port②">default port</a> for <var>scheme B</var>, return "<code>Matches</code>". Otherwise,
   return "<code>Does not Match</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.2.10" id="match-paths"><span class="secno">6.6.2.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
   For example, we say that "/subdirectory/" <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match①"><code>path-part</code> matches</a> "/subdirectory/file".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>path A</var> matching <var>path B</var> does not mean that <var>path B</var> will match <var>path A</var>.</p>
     <ol class="algorithm">
-     <li data-md="">
+     <li data-md>
       <p>If <var>path A</var> is empty, return "<code>Matches</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>path A</var> consists of one character that is equal to the U+002F SOLIDUS
   character (<code>/</code>) and <var>path B</var> is empty, return "<code>Matches</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>exact match</var> be <code>false</code> if the final character of <var>path A</var> is the U+002F
   SOLIDUS character (<code>/</code>), and <code>true</code> otherwise.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>path list A</var> and <var>path list B</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split①">strictly splitting</a> <var>path A</var> and <var>path B</var> respectively on the U+002F SOLIDUS character (<code>/</code>).</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>path list A</var> has more items than <var>path list B</var>, return
   "<code>Does Not Match</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>exact match</var> is <code>true</code>, and <var>path list A</var> does not have the same
   number of items as <var>path list B</var>, return "<code>Does Not Match</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>exact match</var> is <code>false</code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p class="assertion">Assert: the final item in <var>path list A</var> is the empty string.</p>
-       <li data-md="">
+       <li data-md>
         <p>Remove the final item from <var>path list A</var>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>piece A</var> in <var>path list A</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>Let <var>piece B</var> be the next item in <var>path list B</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#percent-decode" id="ref-for-percent-decode">Percent decode</a> <var>piece A</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#percent-decode" id="ref-for-percent-decode①">Percent decode</a> <var>piece B</var>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>piece A</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive④">case-sensitive</a> match
   for <var>piece B</var>, return "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
@@ -4760,26 +4760,26 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>element</var> does not have an attribute named "<code>nonce</code>", return "<code>Not Nonceable</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>element</var> is a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑤">script</a></code> element, then for each <var>attribute</var> in <var>element</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>attribute</var>’s name is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑧">ASCII case-insensitive</a> match for
   the string "<code>&lt;script</code>" or the string
   "<code>&lt;style</code>", return "<code>Not Nonceable</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>attribute</var>’s value contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑨">ASCII case-insensitive</a> match
   the string "<code>&lt;script</code>" or the string
   "<code>&lt;style</code>", return "<code>Not Nonceable</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>element</var> had a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute" id="ref-for-parse-error-duplicate-attribute">duplicate-attribute</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error" id="ref-for-concept-script-parse-error">parse error</a> during tokenization, return
   "<code>Not Nonceable</code>".</p>
       <p class="issue" id="issue-820579ab"><a class="self-link" href="#issue-820579ab"></a> We need some sort of hook in HTML to record this error if we’re
   planning on using it here. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a></p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Nonceable</code>".</p>
     </ol>
     <p class="issue" id="issue-4592ac7e"><a class="self-link" href="#issue-4592ac7e"></a> This processing is meant to mitigate the risk
@@ -4791,29 +4791,29 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
     <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.3.2" id="allow-all-inline"><span class="secno">6.6.3.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
-    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
+    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
     <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
   algorithm returns "<code>Allows</code>" if all inline content of a given <var>type</var> is
   allowed and "<code>Does Not Allow</code>" otherwise.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>allow all inline</var> be <code>false</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑥"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑥"><code>hash-source</code></a> grammar, return "<code>Does Not Allow</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>"
   and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
         <p class="note" role="note"><span>Note:</span> <code>'strict-dynamic'</code> only applies to scripts, not other resource
   types. Usage is explained in more detail in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②⓪">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑥"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline②"><code>'unsafe-inline'</code></a>",
   set <var>allow all inline</var> to <code>true</code>.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>allow all inline</var> is <code>true</code>, return "<code>Allows</code>".
   Otherwise, return "<code>Does Not Allow</code>".</p>
     </ol>
@@ -4841,61 +4841,61 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
   is embedded. See the integration points in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
   return "<code>Matches</code>".</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑦"><code>nonce-source</code></a> grammar,
   and <var>element</var> has a <code class="idl"><a data-link-type="idl">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑦">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a></code>, not to
   attributes of either element or to <code>javascript:</code> navigations.</p>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>unsafe-hashes flag</var> be <code>false</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②①">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑦"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes"><code>'unsafe-hashes'</code></a>",
   set <var>unsafe-hashes flag</var> to <code>true</code>. Break out of the loop.</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>unsafe-hashes flag</var> is <code>true</code>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑦"><code>hash-source</code></a> grammar:</p>
           <ol>
-           <li data-md="">
+           <li data-md>
             <p>Let <var>algorithm</var> be <code>null</code>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm②"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②②">ASCII case-insensitive</a> match for "sha256", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-">SHA-256</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm③"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②③">ASCII case-insensitive</a> match for "sha384", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-①">SHA-384</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm④"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②④">ASCII case-insensitive</a> match for "sha512", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-②">SHA-512</a>.</p>
-           <li data-md="">
+           <li data-md>
             <p>If <var>algorithm</var> is not <code>null</code>:</p>
             <ol>
-             <li data-md="">
+             <li data-md>
               <p>Let <var>actual</var> be the result of <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4①">base64 encoding</a> the
   result of applying <var>algorithm</var> to <var>source</var>.</p>
-             <li data-md="">
+             <li data-md>
               <p>Let <var>expected</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑦"><code>base64-value</code></a> part,
   with all '<code>-</code>' characters replaced with '<code>+</code>', and all '<code>_</code>' characters
   replaced with '<code>/</code>'.</p>
               <p class="note" role="note"><span>Note:</span> This replacement normalizes hashes expressed in <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-5" id="ref-for-section-5①">base64url
   encoding</a> into <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4②">base64 encoding</a> for matching.</p>
-             <li data-md="">
+             <li data-md>
               <p>If <var>actual</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑥">case-sensitive</a> match for <var>expected</var>, return
   "<code>Matches</code>".</p>
             </ol>
@@ -4905,85 +4905,85 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <p class="note" role="note"><span>Note:</span> Hashes apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑧">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element②">style</a></code>. If the
   "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes①"><code>'unsafe-hashes'</code></a>" source expression is present,
   they will also apply to event handlers, style attributes and <code>javascript:</code> navigations.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
     <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>",
   return <code>prefetch-src</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a>, and execute
   the associated steps:</p>
       <dl>
-       <dt data-md="">"<code>manifest</code>"
-       <dd data-md="">
+       <dt data-md>"<code>manifest</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>manifest-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>object</code>"
-       <dt data-md="">"<code>embed</code>"
-       <dd data-md="">
+       <dt data-md>"<code>object</code>"
+       <dt data-md>"<code>embed</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>object-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>document</code>"
-       <dd data-md="">
+       <dt data-md>"<code>document</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, return <code>frame-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>audio</code>"
-       <dt data-md="">"<code>track</code>"
-       <dt data-md="">"<code>video</code>"
-       <dd data-md="">
+       <dt data-md>"<code>audio</code>"
+       <dt data-md>"<code>track</code>"
+       <dt data-md>"<code>video</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>media-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>font</code>"
-       <dd data-md="">
+       <dt data-md>"<code>font</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>font-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>image</code>"
-       <dd data-md="">
+       <dt data-md>"<code>image</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>img-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>style</code>"
-       <dd data-md="">
+       <dt data-md>"<code>style</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>style-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>script</code>"
-       <dt data-md="">"<code>xslt</code>"
-       <dd data-md="">
+       <dt data-md>"<code>script</code>"
+       <dt data-md>"<code>xslt</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>script-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>serviceworker</code>"
-       <dt data-md="">"<code>sharedworker</code>"
-       <dt data-md="">"<code>worker</code>"
-       <dd data-md="">
+       <dt data-md>"<code>serviceworker</code>"
+       <dt data-md>"<code>sharedworker</code>"
+       <dt data-md>"<code>worker</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>worker-src</code>.</p>
         </ol>
       </dl>
-     <li data-md="">
+     <li data-md>
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
@@ -4991,26 +4991,26 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Switch on <var>type</var>:</p>
       <dl>
-       <dt data-md="">"<code>script</code>"
-       <dt data-md="">"<code>navigation</code>"
-       <dt data-md="">"<code>script attribute</code>"
-       <dd data-md="">
+       <dt data-md>"<code>script</code>"
+       <dt data-md>"<code>navigation</code>"
+       <dt data-md>"<code>script attribute</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>script-src</code>.</p>
         </ol>
-       <dt data-md="">"<code>style</code>"
-       <dt data-md="">"<code>style attribute</code>"
-       <dd data-md="">
+       <dt data-md>"<code>style</code>"
+       <dt data-md>"<code>style attribute</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
+         <li data-md>
           <p>Return <code>style-src</code>.</p>
         </ol>
       </dl>
-     <li data-md="">
+     <li data-md>
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get fetch directive fallback list" data-level="6.7.3" id="directive-fallback-list"><span class="secno">6.7.3. </span><span class="content"> Get fetch directive fallback list </span><a class="self-link" href="#directive-fallback-list"></a></h4>
@@ -5019,77 +5019,77 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   and it includes the effective directive itself.</p>
     <p>Given a string (<var>directive name</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Switch on <var>directive name</var>:</p>
       <dl>
-       <dt data-md="">"<code>script-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>script-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; script-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>style-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>style-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "style-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "style-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>worker-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>worker-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "worker-src", "child-src", "script-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "worker-src", "child-src", "script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>connect-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>connect-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "connect-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "connect-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>manifest-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>manifest-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "manifest-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "manifest-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>prefetch-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>prefetch-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "prefetch-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "prefetch-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>object-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>object-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "object-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "object-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>frame-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>frame-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "frame-src", "child-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "frame-src", "child-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>media-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>media-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "media-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "media-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>font-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>font-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "font-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "font-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>image-src</code>"
-       <dd data-md="">
+       <dt data-md>"<code>image-src</code>"
+       <dd data-md>
         <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "image-src", "default-src" >></code>.</p>
+         <li data-md>
+          <p>Return <code>&lt;&lt; "image-src", "default-src" >></code>.</p>
         </ol>
       </dl>
-     <li data-md="">
+     <li data-md>
       <p>Return <code>&lt;&lt; >></code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should fetch directive execute" data-level="6.7.4" id="should-directive-execute"><span class="secno">6.7.4. </span><span class="content"> Should fetch directive execute </span><a class="self-link" href="#should-directive-execute"></a></h4>
@@ -5101,17 +5101,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
   a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
-     <li data-md="">
+     <li data-md>
       <p>For each <var>fallback directive</var> in <var>directive fallback list</var>:</p>
       <ol>
-       <li data-md="">
+       <li data-md>
         <p>If <var>directive name</var> is <var>fallback directive</var>, Return "<code>Yes</code>".</p>
-       <li data-md="">
+       <li data-md>
         <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
       </ol>
-     <li data-md="">
+     <li data-md>
       <p>Return "<code>No</code>".</p>
     </ol>
    </section>
@@ -5136,13 +5136,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.2" id="security-nonce-stealing"><span class="secno">7.2. </span><span class="content">Nonce Stealing</span><a class="self-link" href="#security-nonce-stealing"></a></h3>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
   example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑨">script</a></code> element:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, [INJECTION POINT]<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>p</c-><c- p>></c->Hello, [INJECTION POINT]<c- p>&lt;/</c-><c- f>p</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     <p>If an attacker injects the string "<code>&lt;script src='https://evil.com/evil.js' </code>",
   then the browser will receive the following:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="p">></span>
-<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>p</c-><c- p>></c->Hello, <c- p>&lt;</c-><c- f>script</c-> <c- e>src</c-><c- o>=</c-><c- s>'https://evil.com/evil.js'</c-> &lt;/<c- e>p</c-><c- p>></c->
+<c- o>&lt;</c->script nonce<c- o>=</c->abc src<c- o>=</c->/good.js><c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
@@ -5155,11 +5155,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   origin. This, generally, is fine, and desirable from the developer’s perspective. However, if an
   attacker can inject a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element③">base</a></code> element, then an otherwise safe page can be subverted when relative
   URLs are resolved. That is, on <code>https://example.com/</code> the following code will load <code>https://example.com/good.js</code>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     <p>However, the following will load <code>https://evil.com/good.js</code>:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">base</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://evil.com"</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>base</c-> <c- e>href</c-><c- o>=</c-><c- s>"https://evil.com"</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
@@ -5195,11 +5195,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   expression if the resource being loaded is the result of a
   redirect. For example, given a page with an active policy of <code><a data-link-type="dfn" href="#img-src" id="ref-for-img-src③">img-src</a> example.com example.org/path</code>:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Directly loading <code>https://example.org/not-path</code> would fail, as it doesn’t match the policy.</p>
-     <li data-md="">
+     <li data-md>
       <p>Directly loading <code>https://example.com/redirector</code> would pass, as it matches <code>example.com</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Assuming that <code>https://example.com/redirector</code> delivered a redirect response pointing to <code>https://example.org/not-path</code>,
   the load would succeed, as the initial URL matches <code>example.com</code>,
   and the redirect target matches <code>example.org/path</code> if we ignore its path component.</p>
@@ -5219,7 +5219,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
      <a class="self-link" href="#example-d8547a52"></a> If this would not happen a page could execute inline scripts even without <code>unsafe-inline</code> in the page’s execution context by simply embedding a <code>srcdoc</code> <code>iframe</code>. 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">"&lt;script>alert(1);&lt;/script>"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
@@ -5230,10 +5230,10 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
     iframe will load (assuming the main page policy does not block it) since the
     policy inserted in the iframe will not affect it. 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></span>
-<span class="s">                   &lt;img src="not-example.com/image">'</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></c->
+<c- s>                   &lt;img src="not-example.com/image">'</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 
-<span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"not-example.com/image"</span><span class="p">></span>
+<c- p>&lt;</c-><c- f>img</c-> <c- e>src</c-><c- o>=</c-><c- s>"not-example.com/image"</c-><c- p>></c->
 </pre>
     </div>
    </section>
@@ -5278,13 +5278,13 @@ Content-Security-Policy: connect-src http://example.com/;
     <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
-     <li data-md="">
+     <li data-md>
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
   and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
-     <li data-md="">
+     <li data-md>
       <p>Script requests which are triggered by non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted③">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①②">script</a></code> elements are allowed.</p>
     </ol>
     <p>The first change allows you to deploy "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑤"><code>'strict-dynamic'</code></a> in a
@@ -5299,17 +5299,17 @@ Content-Security-Policy: connect-src http://example.com/;
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce</span><span class="o">=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<c- p>&lt;</c-><c- f>script</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://cdn.example.com/script.js"</c-> <c- e>nonce</c-><c- o>=</c-><c- s>"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</c-> <c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
     will not be blocked because of the matching <code class="idl"><a data-link-type="idl">nonce</a></code> attribute.</p>
      <p>If <code>script.js</code> contains the following code:</p>
-<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> document<span class="p">.</span>createElement<span class="p">(</span><span class="s1">'script'</span><span class="p">);</span>
-s<span class="p">.</span>src <span class="o">=</span> <span class="s1">'https://othercdn.not-example.net/dependency.js'</span><span class="p">;</span>
-document<span class="p">.</span>head<span class="p">.</span>appendChild<span class="p">(</span>s<span class="p">);</span>
+<pre class="highlight"><c- a>var</c-> s <c- o>=</c-> document<c- p>.</c->createElement<c- p>(</c-><c- t>'script'</c-><c- p>);</c->
+s<c- p>.</c->src <c- o>=</c-> <c- t>'https://othercdn.not-example.net/dependency.js'</c-><c- p>;</c->
+document<c- p>.</c->head<c- p>.</c->appendChild<c- p>(</c->s<c- p>);</c->
 
-document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&lt;scr'</span> <span class="o">+</span> <span class="s1">'ipt src="/sadness.js">&lt;/scr'</span> <span class="o">+</span> <span class="s1">'ipt>'</span><span class="p">);</span>
+document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ipt src="/sadness.js">&lt;/scr'</c-> <c- o>+</c-> <c- t>'ipt>'</c-><c- p>);</c->
 </pre>
      <p><code>dependency.js</code> will load, as the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①③">script</a></code> element created by <code>createElement()</code> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted④">"parser-inserted"</a>.</p>
      <p><code>sadness.js</code> will <em>not</em> load, however, as <code>document.write()</code> produces <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①④">script</a></code> elements which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted⑤">"parser-inserted"</a>.</p>
@@ -5327,7 +5327,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <div class="example" id="example-5d2d17c6">
       <a class="self-link" href="#example-5d2d17c6"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
       resembling a reasonable schedule: 
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>button</c-> <c- e>id</c-><c- o>=</c-><c- s>"action"</c-> <c- e>onclick</c-><c- o>=</c-><c- s>"doSubmit()"</c-><c- p>></c->
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
@@ -5358,16 +5358,16 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑦">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
       <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑧">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"</c-><b><c- s>sha384-xyz789</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"</c-><b><c- s>sha384-xyz789</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>sha384-xyz789</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
       <p>Metadata that is not recognized (either because it’s entirely invalid, or
       because it specifies a not-yet-supported hashing algorithm) does not affect
@@ -5375,9 +5375,9 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
       allowed to execute in the presence of the above policy, as the additional
       metadata is invalid and therefore wouldn’t allow a script whose content
       wasn’t listed explicitly in the policy to execute:</p>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>sha1024-abcd</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha512-321cba </c-><b><c- s>entirely-invalid</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>not-a-hash-at-all</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
      </div>
     </section>
@@ -5402,65 +5402,65 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
     <p>The Content Security Policy Directive registry should be updated with the
   following directives and references <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>:</p>
     <dl>
-     <dt data-md=""><a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri②"><code>base-uri</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri②"><code>base-uri</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-base-uri">§6.2.1 base-uri</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#child-src" id="ref-for-child-src①"><code>child-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#child-src" id="ref-for-child-src①"><code>child-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-child-src">§6.1.1 child-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src③"><code>connect-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src③"><code>connect-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-connect-src">§6.1.2 connect-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#default-src" id="ref-for-default-src⑤"><code>default-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#default-src" id="ref-for-default-src⑤"><code>default-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-default-src">§6.1.3 default-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#disown-opener" id="ref-for-disown-opener①"><code>disown-opener</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#disown-opener" id="ref-for-disown-opener①"><code>disown-opener</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-disown-opener">§6.2.4 disown-opener</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#font-src" id="ref-for-font-src④"><code>font-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#font-src" id="ref-for-font-src④"><code>font-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-font-src">§6.1.4 font-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#form-action" id="ref-for-form-action①"><code>form-action</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#form-action" id="ref-for-form-action①"><code>form-action</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-form-action">§6.3.1 form-action</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors⑤"><code>frame-ancestors</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors⑤"><code>frame-ancestors</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-frame-ancestors">§6.3.2 frame-ancestors</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src③"><code>frame-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src③"><code>frame-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-frame-src">§6.1.5 frame-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#img-src" id="ref-for-img-src④"><code>img-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#img-src" id="ref-for-img-src④"><code>img-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-img-src">§6.1.6 img-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src③"><code>manifest-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src③"><code>manifest-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-manifest-src">§6.1.7 manifest-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#media-src" id="ref-for-media-src③"><code>media-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#media-src" id="ref-for-media-src③"><code>media-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-media-src">§6.1.8 media-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-object-src">§6.1.10 object-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-plugin-types">§6.2.2 plugin-types</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri④"><code>report-uri</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri④"><code>report-uri</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-report-uri">§6.4.1 report-uri</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#report-to" id="ref-for-report-to⑤"><code>report-to</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#report-to" id="ref-for-report-to⑤"><code>report-to</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-report-to">§6.4.2 report-to</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
-     <dd data-md="">
+     <dt data-md><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
+     <dd data-md>
       <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
@@ -5497,9 +5497,9 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
     <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
     <p>Lots of people are awesome. For instance:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Mario and all of Cure53.</p>
-     <li data-md="">
+     <li data-md>
       <p>Artur Janc, Michele Spagnuolo, Lukas Weichselbaum, Jochen Eisinger, and the
 rest of Google’s CSP Cabal.</p>
     </ul>
@@ -6862,12 +6862,6 @@ rest of Google’s CSP Cabal.</p>
     Is element nonceable? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-a-ping">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping">https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-a-ping">6.1.2. connect-src</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-plugin-document">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document</a><b>Referenced in:</b>
    <ul>
@@ -7388,6 +7382,12 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-AElementPingAttribute">
+   <a href="https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute">https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-AElementPingAttribute">6.1.2. connect-src</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-url">
    <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
@@ -7684,7 +7684,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
      <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
      <li><span class="dfn-paneled" id="term-for-concept-script-parse-error" style="color:initial">parse error</span>
-     <li><span class="dfn-paneled" id="term-for-dom-a-ping" style="color:initial">ping</span>
      <li><span class="dfn-paneled" id="term-for-plugin-document" style="color:initial">plugin document</span>
      <li><span class="dfn-paneled" id="term-for-prepare-a-script" style="color:initial">prepare a script</span>
      <li><span class="dfn-paneled" id="term-for-process-a-navigate-fetch" style="color:initial">process a navigate fetch</span>
@@ -7793,6 +7792,11 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-②" style="color:initial">sha-512</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[SVG2]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-AElementPingAttribute" style="color:initial">ping</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-url" style="color:initial">URL</span>
@@ -7876,6 +7880,8 @@ rest of Google’s CSP Cabal.</p>
    <dd><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">FIPS PUB 180-4, Secure Hash Standard</a>. URL: <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf</a>
    <dt id="biblio-sri">[SRI]
    <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
+   <dt id="biblio-svg2">[SVG2]
+   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 7 August 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
@@ -7886,7 +7892,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 4 July 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 19 July 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -7917,39 +7923,39 @@ rest of Google’s CSP Cabal.</p>
    <dd>James Clark. <a href="https://www.w3.org/TR/xslt/">XSL Transformations (XSLT) Version 1.0</a>. 16 November 1999. REC. URL: <a href="https://www.w3.org/TR/xslt/">https://www.w3.org/TR/xslt/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><span class="kt">enum</span> <a class="nv" href="#enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></a> {
-  <a class="s" href="#dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code></a>, <a class="s" href="#dom-securitypolicyviolationeventdisposition-report"><code>"report"</code></a>
+<pre class="idl highlight def"><c- b>enum</c-> <a href="#enumdef-securitypolicyviolationeventdisposition"><code><c- g>SecurityPolicyViolationEventDisposition</c-></code></a> {
+  <a href="#dom-securitypolicyviolationeventdisposition-enforce"><code><c- s>"enforce"</c-></code></a>, <a href="#dom-securitypolicyviolationeventdisposition-report"><code><c- s>"report"</c-></code></a>
 };
 
-[<a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit①">SecurityPolicyViolationEventInit</a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
-<span class="kt">interface</span> <a class="nv" href="#securitypolicyviolationevent"><code>SecurityPolicyViolationEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①">Event</a> {
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi"><code>documentURI</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-referrer"><code>referrer</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri"><code>blockedURI</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective"><code>violatedDirective</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code>effectiveDirective</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code>originalPolicy</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-sourcefile"><code>sourceFile</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code>sample</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition②">SecurityPolicyViolationEventDisposition</a>      <a class="nv" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code>disposition</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code>statusCode</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber"><code>lineNumber</code></a>;
-    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber"><code>columnNumber</code></a>;
+[<a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨"><c- b>DOMString</c-></a> <a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit①"><c- n>SecurityPolicyViolationEventInit</c-></a> <a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>)]
+<c- b>interface</c-> <a href="#securitypolicyviolationevent"><code><c- g>SecurityPolicyViolationEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①"><c- n>Event</c-></a> {
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi"><code><c- g>documentURI</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-referrer"><code><c- g>referrer</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri"><code><c- g>blockedURI</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective"><code><c- g>violatedDirective</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code><c- g>effectiveDirective</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code><c- g>originalPolicy</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-sourcefile"><code><c- g>sourceFile</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code><c- g>sample</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition②"><c- n>SecurityPolicyViolationEventDisposition</c-></a>      <a data-readonly data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code><c- g>disposition</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><c- b>unsigned</c-> <c- b>short</c-></a> <a data-readonly data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code><c- g>statusCode</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber"><code><c- g>lineNumber</c-></code></a>;
+    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber"><code><c- g>columnNumber</c-></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-securitypolicyviolationeventinit"><code>SecurityPolicyViolationEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①">EventInit</a> {
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④①"><span class="kt">USVString</span></a>      <a class="nv" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-documenturi"><code>documentURI</code></a>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-referrer"><code>referrer</code></a> = "";
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-blockeduri"><code>blockedURI</code></a> = "";
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-violateddirective"><code>violatedDirective</code></a>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code>effectiveDirective</code></a>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code>originalPolicy</code></a>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code>sourceFile</code></a> = "";
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧①"><span class="kt">DOMString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code>sample</code></a> = "";
-    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①①">SecurityPolicyViolationEventDisposition</a> <a class="nv" data-type="SecurityPolicyViolationEventDisposition " href="#dom-securitypolicyviolationeventinit-disposition"><code>disposition</code></a>;
-    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code>statusCode</code></a>;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-linenumber"><code>lineNumber</code></a> = 0;
-             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-columnnumber"><code>columnNumber</code></a> = 0;
+<c- b>dictionary</c-> <a href="#dictdef-securitypolicyviolationeventinit"><code><c- g>SecurityPolicyViolationEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①"><c- n>EventInit</c-></a> {
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④①"><c- b>USVString</c-></a>      <a data-type="USVString      " href="#dom-securitypolicyviolationeventinit-documenturi"><code><c- g>documentURI</c-></code></a>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-referrer"><code><c- g>referrer</c-></code></a> = "";
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-blockeduri"><code><c- g>blockedURI</c-></code></a> = "";
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a>      <a data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-violateddirective"><code><c- g>violatedDirective</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><c- b>DOMString</c-></a>      <a data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code><c- g>effectiveDirective</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><c- b>DOMString</c-></a>      <a data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code><c- g>originalPolicy</c-></code></a>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code><c- g>sourceFile</c-></code></a> = "";
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧①"><c- b>DOMString</c-></a>      <a data-default="&quot;&quot;" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code><c- g>sample</c-></code></a> = "";
+    <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①①"><c- n>SecurityPolicyViolationEventDisposition</c-></a> <a data-type="SecurityPolicyViolationEventDisposition " href="#dom-securitypolicyviolationeventinit-disposition"><code><c- g>disposition</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①①"><c- b>unsigned</c-> <c- b>short</c-></a> <a data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code><c- g>statusCode</c-></code></a>;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-linenumber"><code><c- g>lineNumber</c-></code></a> = 0;
+             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-columnnumber"><code><c- g>columnNumber</c-></code></a> = 0;
 };
 
 </pre>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
+  <meta content="86643a535c7102bc8ef9e024596ca9ceb8928cae" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1720,41 +1720,17 @@ of security-relevant policy decisions.</p>
           <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-script-src-elem"><span class="secno">6.1.12</span> <span class="content"><code>script-src-elem</code></span></a>
+         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
          <ol class="toc">
-          <li><a href="#script-src-elem-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>script-src-elem</code> Pre-request check </span></a>
-          <li><a href="#script-src-elem-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>script-src-elem</code> Post-request check </span></a>
-          <li><a href="#script-src-elem-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>script-src-elem</code> Inline Check </span></a>
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-script-src-attr"><span class="secno">6.1.13</span> <span class="content"><code>script-src-attr</code></span></a>
+         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
          <ol class="toc">
-          <li><a href="#script-src-attr-inline"><span class="secno">6.1.13.1</span> <span class="content"> <code>script-src-attr</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src"><span class="secno">6.1.14</span> <span class="content"><code>style-src</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.14.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src-elem"><span class="secno">6.1.15</span> <span class="content"><code>style-src-elem</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-elem-pre-request"><span class="secno">6.1.15.1</span> <span class="content"> <code>style-src-elem</code> Pre-request Check </span></a>
-          <li><a href="#style-src-elem-post-request"><span class="secno">6.1.15.2</span> <span class="content"> <code>style-src-elem</code> Post-request Check </span></a>
-          <li><a href="#style-src-elem-inline"><span class="secno">6.1.15.3</span> <span class="content"> <code>style-src-elem</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src-attr"><span class="secno">6.1.16</span> <span class="content"><code>style-src-attr</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-attr-inline"><span class="secno">6.1.16.1</span> <span class="content"> <code>style-src-attr</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.17</span> <span class="content"><code>worker-src</code></span></a>
-         <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.17.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.17.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -3344,8 +3320,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-327c55f5">
-     <a class="self-link" href="#example-327c55f5"></a> The following header: 
+    <div class="example" id="example-d1d47ff9">
+     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3357,35 +3333,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-8536160a">
-     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-2a1475cd">
+     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3842,97 +3814,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "script-src-elem"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.</p>
-    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
-    <ul>
-     <li data-md="">
-      <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
-(and is ignored for "<code>script attribute</code>" inline checks).</p>
-     <li data-md="">
-      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
-execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
-     <li data-md="">
-      <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
-The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
-    </ul>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "script-src-attr"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
-  it will superseed the <code>script-src</code> directive for relevant checks.</p>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3944,7 +3836,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
@@ -3968,9 +3860,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3978,17 +3870,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3996,24 +3888,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4022,89 +3914,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "style-src-elem"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
-  except for styles defined in inline attributes.</p>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "style-src-attr"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
@@ -4119,30 +3934,30 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4155,7 +3970,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑦">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -4170,7 +3985,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
@@ -4236,9 +4051,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4251,7 +4066,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4259,7 +4074,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
     Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
@@ -4281,7 +4096,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4304,7 +4119,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4317,7 +4132,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4331,7 +4146,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4340,7 +4155,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4363,7 +4178,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4378,11 +4193,11 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4392,7 +4207,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4408,14 +4223,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
@@ -4439,7 +4254,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4451,7 +4266,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4472,12 +4287,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     </div>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigate-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4487,20 +4302,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
-  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
+  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> (<var>navigation response</var>)
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
@@ -4511,7 +4326,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
@@ -4519,7 +4334,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4568,23 +4383,23 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
        <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
@@ -4600,7 +4415,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -4613,7 +4428,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
@@ -4624,29 +4439,29 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4654,7 +4469,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4664,7 +4479,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
@@ -4672,7 +4487,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4691,15 +4506,15 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
@@ -4940,7 +4755,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.3.1" id="is-element-nonceable"><span class="secno">6.6.3.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
   a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
@@ -5020,7 +4835,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.3.3" id="match-element-to-source-list"><span class="secno">6.6.3.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
@@ -5095,8 +4910,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
@@ -5150,14 +4965,14 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src-elem</code>.</p>
+          <p>Return <code>style-src</code>.</p>
         </ol>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>xslt</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src-elem</code>.</p>
+          <p>Return <code>script-src</code>.</p>
         </ol>
        <dt data-md="">"<code>serviceworker</code>"
        <dt data-md="">"<code>sharedworker</code>"
@@ -5173,7 +4988,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
     <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> of the effective directive.</p>
-    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
      <li data-md="">
@@ -5181,28 +4996,18 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <dl>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>navigation</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>script-src-elem</code>.</p>
-        </ol>
        <dt data-md="">"<code>script attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src-attr</code>.</p>
+          <p>Return <code>script-src</code>.</p>
         </ol>
        <dt data-md="">"<code>style</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>style-src-elem</code>.</p>
-        </ol>
        <dt data-md="">"<code>style attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src-attr</code>.</p>
+          <p>Return <code>style-src</code>.</p>
         </ol>
       </dl>
      <li data-md="">
@@ -5217,29 +5022,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md="">
       <p>Switch on <var>directive name</var>:</p>
       <dl>
-       <dt data-md="">"<code>script-src-elem</code>"
+       <dt data-md="">"<code>script-src</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>script-src-attr</code>"
+       <dt data-md="">"<code>style-src</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
-        </ol>
-       <dt data-md="">"<code>style-src-elem</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
-        </ol>
-       <dt data-md="">"<code>style-src-attr</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; "style-src", "default-src" >></code>.</p>
         </ol>
        <dt data-md="">"<code>worker-src</code>"
        <dd data-md="">
@@ -5306,7 +5099,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   we are currently checking a worker request), a <code>default-src</code> directive
   should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
-  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
@@ -5328,7 +5121,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5371,7 +5164,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5482,12 +5275,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5502,7 +5295,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5538,7 +5331,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5592,7 +5385,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5660,15 +5453,15 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5899,8 +5692,6 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.2.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
    <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
-   <li><a href="#script-src-attr">script-src-attr</a><span>, in §6.1.13</span>
-   <li><a href="#script-src-elem">script-src-elem</a><span>, in §6.1.12</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5935,9 +5726,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.14</span>
-   <li><a href="#style-src-attr">style-src-attr</a><span>, in §6.1.16</span>
-   <li><a href="#style-src-elem">style-src-elem</a><span>, in §6.1.15</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
@@ -5952,7 +5741,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
    <a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">https://www.w3.org/TR/CSP3/#header-content-security-policy</a><b>Referenced in:</b>
@@ -5979,31 +5768,31 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
+    <li><a href="#ref-for-at-ruledef-import">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
+    <li><a href="#ref-for-insert-a-css-rule">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-css-rule">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -6023,7 +5812,7 @@ rest of Google’s CSP Cabal.</p>
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-document①①">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-document①②">6.1.14. style-src</a>
+    <li><a href="#ref-for-document①②">6.1.12. style-src</a>
     <li><a href="#ref-for-document①③">6.2.1. base-uri</a>
     <li><a href="#ref-for-document①④">6.2.1.1. 
     Is base allowed for document? </a>
@@ -6046,21 +5835,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-element③">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-element④">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑤">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-element⑦">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑧">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑨">6.2.2.2. 
+    <li><a href="#ref-for-element⑤">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-element①⓪">6.6.3.1. 
+    <li><a href="#ref-for-element⑥">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-element①①">6.6.3.3. 
+    <li><a href="#ref-for-element⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -6204,19 +5985,15 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata③">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata④">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.2.2. 
     Does nonce match source list? </a>
    </ul>
   </aside>
@@ -6502,50 +6279,42 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-concept-request④③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
+    <li><a href="#ref-for-concept-request④④">6.1.12. style-src</a>
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
+    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
+    <li><a href="#ref-for-concept-request④⑦">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
+    <li><a href="#ref-for-concept-request④⑧">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
+    <li><a href="#ref-for-concept-request④⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤⓪">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤①">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤②">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤③">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤④">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥⓪">(2)</a>
+    <li><a href="#ref-for-concept-request⑥①">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
+    <li><a href="#ref-for-concept-request⑥②">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥③">(2)</a>
+    <li><a href="#ref-for-concept-request⑥④">6.7.2. 
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
@@ -6592,32 +6361,28 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑦">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-response③①">6.1.14.2. 
+    <li><a href="#ref-for-concept-response②⑨">6.1.12. style-src</a>
+    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③②">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.1.17.2. 
+    <li><a href="#ref-for-concept-response③①">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③④">6.2.2.1. 
+    <li><a href="#ref-for-concept-response③②">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.3.1. 
+    <li><a href="#ref-for-concept-response③③">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③⑥">6.2.3.2. 
+    <li><a href="#ref-for-concept-response③④">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑦">6.2.4.1. 
+    <li><a href="#ref-for-concept-response③⑤">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
+    <li><a href="#ref-for-concept-response③⑥">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
-    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
+    <li><a href="#ref-for-concept-response③⑦">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response③⑧">(2)</a>
+    <li><a href="#ref-for-concept-response③⑨">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
+    <li><a href="#ref-for-concept-response④⓪">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
+    <li><a href="#ref-for-concept-response④①">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6696,7 +6461,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
+    <li><a href="#ref-for-sharedworker①">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
@@ -6723,7 +6488,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
+    <li><a href="#ref-for-worker②">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -6999,7 +6764,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-link-element①">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
@@ -7249,7 +7014,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
@@ -7592,7 +7357,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
+    <li><a href="#ref-for-serviceworker①">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -8310,55 +8075,39 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.3. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.17.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.7.4. 
     Should fetch directive execute </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑦①">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑦②">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8633,52 +8382,39 @@ rest of Google’s CSP Cabal.</p>
     object-src Post-request check </a>
     <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
-    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
-    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
-    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.12.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③②">(2)</a>
+    <li><a href="#ref-for-directive-value③③">6.1.12.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value③④">(2)</a>
+    <li><a href="#ref-for-directive-value③⑤">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
-    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
-    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
-    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
+    <li><a href="#ref-for-directive-value③⑥">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
+    <li><a href="#ref-for-directive-value③⑦">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
+    <li><a href="#ref-for-directive-value③⑧">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
+    <li><a href="#ref-for-directive-value③⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⓪">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-directive-value④①">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
+    <li><a href="#ref-for-directive-value④②">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
+    <li><a href="#ref-for-directive-value④③">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
+    <li><a href="#ref-for-directive-value④④">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
-    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
-    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
+    <li><a href="#ref-for-directive-value④⑤">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value④⑥">(2)</a>
+    <li><a href="#ref-for-directive-value④⑦">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value④⑧">(2)</a>
+    <li><a href="#ref-for-directive-value④⑨">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⓪">(2)</a> <a href="#ref-for-directive-value⑤①">(3)</a> <a href="#ref-for-directive-value⑤②">(4)</a> <a href="#ref-for-directive-value⑤③">(5)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a> <a href="#ref-for-directive-value⑤⑥">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8733,18 +8469,14 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.1.17.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑧">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑨">6.6.2.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check②⓪">6.6.2.3. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -8779,20 +8511,16 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.1.17.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑨">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check②⓪">6.5. 
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check②①">6.6.1.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check②②">6.6.2.4. 
+    <li><a href="#ref-for-directive-post-request-check②⓪">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -8823,15 +8551,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-directive-inline-check⑤">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑥">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑦">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑧">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑨">6.1.16.1. 
-    style-src-attr Inline Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-initialization">
@@ -8839,7 +8559,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.14.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -8886,7 +8606,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-source-lists①②">6.6.2.2. 
     Does nonce match source list? </a>
@@ -8935,15 +8655,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.1.15. style-src-elem</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.1.16. style-src-attr</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.1.17. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑦">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑧">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigate-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -9050,9 +8766,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
-    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
+    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -9121,7 +8837,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-nonce-source④">6.6.2.2. 
     Does nonce match source list? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.3.1. 
@@ -9152,7 +8868,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-hash-source④">6.6.1.1. 
     Script directives pre-request check </a> <a href="#ref-for-grammardef-hash-source⑤">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source⑥">6.6.3.2. 
@@ -9644,51 +9360,29 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
-    <li><a href="#ref-for-script-src④">8.3. 
+    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
+    <li><a href="#ref-for-script-src⑤">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
+    <li><a href="#ref-for-script-src⑦">8.3. 
       Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑤">10.1. 
+    <li><a href="#ref-for-script-src⑧">10.1. 
     Directive Registry </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="script-src-elem">
-   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="script-src-attr">
-   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src①">10.1. 
+    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
+    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src③">10.1. 
     Directive Registry </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="style-src-elem">
-   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="style-src-attr">
-   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
+    <li><a href="#ref-for-worker-src②">6.1.13. worker-src</a>
     <li><a href="#ref-for-worker-src③">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="f3349bf4cc808ae7f96ac3379286523d5ee3eda3" name="document-revision">
+  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-10">10 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-11">11 July 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1562,7 +1562,7 @@ of security-relevant policy decisions.</p>
   <div data-fill-with="at-risk">
    <p>The following features are at-risk, and may be dropped during the CR period: </p>
    <ul>
-    <li>The <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> algorithm.
+    <li>The <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm.
    </ul>
    <p>“At-risk” is a W3C Process term-of-art, and does not necessarily imply that the feature is in danger of being dropped or delayed. It means that the WG believes the feature may have difficulty being interoperably implemented in a timely manner, and marking it as such allows the WG to drop the feature if necessary when transitioning to the Proposed Rec stage, without having to publish a new Candidate Rec without the feature first.</p>
   </div>
@@ -1668,6 +1668,7 @@ of security-relevant policy decisions.</p>
          <ol class="toc">
           <li><a href="#default-src-pre-request"><span class="secno">6.1.3.1</span> <span class="content"> <code>default-src</code> Pre-request check </span></a>
           <li><a href="#default-src-post-request"><span class="secno">6.1.3.2</span> <span class="content"> <code>default-src</code> Post-request check </span></a>
+          <li><a href="#default-src-inline"><span class="secno">6.1.3.3</span> <span class="content"> <code>default-src</code> Inline Check </span></a>
          </ol>
         <li>
          <a href="#directive-font-src"><span class="secno">6.1.4</span> <span class="content"><code>font-src</code></span></a>
@@ -1719,17 +1720,41 @@ of security-relevant policy decisions.</p>
           <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
+         <a href="#directive-script-src-elem"><span class="secno">6.1.12</span> <span class="content"><code>script-src-elem</code></span></a>
          <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+          <li><a href="#script-src-elem-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>script-src-elem</code> Pre-request check </span></a>
+          <li><a href="#script-src-elem-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>script-src-elem</code> Post-request check </span></a>
+          <li><a href="#script-src-elem-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>script-src-elem</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
+         <a href="#directive-script-src-attr"><span class="secno">6.1.13</span> <span class="content"><code>script-src-attr</code></span></a>
          <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#script-src-attr-inline"><span class="secno">6.1.13.1</span> <span class="content"> <code>script-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src"><span class="secno">6.1.14</span> <span class="content"><code>style-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.14.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-elem"><span class="secno">6.1.15</span> <span class="content"><code>style-src-elem</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-elem-pre-request"><span class="secno">6.1.15.1</span> <span class="content"> <code>style-src-elem</code> Pre-request Check </span></a>
+          <li><a href="#style-src-elem-post-request"><span class="secno">6.1.15.2</span> <span class="content"> <code>style-src-elem</code> Post-request Check </span></a>
+          <li><a href="#style-src-elem-inline"><span class="secno">6.1.15.3</span> <span class="content"> <code>style-src-elem</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-attr"><span class="secno">6.1.16</span> <span class="content"><code>style-src-attr</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-attr-inline"><span class="secno">6.1.16.1</span> <span class="content"> <code>style-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-worker-src"><span class="secno">6.1.17</span> <span class="content"><code>worker-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.17.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.17.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -1788,30 +1813,43 @@ of security-relevant policy decisions.</p>
        </ol>
       <li><a href="#directives-elsewhere"><span class="secno">6.5</span> <span class="content"> Directives Defined in Other Documents </span></a>
       <li>
-       <a href="#algorithms"><span class="secno">6.6</span> <span class="content">Matching Algorithms</span></a>
+       <a href="#matching-algorithms"><span class="secno">6.6</span> <span class="content">Matching Algorithms</span></a>
        <ol class="toc">
         <li>
-         <a href="#matching-urls"><span class="secno">6.6.1</span> <span class="content">URL Matching</span></a>
+         <a href="#script-checks"><span class="secno">6.6.1</span> <span class="content">Script directive checks</span></a>
          <ol class="toc">
-          <li><a href="#does-request-violate-policy"><span class="secno">6.6.1.1</span> <span class="content"> Does <var>request</var> violate <var>policy</var>? </span></a>
-          <li><a href="#match-nonce-to-source-list"><span class="secno">6.6.1.2</span> <span class="content"> Does <var>nonce</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-request-to-source-list"><span class="secno">6.6.1.3</span> <span class="content"> Does <var>request</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-response-to-source-list"><span class="secno">6.6.1.4</span> <span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-url-to-source-list"><span class="secno">6.6.1.5</span> <span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
-          <li><a href="#match-url-to-source-expression"><span class="secno">6.6.1.6</span> <span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
-          <li><a href="#match-schemes"><span class="secno">6.6.1.7</span> <span class="content"> <code>scheme-part</code> matching </span></a>
-          <li><a href="#match-hosts"><span class="secno">6.6.1.8</span> <span class="content"> <code>host-part</code> matching </span></a>
-          <li><a href="#match-ports"><span class="secno">6.6.1.9</span> <span class="content"> <code>port-part</code> matching </span></a>
-          <li><a href="#match-paths"><span class="secno">6.6.1.10</span> <span class="content"> <code>path-part</code> matching </span></a>
-          <li><a href="#effective-directive-for-a-request"><span class="secno">6.6.1.11</span> <span class="content"> Get the effective directive for <var>request</var> </span></a>
+          <li><a href="#script-pre-request"><span class="secno">6.6.1.1</span> <span class="content"> Script directives pre-request check </span></a>
+          <li><a href="#script-post-request"><span class="secno">6.6.1.2</span> <span class="content"> Script directives post-request check </span></a>
          </ol>
         <li>
-         <a href="#matching-elements"><span class="secno">6.6.2</span> <span class="content">Element Matching Algorithms</span></a>
+         <a href="#matching-urls"><span class="secno">6.6.2</span> <span class="content">URL Matching</span></a>
          <ol class="toc">
-          <li><a href="#is-element-nonceable"><span class="secno">6.6.2.1</span> <span class="content"> Is <var>element</var> nonceable? </span></a>
-          <li><a href="#allow-all-inline"><span class="secno">6.6.2.2</span> <span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span></a>
-          <li><a href="#match-element-to-source-list"><span class="secno">6.6.2.3</span> <span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span></a>
+          <li><a href="#does-request-violate-policy"><span class="secno">6.6.2.1</span> <span class="content"> Does <var>request</var> violate <var>policy</var>? </span></a>
+          <li><a href="#match-nonce-to-source-list"><span class="secno">6.6.2.2</span> <span class="content"> Does <var>nonce</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-request-to-source-list"><span class="secno">6.6.2.3</span> <span class="content"> Does <var>request</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-response-to-source-list"><span class="secno">6.6.2.4</span> <span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-url-to-source-list"><span class="secno">6.6.2.5</span> <span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
+          <li><a href="#match-url-to-source-expression"><span class="secno">6.6.2.6</span> <span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
+          <li><a href="#match-schemes"><span class="secno">6.6.2.7</span> <span class="content"> <code>scheme-part</code> matching </span></a>
+          <li><a href="#match-hosts"><span class="secno">6.6.2.8</span> <span class="content"> <code>host-part</code> matching </span></a>
+          <li><a href="#match-ports"><span class="secno">6.6.2.9</span> <span class="content"> <code>port-part</code> matching </span></a>
+          <li><a href="#match-paths"><span class="secno">6.6.2.10</span> <span class="content"> <code>path-part</code> matching </span></a>
          </ol>
+        <li>
+         <a href="#matching-elements"><span class="secno">6.6.3</span> <span class="content">Element Matching Algorithms</span></a>
+         <ol class="toc">
+          <li><a href="#is-element-nonceable"><span class="secno">6.6.3.1</span> <span class="content"> Is <var>element</var> nonceable? </span></a>
+          <li><a href="#allow-all-inline"><span class="secno">6.6.3.2</span> <span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span></a>
+          <li><a href="#match-element-to-source-list"><span class="secno">6.6.3.3</span> <span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span></a>
+         </ol>
+       </ol>
+      <li>
+       <a href="#directive-algorithms"><span class="secno">6.7</span> <span class="content">Directive Algorithms</span></a>
+       <ol class="toc">
+        <li><a href="#effective-directive-for-a-request"><span class="secno">6.7.1</span> <span class="content"> Get the effective directive for <var>request</var> </span></a>
+        <li><a href="#effective-directive-for-inline-check"><span class="secno">6.7.2</span> <span class="content"> Get the effective directive for inline checks </span></a>
+        <li><a href="#directive-fallback-list"><span class="secno">6.7.3</span> <span class="content"> Get fetch directive fallback list </span></a>
+        <li><a href="#should-directive-execute"><span class="secno">6.7.4</span> <span class="content"> Should fetch directive execute </span></a>
        </ol>
      </ol>
     <li>
@@ -1974,7 +2012,7 @@ of security-relevant policy decisions.</p>
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
   unless that non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme①">network scheme</a> is the same as the scheme of protected resource,
-  as described in <a href="#match-url-to-source-expression">§6.6.1.6 Does url match expression in origin with redirect count?</a>.</p>
+  as described in <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a>.</p>
      <li data-md="">
       <p>Hash-based source expressions may now match external scripts if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①">script</a></code> element that triggers the request specifies a set of integrity
   metadata which is listed in the current policy. Details in <a href="#external-hash">§8.4 Allowing external JavaScript via hashes</a>.</p>
@@ -2107,22 +2145,23 @@ of security-relevant policy decisions.</p>
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
-  type string, and a source string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
-    by Content Security Policy?</a> for <code>javascript:</code> requests. This algorithm returns "<code>Allowed</code>" unless
-  otherwise specified.</p>
+  type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a>, and a source string as arguments,
+  and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
+    by Content Security Policy?</a> for <code>javascript:</code> requests. This
+  algorithm returns "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
      <li data-md="">
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments, and
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing contexts</a>, a check type string ("<code>source</code>"
-  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
+  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
@@ -2188,7 +2227,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   characters; internationalized domain names cannot be entered directly as part
   of a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp②">serialized CSP</a>, but instead MUST be Punycode-encoded <a data-link-type="biblio" href="#biblio-rfc3492">[RFC3492]</a>. For example, the domain <code>üüüüüü.de</code> MUST be represented as <code>xn--tdaaaaaa.de</code>.</p>
     <p class="note" role="note"><span>Note:</span> Though IP address do match the grammar above, only <code>127.0.0.1</code> will actually match a URL when used in a source
-  expression (see <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> for details). The security
+  expression (see <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> for details). The security
   properties of IP addresses are suspect, and authors ought to prefer hostnames
   whenever possible.</p>
     <p class="note" role="note"><span>Note:</span> The <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value②">base64-value</a> grammar allows both <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4">base64</a> and <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-5" id="ref-for-section-5">base64url</a> encoding. These encodings are treated as equivalant when
@@ -2198,9 +2237,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
-  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
+  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
-  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> has been violated.</p>
+  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
@@ -2210,8 +2249,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   which violated the policy.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
   enforcement caused the violation.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
@@ -2227,7 +2266,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   characters of an inline script, event handler, or style that caused an violation. Violations
   which stem from an external file will not include a sample in the violation report.</p>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
+    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
      <li data-md="">
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
@@ -2253,7 +2292,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, policy, and directive" data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a string
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> (<var>policy</var>), and a string
   (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
@@ -2269,10 +2308,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="policy-delivery"><span class="secno">3. </span><span class="content"> Policy Delivery </span><a class="self-link" href="#policy-delivery"></a></h2>
-    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
+    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
   representation</a> via an HTTP response header field whose value is a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp③">serialized CSP</a>. This mechanism is defined in detail in <a href="#csp-header">§3.1 The Content-Security-Policy HTTP Response Header Field</a> and <a href="#cspro-header">§3.2 The Content-Security-Policy-Report-Only HTTP Response Header Field</a>, and the integration with Fetch
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
@@ -2363,7 +2402,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
   user agent needs to <a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#parse-serialized-policy" id="ref-for-parse-serialized-policy②">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
@@ -2407,7 +2446,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>violates</var>.</p>
       </ol>
@@ -2426,7 +2465,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then:</p>
         <ol>
@@ -2494,18 +2533,18 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
      <li data-md="">
-      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> objects which are
+      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md="">
       <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑥">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a> as the <code>object</code>.</p>
      <li data-md="">
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
      <li data-md="">
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithms in order to
-  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
+  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
      <li data-md="">
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
@@ -2514,7 +2553,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
+      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
      <li data-md="">
       <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
      <li data-md="">
@@ -2571,7 +2610,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> by embedding a frame or popping up a new window containing content it
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
@@ -2663,7 +2702,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <ol>
          <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check">inline check</a> returns
-  "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, and <var>source</var>,
+  "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>,
   skip to the next <var>directive</var>.</p>
          <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
@@ -2862,9 +2901,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></dfn> {
   <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-report"><code>"report"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -3204,31 +3243,27 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is not <code>frame-src</code> or <code>worker-src</code>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is not <code>frame-src</code> or <code>worker-src</code>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
@@ -3272,33 +3307,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is "":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3313,8 +3344,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-d1d47ff9">
-     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
+    <div class="example" id="example-327c55f5">
+     <a class="self-link" href="#example-327c55f5"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3326,31 +3357,35 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-2a1475cd">
-     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-8536160a">
+     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3359,38 +3394,38 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is "<code>script-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> is "<code>child-src</code>" , return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+  comparison.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="default-src Inline Check" data-level="6.1.3.3" id="default-src-inline"><span class="secno">6.1.3.3. </span><span class="content"> <code>default-src</code> Inline Check </span><a class="self-link" href="#default-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
      <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>script-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is "<code>child-src</code>" , return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
@@ -3419,33 +3454,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is "<code>font</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is "<code>font</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3467,35 +3498,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context③">nested browsing
-  context</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context②">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing
-  context</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3507,7 +3532,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑤">serialized-source-list</a>
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">requests</a> which load images. More formally, this
-  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
+  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
     <div class="example" id="example-ad572c5c">
      <a class="self-link" href="#example-ad572c5c"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src②">img-src</a> https://example.com/
@@ -3519,33 +3544,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⓪">destination</a> is "<code>image</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①①">destination</a> is "<code>image</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3567,33 +3588,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①②">destination</a> is "<code>manifest</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①③">destination</a> is "<code>manifest</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3618,35 +3635,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①④">destination</a> is one of "<code>audio</code>", "<code>video</code>",
-  or "<code>track</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑤">destination</a> is one of "<code>audio</code>", "<code>video</code>",
-  or "<code>track</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3668,33 +3679,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator③">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator④">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
-  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
+  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3720,13 +3727,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   on the specified <code>type</code>), it MUST be blocked if <code>object-src</code>'s value is <code>'none'</code>, but will otherwise be allowed.</p>
     <p class="note" role="note"><span>Note:</span> The <code>object-src</code> directive acts upon any request made on behalf of
   an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element②">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element①">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet①"><code>applet</code></a> element. This includes requests
-  which would populate the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a> generated by the
+  which would populate the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context③">nested browsing context</a> generated by the
   former two (also including navigations). This is true even when the data is
   semantically equivalent to content which would otherwise be restricted by
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
-    <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> delivered along
+    <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing context</a>, and not as an embedded
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3734,33 +3741,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑥">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑦">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3803,117 +3806,133 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②④">name</a> is "<code>worker-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑤">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑧">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source expressions</a> in
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
-       <li data-md="">
-        <p>If <var>integrity expressions</var> is not empty:</p>
-        <ol>
-         <li data-md="">
-          <p>Let <var>integrity sources</var> be the result of executing the algorithm
-  defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
-         <li data-md="">
-          <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
-  the remaining substeps.</p>
-         <li data-md="">
-          <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
-         <li data-md="">
-          <p>For each <var>source</var> in <var>integrity sources</var>:</p>
-          <ol>
-           <li data-md="">
-            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> does not
-  contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
-  for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
-  for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
-  integrity match</var> to <code>false</code>.</p>
-          </ol>
-         <li data-md="">
-          <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
-  "<code>Allowed</code>".</p>
-        </ol>
-        <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> specified by
-  this directive. We rely on the browser’s enforcement of Subresource
-  Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
-       <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>:</p>
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
-          <p>Otherwise, return "<code>Allowed</code>".</p>
-          <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
-  in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-        </ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑥">name</a> is "<code>worker-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑦">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑨">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> contains
-  "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
-  return "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>":</p>
-      <ol>
-       <li data-md="">
-        <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.</p>
+    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
+    <ul>
+     <li data-md="">
+      <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
+(and is ignored for "<code>script attribute</code>" inline checks).</p>
+     <li data-md="">
+      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
+execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
+     <li data-md="">
+      <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
+The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
+    </ul>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the <code>script-src</code> directive for relevant checks.</p>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3925,13 +3944,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
   implicitly by not specifying a <code>style-src</code> (or <code>default-src</code>) directive,
-  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> that matches
+  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> that matches
   the inline block.</p>
      <li data-md="">
       <p>The following CSS algorithms are gated on the <code>unsafe-eval</code> source
@@ -3949,57 +3968,53 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⓪">destination</a> is "<code>style</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is "<code>Matches</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②①">destination</a> is "<code>style</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is "<code>Matches</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Does Not Match</code>", return
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>style</code>" or "<code>style attribute</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>, <var>type</var>,
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4007,12 +4022,89 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+  "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
@@ -4027,37 +4119,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②②">destination</a> is one of
-  "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
-      <ol start="4">
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②③">destination</a> is one of
-  "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4069,7 +4155,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑦">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -4082,13 +4168,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
        <li data-md="">
-        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑧">name</a> is
+        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
+        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
          <li data-md="">
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global
@@ -4150,22 +4236,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②④">destination</a> is either "<code>object</code>"
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is either "<code>object</code>"
   or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
         <p>Let <var>type</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">extracting a
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
-        <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>, return "<code>Blocked</code>".</p>
+        <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4173,7 +4259,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
     Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
@@ -4181,7 +4267,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①⓪">CSP list</a>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
+        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
          <li data-md="">
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
@@ -4194,8 +4280,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
            <li data-md="">
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
-            <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
+            <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4218,7 +4304,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4226,12 +4312,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑤">destination</a> is one of
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is one of
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4245,7 +4331,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4254,7 +4340,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4277,7 +4363,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4292,11 +4378,11 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4306,7 +4392,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4322,25 +4408,25 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
-  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directive</a>.</p>
+  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md="">
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
      <li data-md="">
-      <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑦">nested browsing context</a>, return "<code>Allowed</code>".</p>
+      <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Let <var>current</var> be <var>target</var>.</p>
      <li data-md="">
@@ -4352,8 +4438,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
-        <p>If <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+        <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4365,7 +4451,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑥">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4386,12 +4472,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     </div>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigate-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4399,41 +4485,41 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="assertion">Assert: <var>source</var> and <var>target</var> are unused as 'navigate-to'
   is concerned with the details of the request.</p>
      <li data-md="">
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑦">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
-  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
+  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
      <li data-md="">
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑧">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
      <li data-md="">
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑨">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>, return "<code>Allowed</code>".</p>
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
   already checked the navigation in <a href="#navigate-to-pre-navigate">§6.3.3.1 navigate-to Pre-Navigation Check</a>.</p>
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4482,14 +4568,94 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
-    <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
-    <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
-    <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>), this
-  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives④⓪">directive</a> if the request violates the
+    <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
+    <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+       <li data-md="">
+        <p>If <var>integrity expressions</var> is not empty:</p>
+        <ol>
+         <li data-md="">
+          <p>Let <var>integrity sources</var> be the result of executing the algorithm
+  defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
+         <li data-md="">
+          <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
+  the remaining substeps.</p>
+         <li data-md="">
+          <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
+         <li data-md="">
+          <p>For each <var>source</var> in <var>integrity sources</var>:</p>
+          <ol>
+           <li data-md="">
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
+  contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
+  for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
+  for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
+  integrity match</var> to <code>false</code>.</p>
+          </ol>
+         <li data-md="">
+          <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
+  "<code>Allowed</code>".</p>
+        </ol>
+        <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
+  Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
+       <li data-md="">
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
+        <ol>
+         <li data-md="">
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
+          <p>Otherwise, return "<code>Allowed</code>".</p>
+          <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
+  in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
+        </ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
+  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
+  "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
+  return "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
+  "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
      <li data-md="">
@@ -4498,15 +4664,15 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>violates</var>.</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.1.2" id="match-nonce-to-source-list"><span class="secno">6.6.1.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4524,17 +4690,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.1.3" id="match-request-to-source-list"><span class="secno">6.6.1.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
+    <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives④①">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> is reasonable.</p>
-    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.1.4" id="match-response-to-source-list"><span class="secno">6.6.1.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives④②">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> is reasonable.</p>
-    <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.1.5" id="match-url-to-source-list"><span class="secno">6.6.1.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
+    <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
@@ -4553,14 +4719,14 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <a href="#match-url-to-source-expression">§6.6.1.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
+        <p>If <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
   executed upon <var>url</var>, <var>expression</var>, <var>origin</var>, and <var>redirect count</var>, return
   "<code>Matches</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.1.6" id="match-url-to-source-expression"><span class="secno">6.6.1.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.2.6" id="match-url-to-source-expression"><span class="secno">6.6.2.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑨">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
   returns "<code>Matches</code>" if <var>url</var> matches <var>expression</var>, and "<code>Does Not Match</code>"
   otherwise.</p>
@@ -4642,7 +4808,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.1.7" id="match-schemes"><span class="secno">6.6.1.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
@@ -4666,7 +4832,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.1.8" id="match-hosts"><span class="secno">6.6.1.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.2.8" id="match-hosts"><span class="secno">6.6.2.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
   string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part②"><code>host-part</code></a> could
   potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a>. For example, we say that
@@ -4702,7 +4868,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.1.9" id="match-ports"><span class="secno">6.6.1.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
   strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
@@ -4727,7 +4893,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.1.10" id="match-paths"><span class="secno">6.6.1.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.2.10" id="match-paths"><span class="secno">6.6.2.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
   For example, we say that "/subdirectory/" <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match①"><code>path-part</code> matches</a> "/subdirectory/file".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>path A</var> matching <var>path B</var> does not mean that <var>path B</var> will match <var>path A</var>.</p>
@@ -4772,94 +4938,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑨">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
-    <ol>
-     <li data-md="">
-      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑥">destination</a>, and execute
-  the associated steps:</p>
-      <dl>
-       <dt data-md="">""
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator⑤">initiator</a> is
-  the empty string, return <code>connect-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>manifest</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>manifest-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>object</code>"
-       <dt data-md="">"<code>embed</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>object-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>prefetch</code>"
-       <dt data-md="">"<code>prerender</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>prefetch-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>document</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context③">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑧">nested browsing context</a>, return <code>frame-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>audio</code>"
-       <dt data-md="">"<code>track</code>"
-       <dt data-md="">"<code>video</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>media-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>font</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>font-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>image</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>img-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>style</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>style-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>script</code>"
-       <dt data-md="">"<code>xslt</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>script-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>sharedworker</code>"
-       <dt data-md="">"<code>worker</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>worker-src</code>.</p>
-        </ol>
-      </dl>
-     <li data-md="">
-      <p>Return <code>null</code>.</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.6.2" id="matching-elements"><span class="secno">6.6.2. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
-    <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.2.1" id="is-element-nonceable"><span class="secno">6.6.2.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
+    <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.3.1" id="is-element-nonceable"><span class="secno">6.6.3.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
   a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
@@ -4894,7 +4975,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑥">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
-    <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.2.2" id="allow-all-inline"><span class="secno">6.6.2.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.3.2" id="allow-all-inline"><span class="secno">6.6.3.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
     <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
     <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
@@ -4938,18 +5019,18 @@ http://example.com 'unsafe-inline' 'nonce-abc'
 http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.2.3" id="match-element-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.3.3" id="match-element-to-source-list"><span class="secno">6.6.3.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
   is embedded. See the integration points in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
     <ol>
      <li data-md="">
-      <p>If <a href="#allow-all-inline">§6.6.2.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
+      <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
   return "<code>Matches</code>".</p>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
+      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
       <ol>
        <li data-md="">
         <p>For each <var>expression</var> in <var>list</var>:</p>
@@ -5012,6 +5093,234 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
+    <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
+    <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>",
+  return <code>prefetch-src</code>.</p>
+     <li data-md="">
+      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a>, and execute
+  the associated steps:</p>
+      <dl>
+       <dt data-md="">"<code>manifest</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>manifest-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>object</code>"
+       <dt data-md="">"<code>embed</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>object-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>document</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, return <code>frame-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>audio</code>"
+       <dt data-md="">"<code>track</code>"
+       <dt data-md="">"<code>video</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>media-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>font</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>font-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>image</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>img-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>xslt</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>serviceworker</code>"
+       <dt data-md="">"<code>sharedworker</code>"
+       <dt data-md="">"<code>worker</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>worker-src</code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>null</code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
+    <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> of the effective directive.</p>
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
+  the directive that is most relevant to a particular type of inline check.</p>
+    <ol>
+     <li data-md="">
+      <p>Switch on <var>type</var>:</p>
+      <dl>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>navigation</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>script attribute</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-attr</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style attribute</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-attr</code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>null</code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Get fetch directive fallback list" data-level="6.7.3" id="directive-fallback-list"><span class="secno">6.7.3. </span><span class="content"> Get fetch directive fallback list </span><a class="self-link" href="#directive-fallback-list"></a></h4>
+    <p>Will return an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">ordered set</a> of the fallback <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directives</a> for a specific <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a>.
+  The returned <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">ordered set</a> is sorted from most relevant to least relevant
+  and it includes the effective directive itself.</p>
+    <p>Given a string (<var>directive name</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Switch on <var>directive name</var>:</p>
+      <dl>
+       <dt data-md="">"<code>script-src-elem</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>script-src-attr</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-elem</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-attr</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>worker-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "worker-src", "child-src", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>connect-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "connect-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>manifest-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "manifest-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>prefetch-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "prefetch-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>object-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "object-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>frame-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "frame-src", "child-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>media-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "media-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>font-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "font-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>image-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "image-src", "default-src" >></code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>&lt;&lt; >></code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Should fetch directive execute" data-level="6.7.4" id="should-directive-execute"><span class="secno">6.7.4. </span><span class="content"> Should fetch directive execute </span><a class="self-link" href="#should-directive-execute"></a></h4>
+    <p>This algorithm is used for <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives③">fetch directives</a> to decide whether a directive
+  should execute or defer to a different directive that is better suited.
+  For example: if the <var>effective directive name</var> is <code>worker-src</code> (meaning that
+  we are currently checking a worker request), a <code>default-src</code> directive
+  should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
+    <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
+     <li data-md="">
+      <p>For each <var>fallback directive</var> in <var>directive fallback list</var>:</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>directive name</var> is <var>fallback directive</var>, Return "<code>Yes</code>".</p>
+       <li data-md="">
+        <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>No</code>".</p>
+    </ol>
    </section>
    <section>
     <h2 class="heading settled" data-level="7" id="security-considerations"><span class="secno">7. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
@@ -5019,7 +5328,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5045,7 +5354,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
   second <code>src</code> attribute which is helpfully discarded as duplicate by the parser.</p>
-    <p>The <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> algorithm attempts to mitigate this specific
+    <p>The <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm attempts to mitigate this specific
   attack by walking through <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element③">style</a></code> element attributes, looking for the
   string "<code>&lt;script</code>" or "<code>&lt;style</code>" in their names or values.</p>
     <h3 class="heading settled" data-level="7.3" id="security-nonce-retargeting"><span class="secno">7.3. </span><span class="content">Nonce Retargeting</span><a class="self-link" href="#security-nonce-retargeting"></a></h3>
@@ -5062,7 +5371,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5107,7 +5416,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>The relatively long thread <a href="https://lists.w3.org/Archives/Public/public-webappsec/2014Feb/0036.html">"Remove paths from CSP?"</a> from public-webappsec@w3.org has more detailed discussion around alternate proposals.</p>
     <h3 class="heading settled" data-level="7.7" id="security-secure-upgrades"><span class="secno">7.7. </span><span class="content">Secure Upgrades</span><a class="self-link" href="#security-secure-upgrades"></a></h3>
     <p>To mitigate one variant of history-scanning attacks like Yan Zhu’s <a href="http://diracdeltas.github.io/sniffly/">Sniffly</a>, CSP will not allow pages to lock
-  themselves into insecure URLs via policies like <code>script-src http://example.com</code>. As described in <a href="#match-schemes">§6.6.1.7 scheme-part matching</a>, the scheme portion of a source expression will always allow upgrading to a
+  themselves into insecure URLs via policies like <code>script-src http://example.com</code>. As described in <a href="#match-schemes">§6.6.2.7 scheme-part matching</a>, the scheme portion of a source expression will always allow upgrading to a
   secure variant.</p>
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
@@ -5173,12 +5482,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5193,7 +5502,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5229,7 +5538,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5283,7 +5592,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5351,15 +5660,15 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5438,8 +5747,8 @@ rest of Google’s CSP Cabal.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#source-list-allows-all-inline-behavior">allow all inline behavior</a><span>, in §6.6.2.2</span>
-   <li><a href="#source-list-allows-all-inline-behavior">allows all inline behavior</a><span>, in §6.6.2.2</span>
+   <li><a href="#source-list-allows-all-inline-behavior">allow all inline behavior</a><span>, in §6.6.3.2</span>
+   <li><a href="#source-list-allows-all-inline-behavior">allows all inline behavior</a><span>, in §6.6.3.2</span>
    <li><a href="#grammardef-ancestor-source">ancestor-source</a><span>, in §6.3.2</span>
    <li><a href="#grammardef-ancestor-source-list">ancestor-source-list</a><span>, in §6.3.2</span>
    <li><a href="#grammardef-base64-value">base64-value</a><span>, in §2.3.1</span>
@@ -5493,7 +5802,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     effective directive
     <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.6.1.11</span>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
      <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li>
@@ -5517,7 +5826,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-hash-source">hash-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-host-char">host-char</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-host-part">host-part</a><span>, in §2.3.1</span>
-   <li><a href="#host-part-match">host-part match</a><span>, in §6.6.1.8</span>
+   <li><a href="#host-part-match">host-part match</a><span>, in §6.6.2.8</span>
    <li><a href="#grammardef-host-source">host-source</a><span>, in §2.3.1</span>
    <li><a href="#img-src">img-src</a><span>, in §6.1.6</span>
    <li><a href="#directive-initialization">initialization</a><span>, in §2.3</span>
@@ -5550,7 +5859,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</a><span>, in §2.2.1</span>
    <li><a href="#abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</a><span>, in §2.2.2</span>
    <li><a href="#grammardef-path-part">path-part</a><span>, in §2.3.1</span>
-   <li><a href="#path-part-match">path-part match</a><span>, in §6.6.1.10</span>
+   <li><a href="#path-part-match">path-part match</a><span>, in §6.6.2.10</span>
    <li><a href="#plugin-types">plugin-types</a><span>, in §6.2.2</span>
    <li><a href="#plugin-types-post-request-check">plugin-types Post-Request Check</a><span>, in §6.2.2</span>
    <li>
@@ -5560,7 +5869,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#violation-policy">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li><a href="#grammardef-port-part">port-part</a><span>, in §2.3.1</span>
-   <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.1.9</span>
+   <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.2.9</span>
    <li><a href="#directive-post-request-check">post-request check</a><span>, in §2.3</span>
    <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.9</span>
    <li><a href="#directive-pre-navigation-check">pre-navigation check</a><span>, in §2.3</span>
@@ -5587,9 +5896,11 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#sandbox">sandbox</a><span>, in §6.2.3</span>
    <li><a href="#grammardef-scheme-part">scheme-part</a><span>, in §2.3.1</span>
-   <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.1.7</span>
+   <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.2.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
    <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
+   <li><a href="#script-src-attr">script-src-attr</a><span>, in §6.1.13</span>
+   <li><a href="#script-src-elem">script-src-elem</a><span>, in §6.1.12</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5624,7 +5935,9 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.14</span>
+   <li><a href="#style-src-attr">style-src-attr</a><span>, in §6.1.16</span>
+   <li><a href="#style-src-elem">style-src-elem</a><span>, in §6.1.15</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
@@ -5639,7 +5952,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
    <a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">https://www.w3.org/TR/CSP3/#header-content-security-policy</a><b>Referenced in:</b>
@@ -5666,31 +5979,31 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.12. style-src</a>
+    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -5710,7 +6023,7 @@ rest of Google’s CSP Cabal.</p>
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-document①①">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-document①②">6.1.12. style-src</a>
+    <li><a href="#ref-for-document①②">6.1.14. style-src</a>
     <li><a href="#ref-for-document①③">6.2.1. base-uri</a>
     <li><a href="#ref-for-document①④">6.2.1.1. 
     Is base allowed for document? </a>
@@ -5728,16 +6041,26 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-element">2.3. Directives</a>
     <li><a href="#ref-for-element①">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-element②">6.1.11.3. 
+    <li><a href="#ref-for-element②">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-element③">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-element③">6.1.12.3. 
+    <li><a href="#ref-for-element④">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑤">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-element④">6.2.2.2. 
+    <li><a href="#ref-for-element⑦">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑧">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-element⑤">6.6.2.1. 
+    <li><a href="#ref-for-element①⓪">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-element⑥">6.6.2.3. 
+    <li><a href="#ref-for-element①①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -5881,15 +6204,19 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.12.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.12.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
     Does nonce match source list? </a>
    </ul>
   </aside>
@@ -5917,7 +6244,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-concept-request-current-url①">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-current-url①">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -5927,53 +6254,17 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-request-destination">5.3. 
     Report a violation </a>
     <li><a href="#ref-for-concept-request-destination①">6.1.1. child-src</a> <a href="#ref-for-concept-request-destination②">(2)</a>
-    <li><a href="#ref-for-concept-request-destination③">6.1.2.1. 
-    connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination④">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑤">6.1.4.1. 
-    font-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑥">6.1.4.2. 
-    font-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑦">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑧">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑨">6.1.6. img-src</a>
-    <li><a href="#ref-for-concept-request-destination①⓪">6.1.6.1. 
-    img-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①①">6.1.6.2. 
-    img-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①②">6.1.7.1. 
-    manifest-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①③">6.1.7.2. 
-    manifest-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①④">6.1.8.1. 
-    media-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑤">6.1.8.2. 
-    media-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑥">6.1.10.1. 
-    object-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑦">6.1.10.2. 
-    object-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑧">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑨">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination②⓪">6.1.12.1. 
-    style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②①">6.1.12.2. 
-    style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②②">6.1.13.1. 
-    worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②③">6.1.13.2. 
-    worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②④">6.2.2.1. 
+    <li><a href="#ref-for-concept-request-destination③">6.1.6. img-src</a>
+    <li><a href="#ref-for-concept-request-destination④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request-destination②⑤">6.2.3.1. 
+    <li><a href="#ref-for-concept-request-destination⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request-destination②⑥">6.6.1.11. 
-    Get the effective directive for request </a>
+    <li><a href="#ref-for-concept-request-destination⑥">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-destination⑦">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request-destination⑧">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request-destination⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
@@ -6027,23 +6318,15 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request-initiator①">6.1.2.1. 
-    connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-initiator②">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-initiator③">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-initiator④">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-initiator⑤">6.6.1.11. 
-    Get the effective directive for request </a>
+    <li><a href="#ref-for-concept-request-initiator①">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request-initiator②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-integrity-metadata">
    <a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-integrity-metadata">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
+    <li><a href="#ref-for-concept-request-integrity-metadata">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-request-keepalive-flag">
@@ -6097,7 +6380,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://fetch.spec.whatwg.org/#network-scheme">https://fetch.spec.whatwg.org/#network-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network-scheme">1.3. Changes from Level 2</a> <a href="#ref-for-network-scheme①">(2)</a>
-    <li><a href="#ref-for-network-scheme②">6.6.1.6. 
+    <li><a href="#ref-for-network-scheme②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-network-scheme③">(2)</a>
    </ul>
   </aside>
@@ -6106,9 +6389,9 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-origin">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request-origin①">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-origin①">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-origin②">6.6.1.4. 
+    <li><a href="#ref-for-concept-request-origin②">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6117,18 +6400,18 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-parser-metadata①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-parser-metadata②">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-concept-request-parser-metadata①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-parser-metadata②">6.6.1.2. 
+    Script directives post-request check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-redirect-count">
    <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-redirect-count">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-redirect-count">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-redirect-count①">6.6.1.4. 
+    <li><a href="#ref-for-concept-request-redirect-count①">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6219,37 +6502,51 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-concept-request④③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
+    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
+    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.13.1. 
+    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.13.2. 
+    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.2.2.1. 
+    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.6.1.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑤⑧">(2)</a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.4. 
+    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.11. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥①">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
+    Get the effective directive for inline checks </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response">
@@ -6295,36 +6592,42 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑦">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
+    <li><a href="#ref-for-concept-response②⑨">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-response③⓪">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-response③①">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③①">6.1.13.2. 
+    <li><a href="#ref-for-concept-response③②">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-response③③">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③②">6.2.2.1. 
+    <li><a href="#ref-for-concept-response③④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.2.3.1. 
+    <li><a href="#ref-for-concept-response③⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③④">6.2.3.2. 
+    <li><a href="#ref-for-concept-response③⑥">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.4.1. 
+    <li><a href="#ref-for-concept-response③⑦">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-concept-response③⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑦">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response③⑧">(2)</a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.2. 
+    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
+    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④⓪">6.6.1.4. 
+    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-request-destination-script-like">
    <a href="https://fetch.spec.whatwg.org/#request-destination-script-like">https://fetch.spec.whatwg.org/#request-destination-script-like</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-destination-script-like">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-request-destination-script-like①">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-request-destination-script-like">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-request-destination-script-like①">6.6.1.2. 
+    Script directives post-request check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
@@ -6340,11 +6643,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">https://fetch.spec.whatwg.org/#concept-request-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-target-browsing-context">6.1.1. child-src</a>
-    <li><a href="#ref-for-concept-request-target-browsing-context①">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-target-browsing-context②">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-target-browsing-context③">6.6.1.11. 
+    <li><a href="#ref-for-concept-request-target-browsing-context①">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -6363,7 +6662,7 @@ rest of Google’s CSP Cabal.</p>
     in target be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-response-url⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response-url⑥">6.6.1.4. 
+    <li><a href="#ref-for-concept-response-url⑥">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6378,10 +6677,10 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parser-inserted">1.3. Changes from Level 2</a>
-    <li><a href="#ref-for-parser-inserted①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-parser-inserted②">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-parser-inserted①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-parser-inserted②">6.6.1.2. 
+    Script directives post-request check </a>
     <li><a href="#ref-for-parser-inserted③">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-parser-inserted④">(2)</a> <a href="#ref-for-parser-inserted⑤">(3)</a>
    </ul>
@@ -6397,7 +6696,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
@@ -6424,7 +6723,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -6534,15 +6833,15 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-case-sensitive">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-case-sensitive">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-case-sensitive①">(2)</a>
-    <li><a href="#ref-for-case-sensitive②">6.6.1.2. 
+    <li><a href="#ref-for-case-sensitive">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-case-sensitive①">(2)</a>
+    <li><a href="#ref-for-case-sensitive②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-case-sensitive③">6.6.1.9. 
+    <li><a href="#ref-for-case-sensitive③">6.6.2.9. 
     port-part matching </a>
-    <li><a href="#ref-for-case-sensitive④">6.6.1.10. 
+    <li><a href="#ref-for-case-sensitive④">6.6.2.10. 
     path-part matching </a>
-    <li><a href="#ref-for-case-sensitive⑤">6.6.2.3. 
+    <li><a href="#ref-for-case-sensitive⑤">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-case-sensitive⑥">(2)</a>
    </ul>
   </aside>
@@ -6601,7 +6900,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-parse-error-duplicate-attribute">
    <a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.2.1. 
+    <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.3.1. 
     Is element nonceable? </a>
    </ul>
   </aside>
@@ -6700,7 +6999,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.12. style-src</a>
+    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
@@ -6724,14 +7023,10 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">6.1.1. child-src</a> <a href="#ref-for-nested-browsing-context①">(2)</a>
     <li><a href="#ref-for-nested-browsing-context②">6.1.5. frame-src</a>
-    <li><a href="#ref-for-nested-browsing-context③">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-nested-browsing-context④">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-nested-browsing-context⑤">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context⑥">(2)</a>
-    <li><a href="#ref-for-nested-browsing-context⑦">6.3.2.1. 
+    <li><a href="#ref-for-nested-browsing-context③">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
+    <li><a href="#ref-for-nested-browsing-context⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-nested-browsing-context⑧">6.6.1.11. 
+    <li><a href="#ref-for-nested-browsing-context⑥">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -6798,7 +7093,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-script-parse-error">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-script-parse-error">6.6.2.1. 
+    <li><a href="#ref-for-concept-script-parse-error">6.6.3.1. 
     Is element nonceable? </a>
    </ul>
   </aside>
@@ -6909,7 +7204,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-origin-scheme">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-origin-scheme">6.6.1.6. 
+    <li><a href="#ref-for-concept-origin-scheme">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-origin-scheme①">(2)</a>
    </ul>
   </aside>
@@ -6920,9 +7215,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script②">3.3. 
     The &lt;meta> element </a>
     <li><a href="#ref-for-script③">6.1.11. script-src</a> <a href="#ref-for-script④">(2)</a>
-    <li><a href="#ref-for-script⑤">6.6.2.1. 
+    <li><a href="#ref-for-script⑤">6.6.3.1. 
     Is element nonceable? </a> <a href="#ref-for-script⑥">(2)</a>
-    <li><a href="#ref-for-script⑦">6.6.2.3. 
+    <li><a href="#ref-for-script⑦">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a>
     <li><a href="#ref-for-script⑨">7.2. Nonce Stealing</a> <a href="#ref-for-script①⓪">(2)</a> <a href="#ref-for-script①①">(3)</a>
     <li><a href="#ref-for-script①②">8.2. 
@@ -6954,8 +7249,8 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
-    <li><a href="#ref-for-the-style-element①">6.6.2.3. 
+    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-style-element①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
    </ul>
@@ -6993,30 +7288,30 @@ rest of Google’s CSP Cabal.</p>
     The &lt;meta> element </a>
     <li><a href="#ref-for-ascii-case-insensitive①">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-ascii-case-insensitive②">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-ascii-case-insensitive③">6.2.2.1. 
+    <li><a href="#ref-for-ascii-case-insensitive②">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive④">6.2.2.2. 
+    <li><a href="#ref-for-ascii-case-insensitive③">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑤">6.3.3.1. 
+    <li><a href="#ref-for-ascii-case-insensitive④">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑥">6.3.3.2. 
+    <li><a href="#ref-for-ascii-case-insensitive⑤">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑦">6.6.1.5. 
+    <li><a href="#ref-for-ascii-case-insensitive⑥">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-ascii-case-insensitive⑦">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑧">6.6.1.6. 
+    <li><a href="#ref-for-ascii-case-insensitive⑧">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑨">6.6.1.7. 
+    <li><a href="#ref-for-ascii-case-insensitive⑨">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-ascii-case-insensitive①⓪">(2)</a> <a href="#ref-for-ascii-case-insensitive①①">(3)</a> <a href="#ref-for-ascii-case-insensitive①②">(4)</a> <a href="#ref-for-ascii-case-insensitive①③">(5)</a> <a href="#ref-for-ascii-case-insensitive①④">(6)</a> <a href="#ref-for-ascii-case-insensitive①⑤">(7)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑥">6.6.1.8. 
+    <li><a href="#ref-for-ascii-case-insensitive①⑥">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-ascii-case-insensitive①⑦">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑧">6.6.2.1. 
+    <li><a href="#ref-for-ascii-case-insensitive①⑧">6.6.3.1. 
     Is element nonceable? </a> <a href="#ref-for-ascii-case-insensitive①⑨">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive②⓪">6.6.2.2. 
+    <li><a href="#ref-for-ascii-case-insensitive②⓪">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-ascii-case-insensitive②①">6.6.2.3. 
+    <li><a href="#ref-for-ascii-case-insensitive②①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-ascii-case-insensitive②②">(2)</a> <a href="#ref-for-ascii-case-insensitive②③">(3)</a> <a href="#ref-for-ascii-case-insensitive②④">(4)</a>
    </ul>
   </aside>
@@ -7026,13 +7321,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ascii-string">2.2. Policies</a> <a href="#ref-for-ascii-string①">(2)</a>
     <li><a href="#ref-for-ascii-string②">2.3. Directives</a>
     <li><a href="#ref-for-ascii-string③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-ascii-string④">6.6.1.7. 
+    <li><a href="#ref-for-ascii-string④">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-ascii-string⑤">(2)</a> <a href="#ref-for-ascii-string⑥">(3)</a>
-    <li><a href="#ref-for-ascii-string⑦">6.6.1.8. 
+    <li><a href="#ref-for-ascii-string⑦">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-ascii-string⑧">(2)</a> <a href="#ref-for-ascii-string⑨">(3)</a>
-    <li><a href="#ref-for-ascii-string①⓪">6.6.1.9. 
+    <li><a href="#ref-for-ascii-string①⓪">6.6.2.9. 
     port-part matching </a> <a href="#ref-for-ascii-string①①">(2)</a>
-    <li><a href="#ref-for-ascii-string①②">6.6.1.10. 
+    <li><a href="#ref-for-ascii-string①②">6.6.2.10. 
     path-part matching </a> <a href="#ref-for-ascii-string①③">(2)</a>
    </ul>
   </aside>
@@ -7089,6 +7384,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
     <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-ordered-set④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-set">
@@ -7097,6 +7394,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
     <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-ordered-set④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
@@ -7120,7 +7419,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-strictly-split">2.2.1. 
     Parse a serialized CSP </a>
-    <li><a href="#ref-for-strictly-split①">6.6.1.10. 
+    <li><a href="#ref-for-strictly-split①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
@@ -7177,7 +7476,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-section-3.2.2">
    <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-section-3.2.2">6.6.1.8. 
+    <li><a href="#ref-for-section-3.2.2">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -7203,7 +7502,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://tools.ietf.org/html/rfc4648#section-4">https://tools.ietf.org/html/rfc4648#section-4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-4①">6.6.2.3. 
+    <li><a href="#ref-for-section-4①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-section-4②">(2)</a>
    </ul>
   </aside>
@@ -7211,7 +7510,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://tools.ietf.org/html/rfc4648#section-5">https://tools.ietf.org/html/rfc4648#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-5①">6.6.2.3. 
+    <li><a href="#ref-for-section-5①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -7293,7 +7592,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -7306,21 +7605,21 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
@@ -7334,9 +7633,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-url⑥">6.3.1. form-action</a>
     <li><a href="#ref-for-url⑦">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-url⑧">6.3.3. navigate-to</a>
-    <li><a href="#ref-for-url⑨">6.6.1.5. 
+    <li><a href="#ref-for-url⑨">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-url①⓪">6.6.1.6. 
+    <li><a href="#ref-for-url①⓪">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
@@ -7350,23 +7649,23 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-default-port">
    <a href="https://url.spec.whatwg.org/#default-port">https://url.spec.whatwg.org/#default-port</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-port">6.6.1.6. 
+    <li><a href="#ref-for-default-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-default-port①">6.6.1.9. 
+    <li><a href="#ref-for-default-port①">6.6.2.9. 
     port-part matching </a> <a href="#ref-for-default-port②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-host">
    <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-host">6.6.1.8. 
+    <li><a href="#ref-for-concept-url-host">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-ipv6">
    <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-ipv6">6.6.1.8. 
+    <li><a href="#ref-for-concept-ipv6">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -7377,32 +7676,32 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
     <li><a href="#ref-for-concept-url-origin①">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-url-origin②">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-origin②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-path">
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-path">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-path">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-path①">6.6.1.10. 
+    <li><a href="#ref-for-concept-url-path①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-percent-decode">
    <a href="https://url.spec.whatwg.org/#percent-decode">https://url.spec.whatwg.org/#percent-decode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percent-decode">6.6.1.10. 
+    <li><a href="#ref-for-percent-decode">6.6.2.10. 
     path-part matching </a> <a href="#ref-for-percent-decode①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-port">
    <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-port">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-port①">6.6.1.9. 
+    <li><a href="#ref-for-concept-url-port①">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -7416,11 +7715,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-url-scheme②">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-url-scheme③">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-scheme③">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a> <a href="#ref-for-concept-url-scheme⑨">(7)</a> <a href="#ref-for-concept-url-scheme①⓪">(8)</a>
-    <li><a href="#ref-for-concept-url-scheme①①">6.6.1.7. 
+    <li><a href="#ref-for-concept-url-scheme①①">6.6.2.7. 
     scheme-part matching </a>
-    <li><a href="#ref-for-concept-url-scheme①②">6.6.1.9. 
+    <li><a href="#ref-for-concept-url-scheme①②">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -7945,97 +8244,121 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-content-security-policy-object④">(2)</a>
     <li><a href="#ref-for-content-security-policy-object⑤">2.2.2. 
     Parse a serialized CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a> <a href="#ref-for-content-security-policy-object①②">(7)</a>
-    <li><a href="#ref-for-content-security-policy-object①③">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①④">(2)</a> <a href="#ref-for-content-security-policy-object①⑤">(3)</a> <a href="#ref-for-content-security-policy-object①⑥">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object①⑦">2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a> <a href="#ref-for-content-security-policy-object①②">(7)</a> <a href="#ref-for-content-security-policy-object①③">(8)</a>
+    <li><a href="#ref-for-content-security-policy-object①④">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①⑤">(2)</a> <a href="#ref-for-content-security-policy-object①⑥">(3)</a> <a href="#ref-for-content-security-policy-object①⑦">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object①⑧">2.4.1. 
     Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑧">2.4.2. 
+    <li><a href="#ref-for-content-security-policy-object①⑨">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑨">3. 
-    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②⓪">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②①">4.1. 
+    <li><a href="#ref-for-content-security-policy-object②⓪">3. 
+    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②①">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object②②">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-content-security-policy-object②②">4.2. 
-    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②③">(2)</a> <a href="#ref-for-content-security-policy-object②④">(3)</a> <a href="#ref-for-content-security-policy-object②⑤">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑥">4.2.1. 
+    <li><a href="#ref-for-content-security-policy-object②③">4.2. 
+    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②④">(2)</a> <a href="#ref-for-content-security-policy-object②⑤">(3)</a> <a href="#ref-for-content-security-policy-object②⑥">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object②⑦">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object②⑦">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object②⑧">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑨">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object②⑧">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object②⑨">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object③①">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③①">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object③②">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③②">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object③③">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③③">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object③④">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③④">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object④①">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object④②">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④①">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object④③">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④②">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object④④">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④③">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④④">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.10. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.3. 
+    script-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.13.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.3. 
+    style-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.13.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    Should fetch directive execute </a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8185,32 +8508,36 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directives①⑥">6.1.1.2. 
     child-src Post-request check </a>
     <li><a href="#ref-for-directives①⑦">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directives①⑧">(2)</a> <a href="#ref-for-directives①⑨">(3)</a> <a href="#ref-for-directives②⓪">(4)</a> <a href="#ref-for-directives②①">(5)</a>
-    <li><a href="#ref-for-directives②②">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directives②③">(2)</a> <a href="#ref-for-directives②④">(3)</a> <a href="#ref-for-directives②⑤">(4)</a> <a href="#ref-for-directives②⑥">(5)</a>
-    <li><a href="#ref-for-directives②⑦">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directives②⑧">(2)</a>
-    <li><a href="#ref-for-directives②⑨">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directives③⓪">(2)</a>
-    <li><a href="#ref-for-directives③①">6.2.1.1. 
-    Is base allowed for document? </a> <a href="#ref-for-directives③②">(2)</a>
-    <li><a href="#ref-for-directives③③">6.2.2.2. 
+    default-src Pre-request check </a>
+    <li><a href="#ref-for-directives①⑧">6.1.3.2. 
+    default-src Post-request check </a>
+    <li><a href="#ref-for-directives①⑨">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directives②⓪">6.2.1.1. 
+    Is base allowed for document? </a> <a href="#ref-for-directives②①">(2)</a>
+    <li><a href="#ref-for-directives②②">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directives③④">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives③⑤">(2)</a>
-    <li><a href="#ref-for-directives③⑥">6.3.2.2. 
+    <li><a href="#ref-for-directives②③">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives②④">(2)</a>
+    <li><a href="#ref-for-directives②⑤">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-directives③⑦">6.3.3.1. 
+    <li><a href="#ref-for-directives②⑥">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-directives③⑧">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directives③⑨">(2)</a>
-    <li><a href="#ref-for-directives④⓪">6.6.1.1. 
+    <li><a href="#ref-for-directives②⑦">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directives②⑧">(2)</a>
+    <li><a href="#ref-for-directives②⑨">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-directives③⓪">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-directives③①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directives④①">6.6.1.3. 
+    <li><a href="#ref-for-directives③②">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-directives④②">6.6.1.4. 
+    <li><a href="#ref-for-directives③③">6.6.2.4. 
     Does response to request match source list? </a>
+    <li><a href="#ref-for-directives③④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-directives③⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-name">
@@ -8230,21 +8557,23 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-name⑧">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑨">(2)</a>
     <li><a href="#ref-for-directive-name①⓪">6.1.1.1. 
-    child-src Pre-request check </a> <a href="#ref-for-directive-name①①">(2)</a>
-    <li><a href="#ref-for-directive-name①②">6.1.1.2. 
-    child-src Post-request check </a> <a href="#ref-for-directive-name①③">(2)</a>
-    <li><a href="#ref-for-directive-name①④">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directive-name①⑤">(2)</a> <a href="#ref-for-directive-name①⑥">(3)</a> <a href="#ref-for-directive-name①⑦">(4)</a> <a href="#ref-for-directive-name①⑧">(5)</a>
-    <li><a href="#ref-for-directive-name①⑨">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directive-name②⓪">(2)</a> <a href="#ref-for-directive-name②①">(3)</a> <a href="#ref-for-directive-name②②">(4)</a> <a href="#ref-for-directive-name②③">(5)</a>
-    <li><a href="#ref-for-directive-name②④">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-name②⑤">(2)</a>
-    <li><a href="#ref-for-directive-name②⑥">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-name②⑦">(2)</a>
-    <li><a href="#ref-for-directive-name②⑧">6.2.1.1. 
+    child-src Pre-request check </a>
+    <li><a href="#ref-for-directive-name①①">6.1.1.2. 
+    child-src Post-request check </a>
+    <li><a href="#ref-for-directive-name①②">6.1.3.1. 
+    default-src Pre-request check </a>
+    <li><a href="#ref-for-directive-name①③">6.1.3.2. 
+    default-src Post-request check </a>
+    <li><a href="#ref-for-directive-name①④">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directive-name①⑤">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-name②⑨">6.6.1.11. 
+    <li><a href="#ref-for-directive-name①⑥">6.7.1. 
     Get the effective directive for request </a>
+    <li><a href="#ref-for-directive-name①⑦">6.7.2. 
+    Get the effective directive for inline checks </a>
+    <li><a href="#ref-for-directive-name①⑧">6.7.4. 
+    Should fetch directive execute </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-value">
@@ -8272,69 +8601,84 @@ rest of Google’s CSP Cabal.</p>
     default-src Pre-request check </a>
     <li><a href="#ref-for-directive-value①④">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑤">6.1.4.1. 
+    <li><a href="#ref-for-directive-value①⑤">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directive-value①⑥">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑥">6.1.4.2. 
+    <li><a href="#ref-for-directive-value①⑦">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑦">6.1.5.1. 
+    <li><a href="#ref-for-directive-value①⑧">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑧">6.1.5.2. 
+    <li><a href="#ref-for-directive-value①⑨">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑨">6.1.6.1. 
+    <li><a href="#ref-for-directive-value②⓪">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⓪">6.1.6.2. 
+    <li><a href="#ref-for-directive-value②①">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②①">6.1.7.1. 
+    <li><a href="#ref-for-directive-value②②">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②②">6.1.7.2. 
+    <li><a href="#ref-for-directive-value②③">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②③">6.1.8.1. 
+    <li><a href="#ref-for-directive-value②④">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②④">6.1.8.2. 
+    <li><a href="#ref-for-directive-value②⑤">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑤">6.1.9.1. 
+    <li><a href="#ref-for-directive-value②⑥">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑥">6.1.9.2. 
+    <li><a href="#ref-for-directive-value②⑦">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑦">6.1.10.1. 
+    <li><a href="#ref-for-directive-value②⑧">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑧">6.1.10.2. 
+    <li><a href="#ref-for-directive-value②⑨">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑨">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-value③⓪">(2)</a> <a href="#ref-for-directive-value③①">(3)</a> <a href="#ref-for-directive-value③②">(4)</a> <a href="#ref-for-directive-value③③">(5)</a>
-    <li><a href="#ref-for-directive-value③④">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-value③⑤">(2)</a> <a href="#ref-for-directive-value③⑥">(3)</a>
-    <li><a href="#ref-for-directive-value③⑦">6.1.11.3. 
+    <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑧">6.1.12.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑨">(2)</a>
-    <li><a href="#ref-for-directive-value④⓪">6.1.12.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value④①">(2)</a>
-    <li><a href="#ref-for-directive-value④②">6.1.12.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
+    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
+    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value④③">6.1.13.1. 
+    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
+    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
+    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
+    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.13.2. 
+    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑥">6.2.2.1. 
+    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.3.1. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤③">(2)</a>
-    <li><a href="#ref-for-directive-value⑤④">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
+    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8389,14 +8733,18 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.1.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.1.3. 
+    <li><a href="#ref-for-directive-pre-request-check②⓪">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -8431,14 +8779,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
+    <li><a href="#ref-for-directive-post-request-check②⓪">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.4. 
+    <li><a href="#ref-for-directive-post-request-check②①">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check②②">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -8464,10 +8818,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check①">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-inline-check②">6.1.11.3. 
+    <li><a href="#ref-for-directive-inline-check②">6.1.3.3. 
+    default-src Inline Check </a> <a href="#ref-for-directive-inline-check③">(2)</a>
+    <li><a href="#ref-for-directive-inline-check④">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check③">6.1.12.3. 
+    <li><a href="#ref-for-directive-inline-check⑤">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑥">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑦">6.1.14.3. 
     style-src Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑧">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑨">6.1.16.1. 
+    style-src-attr Inline Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-initialization">
@@ -8475,7 +8839,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.14.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -8522,19 +8886,19 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-source-lists①②">6.6.1.2. 
+    <li><a href="#ref-for-source-lists①②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-source-lists①③">6.6.1.3. 
+    <li><a href="#ref-for-source-lists①③">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-source-lists①④">6.6.1.4. 
+    <li><a href="#ref-for-source-lists①④">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-source-lists①⑤">6.6.1.5. 
+    <li><a href="#ref-for-source-lists①⑤">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-source-lists①⑥">6.6.2.2. 
+    <li><a href="#ref-for-source-lists①⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑦">(2)</a> <a href="#ref-for-source-lists①⑧">(3)</a> <a href="#ref-for-source-lists①⑨">(4)</a> <a href="#ref-for-source-lists②⓪">(5)</a>
-    <li><a href="#ref-for-source-lists②①">6.6.2.3. 
+    <li><a href="#ref-for-source-lists②①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -8545,13 +8909,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-expression①">2.3.1. Source Lists</a>
     <li><a href="#ref-for-source-expression②">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-source-expression③">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-source-expression④">(2)</a> <a href="#ref-for-source-expression⑤">(3)</a> <a href="#ref-for-source-expression⑥">(4)</a>
-    <li><a href="#ref-for-source-expression⑦">6.3.3.1. 
+    <li><a href="#ref-for-source-expression③">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-source-expression⑧">6.3.3.2. 
+    <li><a href="#ref-for-source-expression④">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-source-expression⑨">6.6.1.6. 
+    <li><a href="#ref-for-source-expression⑤">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-source-expression⑥">(2)</a> <a href="#ref-for-source-expression⑦">(3)</a> <a href="#ref-for-source-expression⑧">(4)</a>
+    <li><a href="#ref-for-source-expression⑨">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
     <li><a href="#ref-for-source-expression①⓪">8.4. 
       Allowing external JavaScript via hashes </a>
@@ -8571,11 +8935,15 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigate-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.1.15. style-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.1.16. style-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.1.17. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑦">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑧">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -8596,7 +8964,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-scheme-source①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-scheme-source②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-scheme-source②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-scheme-source③">(2)</a>
     <li><a href="#ref-for-grammardef-scheme-source④">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8607,7 +8975,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-host-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-host-source①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-host-source②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-host-source②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-host-source③">(2)</a> <a href="#ref-for-grammardef-host-source④">(3)</a>
     <li><a href="#ref-for-grammardef-host-source⑤">7.3. Nonce Retargeting</a>
     <li><a href="#ref-for-grammardef-host-source⑥">8.2. 
@@ -8618,9 +8986,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-scheme-part">#grammardef-scheme-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-part">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-scheme-part①">(2)</a>
-    <li><a href="#ref-for-grammardef-scheme-part②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-scheme-part②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-scheme-part③">(2)</a> <a href="#ref-for-grammardef-scheme-part④">(3)</a> <a href="#ref-for-grammardef-scheme-part⑤">(4)</a>
-    <li><a href="#ref-for-grammardef-scheme-part⑥">6.6.1.7. 
+    <li><a href="#ref-for-grammardef-scheme-part⑥">6.6.2.7. 
     scheme-part matching </a>
    </ul>
   </aside>
@@ -8628,9 +8996,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-host-part">#grammardef-host-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-host-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-host-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-grammardef-host-part②">6.6.1.8. 
+    <li><a href="#ref-for-grammardef-host-part②">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -8644,9 +9012,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-port-part">#grammardef-port-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-port-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-port-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-port-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-grammardef-port-part②">6.6.1.9. 
+    <li><a href="#ref-for-grammardef-port-part②">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -8654,9 +9022,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-path-part">#grammardef-path-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-path-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-path-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-path-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-path-part②">(2)</a>
-    <li><a href="#ref-for-grammardef-path-part③">6.6.1.10. 
+    <li><a href="#ref-for-grammardef-path-part③">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
@@ -8664,15 +9032,15 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-keyword-source">#grammardef-keyword-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-keyword-source">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-keyword-source①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-keyword-source②">6.3.3.1. 
+    <li><a href="#ref-for-grammardef-keyword-source①">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source③">6.3.3.2. 
+    <li><a href="#ref-for-grammardef-keyword-source②">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source④">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-keyword-source③">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-keyword-source④">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-keyword-source⑤">(2)</a> <a href="#ref-for-grammardef-keyword-source⑥">(3)</a>
-    <li><a href="#ref-for-grammardef-keyword-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-keyword-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-keyword-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8682,9 +9050,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
-    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
+    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8693,7 +9061,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-inline">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-grammardef-unsafe-inline①">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-unsafe-inline①">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-unsafe-inline②">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline③">7.1. Nonce Reuse</a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline⑤">8.2. 
@@ -8710,11 +9078,11 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-strict-dynamic">
    <b><a href="#grammardef-strict-dynamic">#grammardef-strict-dynamic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-strict-dynamic">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
-    <li><a href="#ref-for-grammardef-strict-dynamic②">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-grammardef-strict-dynamic③">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-strict-dynamic">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
+    <li><a href="#ref-for-grammardef-strict-dynamic②">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-grammardef-strict-dynamic③">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
     <li><a href="#ref-for-grammardef-strict-dynamic④">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-grammardef-strict-dynamic⑤">(2)</a> <a href="#ref-for-grammardef-strict-dynamic⑥">(3)</a>
@@ -8723,7 +9091,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-unsafe-hashes">
    <b><a href="#grammardef-unsafe-hashes">#grammardef-unsafe-hashes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashes①">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-hashes②">8.3. 
       Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a>
@@ -8753,14 +9121,14 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source④">6.6.1.2. 
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source④">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.2.1. 
+    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑧">7.1. Nonce Reuse</a>
     <li><a href="#ref-for-grammardef-nonce-source⑨">8.2. 
@@ -8771,11 +9139,11 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-base64-value">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-base64-value①">(2)</a> <a href="#ref-for-grammardef-base64-value②">(3)</a> <a href="#ref-for-grammardef-base64-value③">(4)</a>
-    <li><a href="#ref-for-grammardef-base64-value④">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-base64-value⑤">6.6.1.2. 
+    <li><a href="#ref-for-grammardef-base64-value④">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-base64-value⑤">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-grammardef-base64-value⑥">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-base64-value⑥">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-base64-value⑦">(2)</a>
    </ul>
   </aside>
@@ -8784,12 +9152,12 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-grammardef-hash-source④">(2)</a>
-    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-hash-source⑥">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source④">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-grammardef-hash-source⑤">(2)</a>
+    <li><a href="#ref-for-grammardef-hash-source⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-hash-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8801,9 +9169,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-hash-algorithm">#grammardef-hash-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-algorithm">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-hash-algorithm①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-hash-algorithm②">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-hash-algorithm①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-hash-algorithm②">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-hash-algorithm③">(2)</a> <a href="#ref-for-grammardef-hash-algorithm④">(3)</a>
    </ul>
   </aside>
@@ -9168,8 +9536,10 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#fetch-directives">#fetch-directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-directives">6.1.3. default-src</a> <a href="#ref-for-fetch-directives①">(2)</a>
-    <li><a href="#ref-for-fetch-directives②">6.6.1.11. 
+    <li><a href="#ref-for-fetch-directives②">6.7.1. 
     Get the effective directive for request </a>
+    <li><a href="#ref-for-fetch-directives③">6.7.4. 
+    Should fetch directive execute </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="child-src">
@@ -9274,29 +9644,51 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
-    <li><a href="#ref-for-script-src⑤">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
-    <li><a href="#ref-for-script-src⑦">8.3. 
+    <li><a href="#ref-for-script-src②">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
+    <li><a href="#ref-for-script-src④">8.3. 
       Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑧">10.1. 
+    <li><a href="#ref-for-script-src⑤">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-elem">
+   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-attr">
+   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
-    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src③">10.1. 
+    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src①">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-elem">
+   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-attr">
+   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
     <li><a href="#ref-for-worker-src③">10.1. 
     Directive Registry </a>
    </ul>
@@ -9426,44 +9818,51 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="scheme-part-match">
    <b><a href="#scheme-part-match">#scheme-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scheme-part-match">6.6.1.6. 
+    <li><a href="#ref-for-scheme-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-scheme-part-match①">(2)</a>
-    <li><a href="#ref-for-scheme-part-match②">6.6.1.7. 
+    <li><a href="#ref-for-scheme-part-match②">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-scheme-part-match③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="host-part-match">
    <b><a href="#host-part-match">#host-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-host-part-match">6.6.1.6. 
+    <li><a href="#ref-for-host-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-host-part-match①">6.6.1.8. 
+    <li><a href="#ref-for-host-part-match①">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-host-part-match②">(2)</a> <a href="#ref-for-host-part-match③">(3)</a> <a href="#ref-for-host-part-match④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="port-part-matches">
    <b><a href="#port-part-matches">#port-part-matches</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-port-part-matches">6.6.1.6. 
+    <li><a href="#ref-for-port-part-matches">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-port-part-matches①">6.6.1.9. 
+    <li><a href="#ref-for-port-part-matches①">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="path-part-match">
    <b><a href="#path-part-match">#path-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-path-part-match">6.6.1.6. 
+    <li><a href="#ref-for-path-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-path-part-match①">6.6.1.10. 
+    <li><a href="#ref-for-path-part-match①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="source-list-allows-all-inline-behavior">
    <b><a href="#source-list-allows-all-inline-behavior">#source-list-allows-all-inline-behavior</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-source-list-allows-all-inline-behavior">6.6.2.2. 
+    <li><a href="#ref-for-source-list-allows-all-inline-behavior">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-list-allows-all-inline-behavior①">(2)</a> <a href="#ref-for-source-list-allows-all-inline-behavior②">(3)</a> <a href="#ref-for-source-list-allows-all-inline-behavior③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="request-effective-directive">
+   <b><a href="#request-effective-directive">#request-effective-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-request-effective-directive">6.7.2. 
+    Get the effective directive for inline checks </a>
    </ul>
   </aside>
 <script>/* script-var-click-highlighting */

--- a/index.src.html
+++ b/index.src.html
@@ -529,10 +529,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       "`Allowed`" unless otherwise specified.
 
   4.  An <dfn for="directive" export>inline check</dfn>, which takes an {{Element}} a
-      type string, and a source string as arguments, and is executed during
-      [[#should-block-inline]] and during [[#should-block-navigation-request]] for
-      `javascript:` requests. This algorithm returns "`Allowed`" unless
-      otherwise specified.
+      type string, a <a for="/">policy</a>, and a source string as arguments,
+      and is executed during [[#should-block-inline]] and during
+      [[#should-block-navigation-request]] for `javascript:` requests. This
+      algorithm returns "`Allowed`" unless otherwise specified.
 
   5.  An <dfn for="directive" export>initialization</dfn>, which takes a {{Document}}
       or <a for="/">global object</a>, a <a>response</a>, and a <a for="/">policy</a>
@@ -1274,7 +1274,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
         1.  For each |directive| in |policy|'s <a for="policy">directive set</a>:
 
             1.  If |directive|'s <a for="directive">inline check</a> returns
-                "`Allowed`" when executed upon |element|, |type|, and |source|,
+                "`Allowed`" when executed upon |element|, |type|, |policy| and |source|,
                 skip to the next |directive|.
 
             2.  Otherwise, let |violation| be the result of executing
@@ -1859,12 +1859,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is not `frame-src` or `worker-src`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `child-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a directive whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  Return the result of executing the <a for="directive">pre-request
+  3.  Return the result of executing the <a for="directive">pre-request
       check</a> for the <a>directive</a> whose <a for="directive">name</a>
       is |name| on |request| and |policy|, using this directive's
       <a for="directive">value</a> for the comparison.
@@ -1881,12 +1879,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is not `frame-src` or `worker-src`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `child-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a directive whose <a for="directive">name</a>
-      is |name|, return "`Allowed`"
-
-  4.  Return the result of executing the <a for="directive">post-request
+  3.  Return the result of executing the <a for="directive">post-request
       check</a> for the <a>directive</a> whose <a for="directive">name</a>
       is |name| on |request|, |response|, and |policy|, using this directive's
       <a for="directive">value</a> for the comparison.
@@ -1955,16 +1951,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing
+      [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
-      <a for="request">destination</a> is "":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `connect-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="connect-src-post-request">
     `connect-src` Post-request check
@@ -1975,17 +1972,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing
+      [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
-      <a for="request">destination</a> is "":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `connect-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-default-src">`default-src`</h4>
 
@@ -2023,8 +2021,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> <a grammar>'self'</a>;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> <a grammar>'self'</a>;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2037,7 +2037,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2051,8 +2051,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> https://example.com;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> https://example.com;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2073,19 +2075,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is `null`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a <a>directive</a> whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  If |name| is "`frame-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
-
-  5.  If |name| is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`script-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`" , return "`Allowed`".
-
-  6.  Otherwise, return the result of executing the
+  3.  Return the result of executing the
       <a for="directive">pre-request check</a> for the <a>directive</a> whose
       <a for="directive">name</a> is |name| on |request| and |policy|, using
       this directive's <a for="directive">value</a> for the comparison.
@@ -2102,22 +2095,34 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is `null`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a <a>directive</a> whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  If |name| is "`frame-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
-
-  5.  If |name| is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`script-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`" , return "`Allowed`".
-
-  6.  Otherwise, return the result of executing the
+  3.  Return the result of executing the
       <a for="directive">post-request check</a> for the <a>directive</a> whose
       <a for="directive">name</a> is |name| on |request|, |response|, and
       |policy|, using this directive's <a for="directive">value</a> for the
+      comparison.
+
+  <h5 algorithm id="default-src-inline">
+    `default-src` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Otherwise, return the result of executing the
+      <a for="directive">inline check</a> for the <a>directive</a> whose
+      <a for="directive">name</a> is |name| on |element|, |type|, |policy|
+      and |source|, using this directive's <a for="directive">value</a> for the
       comparison.
 
   <h4 id="directive-font-src">`font-src`</h4>
@@ -2161,15 +2166,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`font`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `font-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="font-src-post-request">
     `font-src` Post-request check
@@ -2180,16 +2187,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`font`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `font-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-frame-src">`frame-src`</h4>
 
@@ -2226,17 +2235,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`document`" and
-      <a for="request">target browsing context</a> is a <a>nested browsing
-      context</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="frame-src-post-request">
     `frame-src` Post-request check
@@ -2247,18 +2256,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`document`" and
-      <a for="request">target browsing context</a> is a <a>nested browsing
-      context</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-img-src">`img-src`</h4>
 
@@ -2298,15 +2307,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`image`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `img-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="img-src-post-request">
     `img-src` Post-request check
@@ -2317,16 +2328,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`image`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-manifest-src">`manifest-src`</h4>
 
@@ -2362,15 +2375,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="manifest-src-post-request">
     `manifest-src` Post-request check
@@ -2381,16 +2396,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-media-src">`media-src`</h4>
 
@@ -2429,16 +2446,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
-      or "`track`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `media-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="media-src-post-request">
     `media-src` Post-request check
@@ -2449,17 +2467,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
-      or "`track`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `media-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-prefetch-src">`prefetch-src`</h4>
 
@@ -2496,14 +2515,16 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on |request| and this
-          directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on |request| and this
+      directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="prefetch-src-post-request">
     `prefetch-src` Post-request check
@@ -2514,14 +2535,16 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
-          and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
+      and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
 
   <h4 id="directive-object-src">`object-src`</h4>
@@ -2583,15 +2606,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `object-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="object-src-post-request">
     `object-src` Post-request check
@@ -2602,16 +2627,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `object-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-script-src">`script-src`</h4>
 
@@ -2660,69 +2687,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  If the result of executing [[#effective-directive-for-a-request]] on |request|
-      is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`worker-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
-
-      2.  Let |integrity expressions| be the set of <a>source expressions</a> in
-          this directive's <a for="directive">value</a> that match the
-          <a grammar>hash-source</a> grammar.
-
-      3.  If |integrity expressions| is not empty:
-
-          1.  Let |integrity sources| be the result of executing the algorithm
-              defined in [[SRI#parse-metadata]] on |request|'s
-              <a for="request">integrity metadata</a>. [[!SRI]]
-
-          2.  If |integrity sources| is "`no metadata`" or an empty set, skip
-              the remaining substeps.
-
-          3.  Let |bypass due to integrity match| be `true`.
-
-          4.  For each |source| in |integrity sources|:
-
-              1.  If this directive's <a for="directive">value</a> does not
-                  contain a <a>source expression</a> whose
-                  <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
-                  for |source|'s `hash-algo` component, and whose
-                  <a grammar>base64-value</a> is a <a>case-sensitive</a> match
-                  for |source|'s `base64-value`, then set |bypass due to
-                  integrity match| to `false`.
-
-          5.  If |bypass due to integrity match| is `true`, return
-              "`Allowed`".
-
-          Note: Here, we verify only that the |request| contains a set of
-          <a for="request">integrity metadata</a> which is a subset of the
-          <a grammar>hash-source</a> <a>source expressions</a> specified by
-          this directive. We rely on the browser's enforcement of Subresource
-          Integrity [[!SRI]] to block non-matching resources upon response.
-
-      3.  If this directive's <a for="directive">value</a> contains a <a>source
-          expression</a> that is an <a>ASCII case-insensitive</a> match for
-          the "<a grammar>`'strict-dynamic'`</a>" <a grammar>keyword-source</a>:
-
-          1.  If the |request|'s <a for="request">parser metadata</a> is
-              <a>"parser-inserted"</a>, return "`Blocked`".
-
-              Otherwise, return "`Allowed`".
-
-              Note: "<a grammar>`'strict-dynamic'`</a>" is explained in more detail
-              in [[#strict-dynamic-usage]].
-
-      4.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
-
-  3.  Return "`Allowed`".
+  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
 
   <h5 algorithm id="script-src-post-request">
     `script-src` Post-request check
@@ -2733,29 +2704,14 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  If the result of executing [[#effective-directive-for-a-request]] on |request|
-      is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`worker-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
-
-      2.  If this directive's <a for="directive">value</a> contains
-          "<a grammar>`'strict-dynamic'`</a>", and |request|'s
-          <a for="request">parser metadata</a> is not <a>"parser-inserted"</a>,
-          return "`Allowed`".
-
-      3.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
-
-  3.  Return "`Allowed`".
+  3.  Return the result of executing [[#script-post-request]] on |request|,
+      |response| and this directive.
 
   <h5 algorithm id="script-src-inline">
     `script-src` Inline Check
@@ -2763,17 +2719,134 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
 
-  1.  If |type| is "`script`", "`script attribute`" or "`navigation`":
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
 
-      1.  Assert: |element| is not `null` or |type| is "`navigation`".
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
 
-      2.  If the result of executing [[#match-element-to-source-list]] on
-          |element|, this directive's <a for="directive">value</a>, |type|,
-          and |source|, is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-  2.  Return "`Allowed`".
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-script-src-elem">`script-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.
+
+  As such, the following differences exist when comparing to `script-src`:
+  * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
+    (and is ignored for "`script attribute`" inline checks).
+  * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
+    execution sink checks that are gated on the "`unsafe-eval`" check.
+  * `script-src-elem` is not used as a fallback for the `worker-src` directive.
+    The `worker-src` checks still fall back on the `script-src` directive.
+
+  <h5 algorithm id="script-src-elem-pre-request">
+    `script-src-elem` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
+
+  <h5 algorithm id="script-src-elem-post-request">
+    `script-src-elem` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-post-request]] on |request|,
+      |response| and this directive.
+
+  <h5 algorithm id="script-src-elem-inline">
+    `script-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-script-src-attr">`script-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the `script-src` directive for relevant checks.
+
+  <h5 algorithm id="script-src-attr-inline">
+    `script-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
 
   <h4 id="directive-style-src">`style-src`</h4>
 
@@ -2829,20 +2902,22 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`style`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
 
-      2.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  4.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  5.  Return "`Allowed`".
 
   <h5 algorithm id="style-src-post-request">
     `style-src` Post-request Check
@@ -2853,21 +2928,23 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`style`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
 
-      2.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  4.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  5.  Return "`Allowed`".
 
   <h5 algorithm id="style-src-inline">
     `style-src` Inline Check
@@ -2875,21 +2952,143 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
 
-  1.  If |type| is "`style`" or "`style attribute`":
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
 
-      1.  If the result of executing [[#match-element-to-source-list]] on
-          |element|, this directive's <a for="directive">value</a>, |type|,
-          and |source|, is "`Does Not Match`", return "`Blocked`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  Return "`Allowed`".
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
 
   This directive's <a for="directive">initialization</a> algorithm is as follows:
 
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
+
+  <h4 id="directive-style-src-elem">`style-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.
+
+  <h5 algorithm id="style-src-elem-pre-request">
+    `style-src-elem` Pre-request Check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-post-request">
+    `style-src-elem` Post-request Check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-inline">
+    `style-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h4 id="directive-style-src-attr">`style-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-attr</dfn> directive governs the behaviour of style attributes.
+
+  <h5 algorithm id="style-src-attr-inline">
+    `style-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 
@@ -2929,16 +3128,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of
-      "`serviceworker`", "`sharedworker`", or "`worker`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `worker-src` and |policy| is "`No`", return "`Allowed`".
 
-      4.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="worker-src-post-request">
     `worker-src` Post-request Check
@@ -2949,17 +3149,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of
-      "`serviceworker`", "`sharedworker`", or "`worker`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `worker-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h3 id="directives-document">
     Document Directives
@@ -3560,7 +3761,102 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   check</a>, and <a for="directive">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.
 
-  <h3 id="algorithms">Matching Algorithms</h3>
+  <h3 id="matching-algorithms">Matching Algorithms</h3>
+
+  <h4 id="script-checks">Script directive checks</h4>
+
+  <h5 algorithm id="script-pre-request">
+    Script directives pre-request check
+  </h5>
+
+  Given a <a for="/">request</a> (|request|) and a <a>directive</a> (|directive|):
+
+  1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+
+      1.  If the result of executing [[#match-nonce-to-source-list]] on
+          |request|'s <a for="request">cryptographic nonce metadata</a> and this
+          directive's <a for="directive">value</a> is "`Matches`", return
+          "`Allowed`".
+
+      2.  Let |integrity expressions| be the set of <a>source expressions</a> in
+          |directive|'s <a for="directive">value</a> that match the
+          <a grammar>hash-source</a> grammar.
+
+      3.  If |integrity expressions| is not empty:
+
+          1.  Let |integrity sources| be the result of executing the algorithm
+              defined in [[SRI#parse-metadata]] on |request|'s
+              <a for="request">integrity metadata</a>. [[!SRI]]
+
+          2.  If |integrity sources| is "`no metadata`" or an empty set, skip
+              the remaining substeps.
+
+          3.  Let |bypass due to integrity match| be `true`.
+
+          4.  For each |source| in |integrity sources|:
+
+              1.  If |directive|'s <a for="directive">value</a> does not
+                  contain a <a>source expression</a> whose
+                  <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
+                  for |source|'s `hash-algo` component, and whose
+                  <a grammar>base64-value</a> is a <a>case-sensitive</a> match
+                  for |source|'s `base64-value`, then set |bypass due to
+                  integrity match| to `false`.
+
+          5.  If |bypass due to integrity match| is `true`, return
+              "`Allowed`".
+
+          Note: Here, we verify only that the |request| contains a set of
+          <a for="request">integrity metadata</a> which is a subset of the
+          <a grammar>hash-source</a> <a>source expressions</a> specified by
+          |directive|. We rely on the browser's enforcement of Subresource
+          Integrity [[!SRI]] to block non-matching resources upon response.
+
+      3.  If |directive|'s <a for="directive">value</a> contains a <a>source
+          expression</a> that is an <a>ASCII case-insensitive</a> match for
+          the "<a grammar>`'strict-dynamic'`</a>" <a grammar>keyword-source</a>:
+
+          1.  If the |request|'s <a for="request">parser metadata</a> is
+              <a>"parser-inserted"</a>, return "`Blocked`".
+
+              Otherwise, return "`Allowed`".
+
+              Note: "<a grammar>`'strict-dynamic'`</a>" is explained in more detail
+              in [[#strict-dynamic-usage]].
+
+      4.  If the result of executing [[#match-request-to-source-list]] on
+          |request| and |directive|'s <a for="directive">value</a> is
+          "`Does Not Match`", return "`Blocked`".
+
+  2.  Return "`Allowed`".
+
+  <h5 algorithm id="script-post-request">
+    Script directives post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a>directive</a> (|directive|):
+
+  1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+
+      1.  If the result of executing [[#match-nonce-to-source-list]] on
+          |request|'s <a for="request">cryptographic nonce metadata</a> and this
+          directive's <a for="directive">value</a> is "`Matches`", return
+          "`Allowed`".
+
+      2.  If |directive|'s <a for="directive">value</a> contains
+          "<a grammar>`'strict-dynamic'`</a>", and |request|'s
+          <a for="request">parser metadata</a> is not <a>"parser-inserted"</a>,
+          return "`Allowed`".
+
+      3.  If the result of executing [[#match-response-to-source-list]] on
+          |response|, |request|, and |directive|'s
+          <a for="directive">value</a> is "`Does Not Match`", return
+          "`Blocked`".
+
+  2.  Return "`Allowed`".
 
   <h4 id="matching-urls">URL Matching</h4>
 
@@ -3903,69 +4199,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     9.  Return "`Matches`".
   </ol>
 
-
-  <h5 id="effective-directive-for-a-request" algorithm>
-    Get the effective directive for |request|
-  </h5>
-
-  Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
-  a <a for="/">request</a> (|request|), the following algorithm returns either
-  `null` or the <a for="directive">name</a> of the request's
-  <dfn for="request" export>effective directive</dfn>:
-
-  1.  Switch on |request|'s <a for="request">destination</a>, and execute
-      the associated steps:
-
-      : ""
-      ::
-        1.  If the |request|'s <a for="request">initiator</a> is
-            the empty string, return `connect-src`.
-      : "`manifest`"
-      ::
-        1.  Return `manifest-src`.
-      : "`object`"
-      : "`embed`"
-      ::
-        1.  Return `object-src`.
-      : "`prefetch`"
-      : "`prerender`"
-      ::
-        1.  Return `prefetch-src`.
-      : "`document`"
-      ::
-        1.  If the |request|'s <a for="request">target browsing context</a>
-            is a <a>nested browsing context</a>, return `frame-src`.
-
-      : "`audio`"
-      : "`track`"
-      : "`video`"
-      ::
-        1.  Return `media-src`.
-
-      : "`font`"
-      ::
-        1.  Return `font-src`.
-
-      : "`image`"
-      ::
-        1.  Return `img-src`.
-
-      : "`style`"
-      ::
-        1.  Return `style-src`.
-
-      : "`script`"
-      : "`xslt`"
-      ::
-        1. Return `script-src`.
-
-      : "`sharedworker`"
-      : "`worker`"
-      ::
-        1. Return `worker-src`.
-
-  2.  Return `null`.
-
   <h4 id="matching-elements">Element Matching Algorithms</h4>
 
   <h5 id="is-element-nonceable" algorithm>
@@ -4151,6 +4384,190 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       navigations.
 
   6.  Return "`Does Not Match`".
+
+  <h3 id="directive-algorithms">Directive Algorithms</h3>
+
+  <h4 id="effective-directive-for-a-request" algorithm>
+    Get the effective directive for |request|
+  </h4>
+
+  Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
+  a <a for="/">request</a> (|request|), the following algorithm returns either
+  `null` or the <a for="directive">name</a> of the request's
+  <dfn for="request" export>effective directive</dfn>:
+
+  1.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
+      <a for="request">destination</a> is "", return `connect-src`.
+
+  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`",
+      return `prefetch-src`.
+
+  2.  Switch on |request|'s <a for="request">destination</a>, and execute
+      the associated steps:
+
+      : "`manifest`"
+      ::
+        1.  Return `manifest-src`.
+      : "`object`"
+      : "`embed`"
+      ::
+        1.  Return `object-src`.
+      : "`document`"
+      ::
+        1.  If the |request|'s <a for="request">target browsing context</a>
+            is a <a>nested browsing context</a>, return `frame-src`.
+
+      : "`audio`"
+      : "`track`"
+      : "`video`"
+      ::
+        1.  Return `media-src`.
+
+
+      : "`font`"
+      ::
+        1.  Return `font-src`.
+
+      : "`image`"
+      ::
+        1.  Return `img-src`.
+
+      : "`style`"
+      ::
+        1.  Return `style-src-elem`.
+
+      : "`script`"
+      : "`xslt`"
+      ::
+        1. Return `script-src-elem`.
+
+      : "`serviceworker`"
+      : "`sharedworker`"
+      : "`worker`"
+      ::
+        1. Return `worker-src`.
+
+  2.  Return `null`.
+
+  <h4 id="effective-directive-for-inline-check" algorithm>
+    Get the effective directive for inline checks
+  </h4>
+
+  Given a string (|type|), this algorithm returns the <a for="directive">name</a>
+  of the effective directive.
+
+  Note: While the <a for="request">effective directive</a> is only defined for
+  <a for="/">requests</a>, in this algorithm it is used similarly to mean
+  the directive that is most relevant to a particular type of inline check.
+
+  1.  Switch on |type|:
+
+      : "`script`"
+      : "`navigation`"
+      ::
+        1.  Return `script-src-elem`.
+      : "`script attribute`"
+      ::
+        1.  Return `script-src-attr`.
+      : "`style`"
+      ::
+        1.  Return `style-src-elem`.
+      : "`style attribute`"
+      ::
+        1.  Return `style-src-attr`.
+  2.  Return `null`.
+
+  <h4 id="directive-fallback-list" algorithm>
+    Get fetch directive fallback list
+  </h4>
+
+  Will return an <a>ordered set</a> of the fallback <a>directives</a> for a specific <a>directive</a>.
+  The returned <a>ordered set</a> is sorted from most relevant to least relevant
+  and it includes the effective directive itself.
+
+  Given a string (|directive name|):
+
+  1.  Switch on |directive name|:
+
+      : "`script-src-elem`"
+      ::
+        1.  `<< "script-src-elem", "script-src", "default-src" >>`.
+
+      : "`script-src-attr`"
+      ::
+        1.  `<< "script-src-attr", "script-src", "default-src" >>`.
+
+      : "`style-src-elem`"
+      ::
+        1.  `<< "style-src-elem", "style-src", "default-src" >>`.
+
+      : "`style-src-attr`"
+      ::
+        1.  `<< "style-src-attr", "style-src", "default-src" >>`.
+
+      : "`worker-src`"
+      ::
+        1.  `<< "worker-src", "child-src", "script-src", "default-src" >>`.
+
+      : "`connect-src`"
+      ::
+        1.  `<< "connect-src", "default-src" >>`.
+
+      : "`manifest-src`"
+      ::
+        1.  `<< "manifest-src", "default-src" >>`.
+
+      : "`prefetch-src`"
+      ::
+        1.  `<< "prefetch-src", "default-src" >>`.
+
+      : "`object-src`"
+      ::
+        1.  `<< "object-src", "default-src" >>`.
+
+      : "`frame-src`"
+      ::
+        1.  `<< "frame-src", "child-src", "default-src" >>`.
+
+      : "`media-src`"
+      ::
+        1.  `<< "media-src", "default-src" >>`.
+
+      : "`font-src`"
+      ::
+        1.  `<< "font-src", "default-src" >>`.
+
+      : "`image-src`"
+      ::
+        1.  `<< "image-src", "default-src" >>`.
+
+  2.  Return `<< >>`.
+
+  <h4 id="should-directive-execute" algorithm>
+    Should fetch directive execute
+  </h4>
+
+  This algorithm is used for <a>fetch directives</a> to decide whether a directive
+  should execute or defer to a different directive that is better suited.
+  For example: if the |effective directive name| is `worker-src` (meaning that
+  we are currently checking a worker request), a `default-src` directive
+  should not execute if a `worker-src` or `script-src` directive exists.
+
+  Given a string (|effective directive name|), a string (|directive name|) and
+  a <a for="/">policy</a> (|policy|):
+
+  1.  Let |directive fallback list| be the result of executing [[#directive-fallback-list]]
+      on |effective directive name|.
+
+  2.  For each |fallback directive| in |directive fallback list|:
+
+      1.  If |directive name| is |fallback directive|, Return "`Yes`".
+
+      2.  If |policy| contains a directive whose <a for="directive">name</a>
+          is |fallback directive|,  Return "`No`".
+
+  3.  Return "`No`".
+
 </section>
 
 <!-- Big text: Security -->

--- a/index.src.html
+++ b/index.src.html
@@ -4169,7 +4169,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`",
       return `prefetch-src`.
 
-  2.  Switch on |request|'s <a for="request">destination</a>, and execute
+  3.  Switch on |request|'s <a for="request">destination</a>, and execute
       the associated steps:
 
       : "`manifest`"
@@ -4214,7 +4214,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       ::
         1. Return `worker-src`.
 
-  2.  Return `null`.
+  4.  Return `null`.
 
   <h4 id="effective-directive-for-inline-check" algorithm>
     Get the effective directive for inline checks
@@ -4256,47 +4256,47 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`script-src`"
       ::
-        1.  `<< script-src", "default-src" >>`.
+        1.  Return `<< script-src", "default-src" >>`.
 
       : "`style-src`"
       ::
-        1.  `<< "style-src", "default-src" >>`.
+        1.  Return `<< "style-src", "default-src" >>`.
 
       : "`worker-src`"
       ::
-        1.  `<< "worker-src", "child-src", "script-src", "default-src" >>`.
+        1.  Return `<< "worker-src", "child-src", "script-src", "default-src" >>`.
 
       : "`connect-src`"
       ::
-        1.  `<< "connect-src", "default-src" >>`.
+        1.  Return `<< "connect-src", "default-src" >>`.
 
       : "`manifest-src`"
       ::
-        1.  `<< "manifest-src", "default-src" >>`.
+        1.  Return `<< "manifest-src", "default-src" >>`.
 
       : "`prefetch-src`"
       ::
-        1.  `<< "prefetch-src", "default-src" >>`.
+        1.  Return `<< "prefetch-src", "default-src" >>`.
 
       : "`object-src`"
       ::
-        1.  `<< "object-src", "default-src" >>`.
+        1.  Return `<< "object-src", "default-src" >>`.
 
       : "`frame-src`"
       ::
-        1.  `<< "frame-src", "child-src", "default-src" >>`.
+        1.  Return `<< "frame-src", "child-src", "default-src" >>`.
 
       : "`media-src`"
       ::
-        1.  `<< "media-src", "default-src" >>`.
+        1.  Return `<< "media-src", "default-src" >>`.
 
       : "`font-src`"
       ::
-        1.  `<< "font-src", "default-src" >>`.
+        1.  Return `<< "font-src", "default-src" >>`.
 
       : "`image-src`"
       ::
-        1.  `<< "image-src", "default-src" >>`.
+        1.  Return `<< "image-src", "default-src" >>`.
 
   2.  Return `<< >>`.
 

--- a/index.src.html
+++ b/index.src.html
@@ -2021,10 +2021,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> <a grammar>'self'</a>;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> <a grammar>'self'</a>;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2037,7 +2035,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2051,10 +2049,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> https://example.com;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> https://example.com;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2736,118 +2732,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   5.  Return "`Allowed`".
 
-  <h4 id="directive-script-src-elem">`script-src-elem`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "script-src-elem"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.
-
-  As such, the following differences exist when comparing to `script-src`:
-  * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
-    (and is ignored for "`script attribute`" inline checks).
-  * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
-    execution sink checks that are gated on the "`unsafe-eval`" check.
-  * `script-src-elem` is not used as a fallback for the `worker-src` directive.
-    The `worker-src` checks still fall back on the `script-src` directive.
-
-  <h5 algorithm id="script-src-elem-pre-request">
-    `script-src-elem` Pre-request check
-  </h5>
-
-  This directive's <a for="directive">pre-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
-
-  <h5 algorithm id="script-src-elem-post-request">
-    `script-src-elem` Post-request check
-  </h5>
-
-  This directive's <a for="directive">post-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  Return the result of executing [[#script-post-request]] on |request|,
-      |response| and this directive.
-
-  <h5 algorithm id="script-src-elem-inline">
-    `script-src-elem` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Assert: |element| is not `null` or |type| is "`navigation`".
-
-  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  3.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  4.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h4 id="directive-script-src-attr">`script-src-attr`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "script-src-attr"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>script-src-attr</dfn> directive applies to event handlers and, if present,
-  it will superseed the `script-src` directive for relevant checks.
-
-  <h5 algorithm id="script-src-attr-inline">
-    `script-src-attr` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Assert: |element| is not `null` or |type| is "`navigation`".
-
-  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  3.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-attr` and |policy| is "`No`", return "`Allowed`".
-
-  4.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
   <h4 id="directive-style-src">`style-src`</h4>
 
   The <dfn export>style-src</dfn> directive restricts the locations from which style
@@ -2972,123 +2856,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
-
-  <h4 id="directive-style-src-elem">`style-src-elem`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "style-src-elem"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>style-src-elem</dfn> directive governs the behaviour of styles
-  except for styles defined in inline attributes.
-
-  <h5 algorithm id="style-src-elem-pre-request">
-    `style-src-elem` Pre-request Check
-  </h5>
-
-  This directive's <a for="directive">pre-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-nonce-to-source-list]] on
-      |request|'s <a for="request">cryptographic nonce metadata</a> and this
-      directive's <a for="directive">value</a> is "`Matches`", return
-      "`Allowed`".
-
-  4.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h5 algorithm id="style-src-elem-post-request">
-    `style-src-elem` Post-request Check
-  </h5>
-
-  This directive's <a for="directive">post-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-nonce-to-source-list]] on
-      |request|'s <a for="request">cryptographic nonce metadata</a> and this
-      directive's <a for="directive">value</a> is "`Matches`", return
-      "`Allowed`".
-
-  4.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h5 algorithm id="style-src-elem-inline">
-    `style-src-elem` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
-
-  <h4 id="directive-style-src-attr">`style-src-attr`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "style-src-attr"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>style-src-attr</dfn> directive governs the behaviour of style attributes.
-
-  <h5 algorithm id="style-src-attr-inline">
-    `style-src-attr` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-attr` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 
@@ -4434,12 +4201,12 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`style`"
       ::
-        1.  Return `style-src-elem`.
+        1.  Return `style-src`.
 
       : "`script`"
       : "`xslt`"
       ::
-        1. Return `script-src-elem`.
+        1. Return `script-src`.
 
       : "`serviceworker`"
       : "`sharedworker`"
@@ -4464,17 +4231,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`script`"
       : "`navigation`"
-      ::
-        1.  Return `script-src-elem`.
       : "`script attribute`"
       ::
-        1.  Return `script-src-attr`.
+        1.  Return `script-src`.
+
       : "`style`"
-      ::
-        1.  Return `style-src-elem`.
       : "`style attribute`"
       ::
-        1.  Return `style-src-attr`.
+        1.  Return `style-src`.
+
   2.  Return `null`.
 
   <h4 id="directive-fallback-list" algorithm>
@@ -4489,21 +4254,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Switch on |directive name|:
 
-      : "`script-src-elem`"
+      : "`script-src`"
       ::
-        1.  `<< "script-src-elem", "script-src", "default-src" >>`.
+        1.  `<< script-src", "default-src" >>`.
 
-      : "`script-src-attr`"
+      : "`style-src`"
       ::
-        1.  `<< "script-src-attr", "script-src", "default-src" >>`.
-
-      : "`style-src-elem`"
-      ::
-        1.  `<< "style-src-elem", "style-src", "default-src" >>`.
-
-      : "`style-src-attr`"
-      ::
-        1.  `<< "style-src-attr", "style-src", "default-src" >>`.
+        1.  `<< "style-src", "default-src" >>`.
 
       : "`worker-src`"
       ::


### PR DESCRIPTION
Updated `#effective-directive-for-a-request` with new directives and updates.
Updated fetch directives to use `#effective-directive-for-[a-request/inline-check]` always, instead of spelling out the exact same logic.

Added `#effective-directive-for-inline-check` which returns the effective directive for inline checks

Added a `#directive-fallback-list` algorithm which will return an orderered set of a directives fallback list. This keeps the fallback logic clear and centralized instead of it being entirely distributed between directives. This means there is an easy way to, for instance, figure out what directive is used as a fallback if `worker-src` is not present.

Added a `#should-directive-execute` algorithm which will take over all checks that were before distributed between all directives. It uses the newly added `#directive-fallback-list` algorithm.
This means that the `default-src` directive won't have to have tons of if checks to check if any more relevant directive is present for the particular request or inline check.
Updated all fetch directives to use `#should-directive-execute`.

Fixed issue where `default-src` would not be used as fallback for inline script/style checks according to the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/318.html" title="Last updated on Aug 17, 2018, 2:09 PM GMT (b8ff592)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/318/af505e8...andypaicu:b8ff592.html" title="Last updated on Aug 17, 2018, 2:09 PM GMT (b8ff592)">Diff</a>