### PR TITLE
Added new directives for more granular script and style policies

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
+  <meta content="3d25c87fbcd39ecdd9fd14dd47128c0dae983f45" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-11">11 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-12">12 July 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2027,6 +2027,9 @@ of security-relevant policy decisions.</p>
   to which it can initiate navigation.</p>
      <li data-md="">
       <p>Reports generated for inline violations will contain a <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample">sample</a> attribute if the relevant directive contains the <a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample"><code>'report-sample'</code></a> expression.</p>
+     <li data-md="">
+      <p>Extra directives are added that provide granularity for script and style
+  attributes and elements. As such these new directives <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem"><code>script-src-elem</code></a>, <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr"><code>script-src-attr</code></a>, <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem"><code>style-src-elem</code></a> and <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr"><code>style-src-attr</code></a> are added.</p>
     </ol>
    </section>
    <section>
@@ -3344,8 +3347,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-327c55f5">
-     <a class="self-link" href="#example-327c55f5"></a> The following header: 
+    <div class="example" id="example-d1d47ff9">
+     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3357,35 +3360,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-8536160a">
-     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-2a1475cd">
+     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3848,8 +3847,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
 </pre>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.</p>
-    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
+  except for script attributes which are covered by <code>script-src-attr</code>.
+  While in most cases policy authors will find it easier to simply use <code>script-src</code>,
+  there are scenarios in which it it useful to be able to apply a policy that
+  does not apply to event handlers.</p>
+    <p>The following differences exist when comparing to <code>script-src</code>:</p>
     <ul>
      <li data-md="">
       <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
@@ -4408,7 +4410,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
@@ -5371,7 +5373,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5482,12 +5484,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5502,7 +5504,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5531,14 +5533,14 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes②"><code>'unsafe-hashes'</code></a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.</p>
-     <div class="example" id="example-5d2d17c6">
-      <a class="self-link" href="#example-5d2d17c6"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
+     <div class="example" id="example-1d41749d">
+      <a class="self-link" href="#example-1d41749d"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
       resembling a reasonable schedule: 
 <pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
 </pre>
-      <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
+      <p>Rather than reducing security severly by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5548,6 +5550,19 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
     then that script becomes available for an attacker to inject as <code>&lt;script>transferAllMyMoney()&lt;/script></code>. Developers should be careful to balance the risk of
     allowing specific scripts to execute against the deployment advantages that allowing inline
     event handlers might provide.</p>
+     <p>Using the new <code>script-src-elem</code> and <code>script-src-attr</code>, a policy can be written
+    that is compatible with CSP2 or older user agents while keeping the <code>'unsafe-hashes'</code> features.</p>
+     <div class="example" id="example-eadb5494">
+      <a class="self-link" href="#example-eadb5494"></a> MegaCorp, Inc. wants to ensure that the above policy does not break the site
+      if user agents don’t implement CSP3 features. The presence of a
+      hash source disables inline behaviour in CSP2 so the <code>onclick</code> action is blocked. 
+      <p>In order to achieve this, the following policy is developed:</p>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑧">Content-Security-Policy</a>:
+  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑥">'unsafe-inline'</a>;
+  <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes④">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=';
+  <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> 'nonce-abc'; # or some other appropriate reasonable policy.
+</pre>
+     </div>
     </section>
     <section>
      <h3 class="heading settled" data-level="8.4" id="external-hash"><span class="secno">8.4. </span><span class="content"> Allowing external JavaScript via hashes </span><a class="self-link" href="#external-hash"></a></h3>
@@ -5660,10 +5675,10 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑨"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
@@ -5962,7 +5977,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy⑥">8.2. 
     Usage of "'strict-dynamic'" </a>
     <li><a href="#ref-for-header-content-security-policy⑦">8.3. 
-      Usage of "'unsafe-hashes'" </a>
+      Usage of "'unsafe-hashes'" </a> <a href="#ref-for-header-content-security-policy⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-serialized-policy">
@@ -9050,9 +9065,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
-    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
+    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -9066,6 +9081,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-unsafe-inline③">7.1. Nonce Reuse</a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
+    <li><a href="#ref-for-grammardef-unsafe-inline⑥">8.3. 
+      Usage of "'unsafe-hashes'" </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-unsafe-eval">
@@ -9094,7 +9111,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashes①">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-hashes②">8.3. 
-      Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a>
+      Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a> <a href="#ref-for-grammardef-unsafe-hashes④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-report-sample">
@@ -9644,44 +9661,50 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
-    <li><a href="#ref-for-script-src④">8.3. 
-      Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑤">10.1. 
+    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
+    <li><a href="#ref-for-script-src⑤">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
+    <li><a href="#ref-for-script-src⑦">8.3. 
+      Usage of "'unsafe-hashes'" </a> <a href="#ref-for-script-src⑧">(2)</a>
+    <li><a href="#ref-for-script-src⑨">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="script-src-elem">
    <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
+    <li><a href="#ref-for-script-src-elem">1.3. Changes from Level 2</a>
+    <li><a href="#ref-for-script-src-elem①">8.3. 
+      Usage of "'unsafe-hashes'" </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="script-src-attr">
    <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
+    <li><a href="#ref-for-script-src-attr">1.3. Changes from Level 2</a>
+    <li><a href="#ref-for-script-src-attr①">8.3. 
+      Usage of "'unsafe-hashes'" </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src①">10.1. 
+    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
+    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src③">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src-elem">
    <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
+    <li><a href="#ref-for-style-src-elem">1.3. Changes from Level 2</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src-attr">
    <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
+    <li><a href="#ref-for-style-src-attr">1.3. Changes from Level 2</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
+  <meta content="86643a535c7102bc8ef9e024596ca9ceb8928cae" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1720,41 +1720,17 @@ of security-relevant policy decisions.</p>
           <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-script-src-elem"><span class="secno">6.1.12</span> <span class="content"><code>script-src-elem</code></span></a>
+         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
          <ol class="toc">
-          <li><a href="#script-src-elem-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>script-src-elem</code> Pre-request check </span></a>
-          <li><a href="#script-src-elem-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>script-src-elem</code> Post-request check </span></a>
-          <li><a href="#script-src-elem-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>script-src-elem</code> Inline Check </span></a>
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-script-src-attr"><span class="secno">6.1.13</span> <span class="content"><code>script-src-attr</code></span></a>
+         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
          <ol class="toc">
-          <li><a href="#script-src-attr-inline"><span class="secno">6.1.13.1</span> <span class="content"> <code>script-src-attr</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src"><span class="secno">6.1.14</span> <span class="content"><code>style-src</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.14.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src-elem"><span class="secno">6.1.15</span> <span class="content"><code>style-src-elem</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-elem-pre-request"><span class="secno">6.1.15.1</span> <span class="content"> <code>style-src-elem</code> Pre-request Check </span></a>
-          <li><a href="#style-src-elem-post-request"><span class="secno">6.1.15.2</span> <span class="content"> <code>style-src-elem</code> Post-request Check </span></a>
-          <li><a href="#style-src-elem-inline"><span class="secno">6.1.15.3</span> <span class="content"> <code>style-src-elem</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-style-src-attr"><span class="secno">6.1.16</span> <span class="content"><code>style-src-attr</code></span></a>
-         <ol class="toc">
-          <li><a href="#style-src-attr-inline"><span class="secno">6.1.16.1</span> <span class="content"> <code>style-src-attr</code> Inline Check </span></a>
-         </ol>
-        <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.17</span> <span class="content"><code>worker-src</code></span></a>
-         <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.17.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.17.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -3344,8 +3320,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-327c55f5">
-     <a class="self-link" href="#example-327c55f5"></a> The following header: 
+    <div class="example" id="example-d1d47ff9">
+     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3357,35 +3333,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-8536160a">
-     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-2a1475cd">
+     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
+                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3842,97 +3814,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "script-src-elem"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.</p>
-    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
-    <ul>
-     <li data-md="">
-      <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
-(and is ignored for "<code>script attribute</code>" inline checks).</p>
-     <li data-md="">
-      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
-execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
-     <li data-md="">
-      <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
-The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
-    </ul>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "script-src-attr"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
-  it will superseed the <code>script-src</code> directive for relevant checks.</p>
-    <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3944,7 +3836,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
@@ -3968,9 +3860,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3978,17 +3870,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3996,24 +3888,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4022,89 +3914,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "style-src-elem"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
-  except for styles defined in inline attributes.</p>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
-    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
-<pre>directive-name  = "style-src-attr"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
-</pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
-    <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
-    <ol>
-     <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
-  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
@@ -4119,30 +3934,30 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4155,7 +3970,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑦">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -4170,7 +3985,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
@@ -4236,9 +4051,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4251,7 +4066,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4259,7 +4074,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
     Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
@@ -4281,7 +4096,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4304,7 +4119,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4317,7 +4132,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4331,7 +4146,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4340,7 +4155,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4363,7 +4178,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4378,11 +4193,11 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4392,7 +4207,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4408,14 +4223,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
@@ -4439,7 +4254,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4451,7 +4266,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4472,12 +4287,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     </div>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigate-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4487,20 +4302,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
-  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
+  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> (<var>navigation response</var>)
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
@@ -4511,7 +4326,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
@@ -4519,7 +4334,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4568,23 +4383,23 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
        <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
@@ -4600,7 +4415,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -4613,7 +4428,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
@@ -4624,29 +4439,29 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4654,7 +4469,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4664,7 +4479,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
@@ -4672,7 +4487,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4691,15 +4506,15 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
@@ -4940,7 +4755,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.3.1" id="is-element-nonceable"><span class="secno">6.6.3.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
   a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
@@ -5020,7 +4835,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.3.3" id="match-element-to-source-list"><span class="secno">6.6.3.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
@@ -5095,8 +4910,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
@@ -5150,14 +4965,14 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src-elem</code>.</p>
+          <p>Return <code>style-src</code>.</p>
         </ol>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>xslt</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src-elem</code>.</p>
+          <p>Return <code>script-src</code>.</p>
         </ol>
        <dt data-md="">"<code>serviceworker</code>"
        <dt data-md="">"<code>sharedworker</code>"
@@ -5173,7 +4988,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
     <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> of the effective directive.</p>
-    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
      <li data-md="">
@@ -5181,28 +4996,18 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <dl>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>navigation</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>script-src-elem</code>.</p>
-        </ol>
        <dt data-md="">"<code>script attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src-attr</code>.</p>
+          <p>Return <code>script-src</code>.</p>
         </ol>
        <dt data-md="">"<code>style</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>style-src-elem</code>.</p>
-        </ol>
        <dt data-md="">"<code>style attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src-attr</code>.</p>
+          <p>Return <code>style-src</code>.</p>
         </ol>
       </dl>
      <li data-md="">
@@ -5217,29 +5022,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md="">
       <p>Switch on <var>directive name</var>:</p>
       <dl>
-       <dt data-md="">"<code>script-src-elem</code>"
+       <dt data-md="">"<code>script-src</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>script-src-attr</code>"
+       <dt data-md="">"<code>style-src</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
-        </ol>
-       <dt data-md="">"<code>style-src-elem</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
-        </ol>
-       <dt data-md="">"<code>style-src-attr</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p><code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; "style-src", "default-src" >></code>.</p>
         </ol>
        <dt data-md="">"<code>worker-src</code>"
        <dd data-md="">
@@ -5306,7 +5099,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   we are currently checking a worker request), a <code>default-src</code> directive
   should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
-  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
@@ -5328,7 +5121,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5371,7 +5164,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5482,12 +5275,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5502,7 +5295,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5538,7 +5331,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5592,7 +5385,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5660,15 +5453,15 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5899,8 +5692,6 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.2.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
    <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
-   <li><a href="#script-src-attr">script-src-attr</a><span>, in §6.1.13</span>
-   <li><a href="#script-src-elem">script-src-elem</a><span>, in §6.1.12</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5935,9 +5726,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.14</span>
-   <li><a href="#style-src-attr">style-src-attr</a><span>, in §6.1.16</span>
-   <li><a href="#style-src-elem">style-src-elem</a><span>, in §6.1.15</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
@@ -5952,7 +5741,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
    <a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">https://www.w3.org/TR/CSP3/#header-content-security-policy</a><b>Referenced in:</b>
@@ -5979,31 +5768,31 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
+    <li><a href="#ref-for-at-ruledef-import">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
+    <li><a href="#ref-for-insert-a-css-rule">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-css-rule">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
+    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -6023,7 +5812,7 @@ rest of Google’s CSP Cabal.</p>
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-document①①">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-document①②">6.1.14. style-src</a>
+    <li><a href="#ref-for-document①②">6.1.12. style-src</a>
     <li><a href="#ref-for-document①③">6.2.1. base-uri</a>
     <li><a href="#ref-for-document①④">6.2.1.1. 
     Is base allowed for document? </a>
@@ -6046,21 +5835,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-element③">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-element④">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑤">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-element⑦">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑧">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑨">6.2.2.2. 
+    <li><a href="#ref-for-element⑤">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-element①⓪">6.6.3.1. 
+    <li><a href="#ref-for-element⑥">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-element①①">6.6.3.3. 
+    <li><a href="#ref-for-element⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -6204,19 +5985,15 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata③">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata④">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.2.2. 
     Does nonce match source list? </a>
    </ul>
   </aside>
@@ -6502,50 +6279,42 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-concept-request④③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
+    <li><a href="#ref-for-concept-request④④">6.1.12. style-src</a>
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
+    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
+    <li><a href="#ref-for-concept-request④⑦">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
+    <li><a href="#ref-for-concept-request④⑧">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
+    <li><a href="#ref-for-concept-request④⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤⓪">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤①">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤②">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤③">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤④">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥⓪">(2)</a>
+    <li><a href="#ref-for-concept-request⑥①">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
+    <li><a href="#ref-for-concept-request⑥②">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥③">(2)</a>
+    <li><a href="#ref-for-concept-request⑥④">6.7.2. 
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
@@ -6592,32 +6361,28 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑦">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-response③①">6.1.14.2. 
+    <li><a href="#ref-for-concept-response②⑨">6.1.12. style-src</a>
+    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③②">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.1.17.2. 
+    <li><a href="#ref-for-concept-response③①">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③④">6.2.2.1. 
+    <li><a href="#ref-for-concept-response③②">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.3.1. 
+    <li><a href="#ref-for-concept-response③③">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③⑥">6.2.3.2. 
+    <li><a href="#ref-for-concept-response③④">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑦">6.2.4.1. 
+    <li><a href="#ref-for-concept-response③⑤">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
+    <li><a href="#ref-for-concept-response③⑥">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
-    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
+    <li><a href="#ref-for-concept-response③⑦">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response③⑧">(2)</a>
+    <li><a href="#ref-for-concept-response③⑨">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
+    <li><a href="#ref-for-concept-response④⓪">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
+    <li><a href="#ref-for-concept-response④①">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6696,7 +6461,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
+    <li><a href="#ref-for-sharedworker①">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
@@ -6723,7 +6488,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
+    <li><a href="#ref-for-worker②">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -6999,7 +6764,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-link-element①">6.1.12. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
@@ -7249,7 +7014,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
@@ -7592,7 +7357,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
+    <li><a href="#ref-for-serviceworker①">6.1.13. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -8310,55 +8075,39 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.3. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.17.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.7.4. 
     Should fetch directive execute </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑦①">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑦②">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8633,52 +8382,39 @@ rest of Google’s CSP Cabal.</p>
     object-src Post-request check </a>
     <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
-    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
-    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
-    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.12.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③②">(2)</a>
+    <li><a href="#ref-for-directive-value③③">6.1.12.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value③④">(2)</a>
+    <li><a href="#ref-for-directive-value③⑤">6.1.12.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
-    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
-    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
-    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
+    <li><a href="#ref-for-directive-value③⑥">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
+    <li><a href="#ref-for-directive-value③⑦">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
+    <li><a href="#ref-for-directive-value③⑧">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
+    <li><a href="#ref-for-directive-value③⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⓪">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-directive-value④①">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
+    <li><a href="#ref-for-directive-value④②">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
+    <li><a href="#ref-for-directive-value④③">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
+    <li><a href="#ref-for-directive-value④④">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
-    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
-    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
+    <li><a href="#ref-for-directive-value④⑤">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value④⑥">(2)</a>
+    <li><a href="#ref-for-directive-value④⑦">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value④⑧">(2)</a>
+    <li><a href="#ref-for-directive-value④⑨">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⓪">(2)</a> <a href="#ref-for-directive-value⑤①">(3)</a> <a href="#ref-for-directive-value⑤②">(4)</a> <a href="#ref-for-directive-value⑤③">(5)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a> <a href="#ref-for-directive-value⑤⑥">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8733,18 +8469,14 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.1.17.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑧">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑨">6.6.2.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check②⓪">6.6.2.3. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -8779,20 +8511,16 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.1.17.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑨">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check②⓪">6.5. 
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check②①">6.6.1.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check②②">6.6.2.4. 
+    <li><a href="#ref-for-directive-post-request-check②⓪">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -8823,15 +8551,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-directive-inline-check⑤">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑥">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑦">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑧">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check⑨">6.1.16.1. 
-    style-src-attr Inline Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-initialization">
@@ -8839,7 +8559,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.14.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -8886,7 +8606,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-source-lists①②">6.6.2.2. 
     Does nonce match source list? </a>
@@ -8935,15 +8655,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.1.15. style-src-elem</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.1.16. style-src-attr</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.1.17. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑦">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑧">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigate-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -9050,9 +8766,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
-    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
+    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -9121,7 +8837,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-nonce-source④">6.6.2.2. 
     Does nonce match source list? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.3.1. 
@@ -9152,7 +8868,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.12. style-src</a>
     <li><a href="#ref-for-grammardef-hash-source④">6.6.1.1. 
     Script directives pre-request check </a> <a href="#ref-for-grammardef-hash-source⑤">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source⑥">6.6.3.2. 
@@ -9644,51 +9360,29 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
-    <li><a href="#ref-for-script-src④">8.3. 
+    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
+    <li><a href="#ref-for-script-src⑤">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
+    <li><a href="#ref-for-script-src⑦">8.3. 
       Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑤">10.1. 
+    <li><a href="#ref-for-script-src⑧">10.1. 
     Directive Registry </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="script-src-elem">
-   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="script-src-attr">
-   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src①">10.1. 
+    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
+    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src③">10.1. 
     Directive Registry </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="style-src-elem">
-   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="style-src-attr">
-   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
+    <li><a href="#ref-for-worker-src②">6.1.13. worker-src</a>
     <li><a href="#ref-for-worker-src③">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="86643a535c7102bc8ef9e024596ca9ceb8928cae" name="document-revision">
+  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1720,17 +1720,41 @@ of security-relevant policy decisions.</p>
           <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
+         <a href="#directive-script-src-elem"><span class="secno">6.1.12</span> <span class="content"><code>script-src-elem</code></span></a>
          <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+          <li><a href="#script-src-elem-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>script-src-elem</code> Pre-request check </span></a>
+          <li><a href="#script-src-elem-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>script-src-elem</code> Post-request check </span></a>
+          <li><a href="#script-src-elem-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>script-src-elem</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
+         <a href="#directive-script-src-attr"><span class="secno">6.1.13</span> <span class="content"><code>script-src-attr</code></span></a>
          <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#script-src-attr-inline"><span class="secno">6.1.13.1</span> <span class="content"> <code>script-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src"><span class="secno">6.1.14</span> <span class="content"><code>style-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.14.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-elem"><span class="secno">6.1.15</span> <span class="content"><code>style-src-elem</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-elem-pre-request"><span class="secno">6.1.15.1</span> <span class="content"> <code>style-src-elem</code> Pre-request Check </span></a>
+          <li><a href="#style-src-elem-post-request"><span class="secno">6.1.15.2</span> <span class="content"> <code>style-src-elem</code> Post-request Check </span></a>
+          <li><a href="#style-src-elem-inline"><span class="secno">6.1.15.3</span> <span class="content"> <code>style-src-elem</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-attr"><span class="secno">6.1.16</span> <span class="content"><code>style-src-attr</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-attr-inline"><span class="secno">6.1.16.1</span> <span class="content"> <code>style-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-worker-src"><span class="secno">6.1.17</span> <span class="content"><code>worker-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.17.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.17.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -3320,8 +3344,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-d1d47ff9">
-     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
+    <div class="example" id="example-327c55f5">
+     <a class="self-link" href="#example-327c55f5"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3333,31 +3357,35 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-2a1475cd">
-     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-8536160a">
+     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3814,17 +3842,97 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.</p>
+    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
+    <ul>
+     <li data-md="">
+      <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
+(and is ignored for "<code>script attribute</code>" inline checks).</p>
+     <li data-md="">
+      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
+execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
+     <li data-md="">
+      <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
+The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
+    </ul>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the <code>script-src</code> directive for relevant checks.</p>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3836,7 +3944,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
@@ -3860,9 +3968,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3870,17 +3978,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3888,24 +3996,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -3914,12 +4022,89 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+  "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
@@ -3934,30 +4119,30 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -3970,7 +4155,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑦">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -3985,7 +4170,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
@@ -4051,9 +4236,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4066,7 +4251,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4074,7 +4259,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
     Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
@@ -4096,7 +4281,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4119,7 +4304,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4132,7 +4317,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4146,7 +4331,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4155,7 +4340,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4178,7 +4363,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4193,11 +4378,11 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4207,7 +4392,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4223,14 +4408,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
@@ -4254,7 +4439,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4266,7 +4451,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4287,12 +4472,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     </div>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigate-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4302,20 +4487,20 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
-  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
+  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
@@ -4326,7 +4511,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
@@ -4334,7 +4519,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4383,23 +4568,23 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
        <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
@@ -4415,7 +4600,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> does not
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -4428,7 +4613,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
@@ -4439,29 +4624,29 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> is "<code>Matches</code>", return
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> contains
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4469,7 +4654,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4479,7 +4664,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
@@ -4487,7 +4672,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4506,15 +4691,15 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
@@ -4755,7 +4940,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.3.1" id="is-element-nonceable"><span class="secno">6.6.3.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
   a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
@@ -4835,7 +5020,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.3.3" id="match-element-to-source-list"><span class="secno">6.6.3.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
@@ -4910,8 +5095,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
      <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
@@ -4965,14 +5150,14 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src</code>.</p>
+          <p>Return <code>style-src-elem</code>.</p>
         </ol>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>xslt</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src</code>.</p>
+          <p>Return <code>script-src-elem</code>.</p>
         </ol>
        <dt data-md="">"<code>serviceworker</code>"
        <dt data-md="">"<code>sharedworker</code>"
@@ -4988,7 +5173,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
     <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> of the effective directive.</p>
-    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">requests</a>, in this algorithm it is used similarly to mean
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
      <li data-md="">
@@ -4996,18 +5181,28 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <dl>
        <dt data-md="">"<code>script</code>"
        <dt data-md="">"<code>navigation</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-elem</code>.</p>
+        </ol>
        <dt data-md="">"<code>script attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>script-src</code>.</p>
+          <p>Return <code>script-src-attr</code>.</p>
         </ol>
        <dt data-md="">"<code>style</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-elem</code>.</p>
+        </ol>
        <dt data-md="">"<code>style attribute</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p>Return <code>style-src</code>.</p>
+          <p>Return <code>style-src-attr</code>.</p>
         </ol>
       </dl>
      <li data-md="">
@@ -5022,17 +5217,29 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md="">
       <p>Switch on <var>directive name</var>:</p>
       <dl>
-       <dt data-md="">"<code>script-src</code>"
+       <dt data-md="">"<code>script-src-elem</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; script-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md="">"<code>style-src</code>"
+       <dt data-md="">"<code>script-src-attr</code>"
        <dd data-md="">
         <ol>
          <li data-md="">
-          <p><code>&lt;&lt; "style-src", "default-src" >></code>.</p>
+          <p><code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-elem</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-attr</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
         </ol>
        <dt data-md="">"<code>worker-src</code>"
        <dd data-md="">
@@ -5099,7 +5306,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   we are currently checking a worker request), a <code>default-src</code> directive
   should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
-  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
@@ -5121,7 +5328,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5164,7 +5371,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5275,12 +5482,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5295,7 +5502,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5331,7 +5538,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5385,7 +5592,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5453,15 +5660,15 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5692,6 +5899,8 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.2.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
    <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
+   <li><a href="#script-src-attr">script-src-attr</a><span>, in §6.1.13</span>
+   <li><a href="#script-src-elem">script-src-elem</a><span>, in §6.1.12</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5726,7 +5935,9 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.14</span>
+   <li><a href="#style-src-attr">style-src-attr</a><span>, in §6.1.16</span>
+   <li><a href="#style-src-elem">style-src-elem</a><span>, in §6.1.15</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
@@ -5741,7 +5952,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
    <a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">https://www.w3.org/TR/CSP3/#header-content-security-policy</a><b>Referenced in:</b>
@@ -5768,31 +5979,31 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.12. style-src</a>
+    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -5812,7 +6023,7 @@ rest of Google’s CSP Cabal.</p>
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-document①①">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-document①②">6.1.12. style-src</a>
+    <li><a href="#ref-for-document①②">6.1.14. style-src</a>
     <li><a href="#ref-for-document①③">6.2.1. base-uri</a>
     <li><a href="#ref-for-document①④">6.2.1.1. 
     Is base allowed for document? </a>
@@ -5835,13 +6046,21 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-element③">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-element④">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑤">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-element⑤">6.2.2.2. 
+    <li><a href="#ref-for-element⑦">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑧">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-element⑥">6.6.3.1. 
+    <li><a href="#ref-for-element①⓪">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-element⑦">6.6.3.3. 
+    <li><a href="#ref-for-element①①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -5985,15 +6204,19 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.12.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.12.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.6.1.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.6.1.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.2.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
     Does nonce match source list? </a>
    </ul>
   </aside>
@@ -6279,42 +6502,50 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-concept-request④③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
+    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
+    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.13.1. 
+    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.13.2. 
+    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.2.2.1. 
+    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.6.2.1. 
+    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑤⑧">6.6.2.2. 
+    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.2.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑥⓪">(2)</a>
-    <li><a href="#ref-for-concept-request⑥①">6.6.2.4. 
+    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥②">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥③">(2)</a>
-    <li><a href="#ref-for-concept-request⑥④">6.7.2. 
+    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
@@ -6361,28 +6592,32 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑦">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
+    <li><a href="#ref-for-concept-response②⑨">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-response③⓪">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-response③①">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③①">6.1.13.2. 
+    <li><a href="#ref-for-concept-response③②">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-response③③">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③②">6.2.2.1. 
+    <li><a href="#ref-for-concept-response③④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.2.3.1. 
+    <li><a href="#ref-for-concept-response③⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③④">6.2.3.2. 
+    <li><a href="#ref-for-concept-response③⑥">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.4.1. 
+    <li><a href="#ref-for-concept-response③⑦">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-concept-response③⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑦">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response③⑧">(2)</a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.2. 
+    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
+    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④⓪">6.6.1.2. 
+    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-response④①">6.6.2.4. 
+    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6461,7 +6696,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
@@ -6488,7 +6723,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -6764,7 +6999,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.12. style-src</a>
+    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
@@ -7014,7 +7249,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
+    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
@@ -7357,7 +7592,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -8075,39 +8310,55 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.12.1. 
-    style-src Pre-request Check </a>
+    script-src-elem Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
-    style-src Post-request Check </a>
+    script-src-elem Post-request check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
-    style-src Inline Check </a>
+    script-src-elem Inline Check </a>
     <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.14.1. 
+    style-src Pre-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.2. 
+    style-src Post-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.3. 
+    style-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.13.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.6.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.7.4. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
     Should fetch directive execute </a>
-    <li><a href="#ref-for-content-security-policy-object⑦①">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑦②">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8382,39 +8633,52 @@ rest of Google’s CSP Cabal.</p>
     object-src Post-request check </a>
     <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③①">6.1.12.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③②">(2)</a>
-    <li><a href="#ref-for-directive-value③③">6.1.12.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value③④">(2)</a>
-    <li><a href="#ref-for-directive-value③⑤">6.1.12.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
+    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
+    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑥">6.1.13.1. 
+    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
+    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
+    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
+    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value③⑦">6.1.13.2. 
+    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value③⑧">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value③⑨">6.2.2.1. 
+    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⓪">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④①">6.2.3.1. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value④②">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value④③">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value④④">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value④⑥">(2)</a>
-    <li><a href="#ref-for-directive-value④⑦">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value④⑧">(2)</a>
-    <li><a href="#ref-for-directive-value④⑨">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⓪">(2)</a> <a href="#ref-for-directive-value⑤①">(3)</a> <a href="#ref-for-directive-value⑤②">(4)</a> <a href="#ref-for-directive-value⑤③">(5)</a>
-    <li><a href="#ref-for-directive-value⑤④">6.6.1.2. 
-    Script directives post-request check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a> <a href="#ref-for-directive-value⑤⑥">(3)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
+    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8469,14 +8733,18 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.2.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.2.3. 
+    <li><a href="#ref-for-directive-pre-request-check②⓪">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -8511,16 +8779,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
+    <li><a href="#ref-for-directive-post-request-check②⓪">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.2. 
+    <li><a href="#ref-for-directive-post-request-check②①">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check②⓪">6.6.2.4. 
+    <li><a href="#ref-for-directive-post-request-check②②">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -8551,7 +8823,15 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check④">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-directive-inline-check⑤">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑥">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑦">6.1.14.3. 
     style-src Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑧">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑨">6.1.16.1. 
+    style-src-attr Inline Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-initialization">
@@ -8559,7 +8839,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.14.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -8606,7 +8886,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-source-lists①②">6.6.2.2. 
     Does nonce match source list? </a>
@@ -8655,11 +8935,15 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigate-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.1.15. style-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.1.16. style-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.1.17. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑦">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑧">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -8766,9 +9050,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
-    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
+    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8837,7 +9121,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.14. style-src</a>
     <li><a href="#ref-for-grammardef-nonce-source④">6.6.2.2. 
     Does nonce match source list? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.3.1. 
@@ -8868,7 +9152,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.12. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.14. style-src</a>
     <li><a href="#ref-for-grammardef-hash-source④">6.6.1.1. 
     Script directives pre-request check </a> <a href="#ref-for-grammardef-hash-source⑤">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source⑥">6.6.3.2. 
@@ -9360,29 +9644,51 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
-    <li><a href="#ref-for-script-src⑤">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
-    <li><a href="#ref-for-script-src⑦">8.3. 
+    <li><a href="#ref-for-script-src②">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
+    <li><a href="#ref-for-script-src④">8.3. 
       Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑧">10.1. 
+    <li><a href="#ref-for-script-src⑤">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-elem">
+   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-attr">
+   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
-    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src③">10.1. 
+    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src①">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-elem">
+   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-attr">
+   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
     <li><a href="#ref-for-worker-src③">10.1. 
     Directive Registry </a>
    </ul>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="f3349bf4cc808ae7f96ac3379286523d5ee3eda3" name="document-revision">
+  <meta content="af505e8a7458c467b418902b5860e3e1edebd1c4" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-10">10 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-07-11">11 July 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1562,7 +1562,7 @@ of security-relevant policy decisions.</p>
   <div data-fill-with="at-risk">
    <p>The following features are at-risk, and may be dropped during the CR period: </p>
    <ul>
-    <li>The <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> algorithm.
+    <li>The <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm.
    </ul>
    <p>“At-risk” is a W3C Process term-of-art, and does not necessarily imply that the feature is in danger of being dropped or delayed. It means that the WG believes the feature may have difficulty being interoperably implemented in a timely manner, and marking it as such allows the WG to drop the feature if necessary when transitioning to the Proposed Rec stage, without having to publish a new Candidate Rec without the feature first.</p>
   </div>
@@ -1668,6 +1668,7 @@ of security-relevant policy decisions.</p>
          <ol class="toc">
           <li><a href="#default-src-pre-request"><span class="secno">6.1.3.1</span> <span class="content"> <code>default-src</code> Pre-request check </span></a>
           <li><a href="#default-src-post-request"><span class="secno">6.1.3.2</span> <span class="content"> <code>default-src</code> Post-request check </span></a>
+          <li><a href="#default-src-inline"><span class="secno">6.1.3.3</span> <span class="content"> <code>default-src</code> Inline Check </span></a>
          </ol>
         <li>
          <a href="#directive-font-src"><span class="secno">6.1.4</span> <span class="content"><code>font-src</code></span></a>
@@ -1719,17 +1720,41 @@ of security-relevant policy decisions.</p>
           <li><a href="#script-src-inline"><span class="secno">6.1.11.3</span> <span class="content"> <code>script-src</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-style-src"><span class="secno">6.1.12</span> <span class="content"><code>style-src</code></span></a>
+         <a href="#directive-script-src-elem"><span class="secno">6.1.12</span> <span class="content"><code>script-src-elem</code></span></a>
          <ol class="toc">
-          <li><a href="#style-src-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
-          <li><a href="#style-src-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
-          <li><a href="#style-src-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+          <li><a href="#script-src-elem-pre-request"><span class="secno">6.1.12.1</span> <span class="content"> <code>script-src-elem</code> Pre-request check </span></a>
+          <li><a href="#script-src-elem-post-request"><span class="secno">6.1.12.2</span> <span class="content"> <code>script-src-elem</code> Post-request check </span></a>
+          <li><a href="#script-src-elem-inline"><span class="secno">6.1.12.3</span> <span class="content"> <code>script-src-elem</code> Inline Check </span></a>
          </ol>
         <li>
-         <a href="#directive-worker-src"><span class="secno">6.1.13</span> <span class="content"><code>worker-src</code></span></a>
+         <a href="#directive-script-src-attr"><span class="secno">6.1.13</span> <span class="content"><code>script-src-attr</code></span></a>
          <ol class="toc">
-          <li><a href="#worker-src-pre-request"><span class="secno">6.1.13.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
-          <li><a href="#worker-src-post-request"><span class="secno">6.1.13.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
+          <li><a href="#script-src-attr-inline"><span class="secno">6.1.13.1</span> <span class="content"> <code>script-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src"><span class="secno">6.1.14</span> <span class="content"><code>style-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-pre-request"><span class="secno">6.1.14.1</span> <span class="content"> <code>style-src</code> Pre-request Check </span></a>
+          <li><a href="#style-src-post-request"><span class="secno">6.1.14.2</span> <span class="content"> <code>style-src</code> Post-request Check </span></a>
+          <li><a href="#style-src-inline"><span class="secno">6.1.14.3</span> <span class="content"> <code>style-src</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-elem"><span class="secno">6.1.15</span> <span class="content"><code>style-src-elem</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-elem-pre-request"><span class="secno">6.1.15.1</span> <span class="content"> <code>style-src-elem</code> Pre-request Check </span></a>
+          <li><a href="#style-src-elem-post-request"><span class="secno">6.1.15.2</span> <span class="content"> <code>style-src-elem</code> Post-request Check </span></a>
+          <li><a href="#style-src-elem-inline"><span class="secno">6.1.15.3</span> <span class="content"> <code>style-src-elem</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-style-src-attr"><span class="secno">6.1.16</span> <span class="content"><code>style-src-attr</code></span></a>
+         <ol class="toc">
+          <li><a href="#style-src-attr-inline"><span class="secno">6.1.16.1</span> <span class="content"> <code>style-src-attr</code> Inline Check </span></a>
+         </ol>
+        <li>
+         <a href="#directive-worker-src"><span class="secno">6.1.17</span> <span class="content"><code>worker-src</code></span></a>
+         <ol class="toc">
+          <li><a href="#worker-src-pre-request"><span class="secno">6.1.17.1</span> <span class="content"> <code>worker-src</code> Pre-request Check </span></a>
+          <li><a href="#worker-src-post-request"><span class="secno">6.1.17.2</span> <span class="content"> <code>worker-src</code> Post-request Check </span></a>
          </ol>
        </ol>
       <li>
@@ -1788,30 +1813,43 @@ of security-relevant policy decisions.</p>
        </ol>
       <li><a href="#directives-elsewhere"><span class="secno">6.5</span> <span class="content"> Directives Defined in Other Documents </span></a>
       <li>
-       <a href="#algorithms"><span class="secno">6.6</span> <span class="content">Matching Algorithms</span></a>
+       <a href="#matching-algorithms"><span class="secno">6.6</span> <span class="content">Matching Algorithms</span></a>
        <ol class="toc">
         <li>
-         <a href="#matching-urls"><span class="secno">6.6.1</span> <span class="content">URL Matching</span></a>
+         <a href="#script-checks"><span class="secno">6.6.1</span> <span class="content">Script directive checks</span></a>
          <ol class="toc">
-          <li><a href="#does-request-violate-policy"><span class="secno">6.6.1.1</span> <span class="content"> Does <var>request</var> violate <var>policy</var>? </span></a>
-          <li><a href="#match-nonce-to-source-list"><span class="secno">6.6.1.2</span> <span class="content"> Does <var>nonce</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-request-to-source-list"><span class="secno">6.6.1.3</span> <span class="content"> Does <var>request</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-response-to-source-list"><span class="secno">6.6.1.4</span> <span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span></a>
-          <li><a href="#match-url-to-source-list"><span class="secno">6.6.1.5</span> <span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
-          <li><a href="#match-url-to-source-expression"><span class="secno">6.6.1.6</span> <span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
-          <li><a href="#match-schemes"><span class="secno">6.6.1.7</span> <span class="content"> <code>scheme-part</code> matching </span></a>
-          <li><a href="#match-hosts"><span class="secno">6.6.1.8</span> <span class="content"> <code>host-part</code> matching </span></a>
-          <li><a href="#match-ports"><span class="secno">6.6.1.9</span> <span class="content"> <code>port-part</code> matching </span></a>
-          <li><a href="#match-paths"><span class="secno">6.6.1.10</span> <span class="content"> <code>path-part</code> matching </span></a>
-          <li><a href="#effective-directive-for-a-request"><span class="secno">6.6.1.11</span> <span class="content"> Get the effective directive for <var>request</var> </span></a>
+          <li><a href="#script-pre-request"><span class="secno">6.6.1.1</span> <span class="content"> Script directives pre-request check </span></a>
+          <li><a href="#script-post-request"><span class="secno">6.6.1.2</span> <span class="content"> Script directives post-request check </span></a>
          </ol>
         <li>
-         <a href="#matching-elements"><span class="secno">6.6.2</span> <span class="content">Element Matching Algorithms</span></a>
+         <a href="#matching-urls"><span class="secno">6.6.2</span> <span class="content">URL Matching</span></a>
          <ol class="toc">
-          <li><a href="#is-element-nonceable"><span class="secno">6.6.2.1</span> <span class="content"> Is <var>element</var> nonceable? </span></a>
-          <li><a href="#allow-all-inline"><span class="secno">6.6.2.2</span> <span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span></a>
-          <li><a href="#match-element-to-source-list"><span class="secno">6.6.2.3</span> <span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span></a>
+          <li><a href="#does-request-violate-policy"><span class="secno">6.6.2.1</span> <span class="content"> Does <var>request</var> violate <var>policy</var>? </span></a>
+          <li><a href="#match-nonce-to-source-list"><span class="secno">6.6.2.2</span> <span class="content"> Does <var>nonce</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-request-to-source-list"><span class="secno">6.6.2.3</span> <span class="content"> Does <var>request</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-response-to-source-list"><span class="secno">6.6.2.4</span> <span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span></a>
+          <li><a href="#match-url-to-source-list"><span class="secno">6.6.2.5</span> <span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
+          <li><a href="#match-url-to-source-expression"><span class="secno">6.6.2.6</span> <span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span></a>
+          <li><a href="#match-schemes"><span class="secno">6.6.2.7</span> <span class="content"> <code>scheme-part</code> matching </span></a>
+          <li><a href="#match-hosts"><span class="secno">6.6.2.8</span> <span class="content"> <code>host-part</code> matching </span></a>
+          <li><a href="#match-ports"><span class="secno">6.6.2.9</span> <span class="content"> <code>port-part</code> matching </span></a>
+          <li><a href="#match-paths"><span class="secno">6.6.2.10</span> <span class="content"> <code>path-part</code> matching </span></a>
          </ol>
+        <li>
+         <a href="#matching-elements"><span class="secno">6.6.3</span> <span class="content">Element Matching Algorithms</span></a>
+         <ol class="toc">
+          <li><a href="#is-element-nonceable"><span class="secno">6.6.3.1</span> <span class="content"> Is <var>element</var> nonceable? </span></a>
+          <li><a href="#allow-all-inline"><span class="secno">6.6.3.2</span> <span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span></a>
+          <li><a href="#match-element-to-source-list"><span class="secno">6.6.3.3</span> <span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span></a>
+         </ol>
+       </ol>
+      <li>
+       <a href="#directive-algorithms"><span class="secno">6.7</span> <span class="content">Directive Algorithms</span></a>
+       <ol class="toc">
+        <li><a href="#effective-directive-for-a-request"><span class="secno">6.7.1</span> <span class="content"> Get the effective directive for <var>request</var> </span></a>
+        <li><a href="#effective-directive-for-inline-check"><span class="secno">6.7.2</span> <span class="content"> Get the effective directive for inline checks </span></a>
+        <li><a href="#directive-fallback-list"><span class="secno">6.7.3</span> <span class="content"> Get fetch directive fallback list </span></a>
+        <li><a href="#should-directive-execute"><span class="secno">6.7.4</span> <span class="content"> Should fetch directive execute </span></a>
        </ol>
      </ol>
     <li>
@@ -1974,7 +2012,7 @@ of security-relevant policy decisions.</p>
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
   unless that non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme①">network scheme</a> is the same as the scheme of protected resource,
-  as described in <a href="#match-url-to-source-expression">§6.6.1.6 Does url match expression in origin with redirect count?</a>.</p>
+  as described in <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a>.</p>
      <li data-md="">
       <p>Hash-based source expressions may now match external scripts if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①">script</a></code> element that triggers the request specifies a set of integrity
   metadata which is listed in the current policy. Details in <a href="#external-hash">§8.4 Allowing external JavaScript via hashes</a>.</p>
@@ -2107,22 +2145,23 @@ of security-relevant policy decisions.</p>
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
-  type string, and a source string as arguments, and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
-    by Content Security Policy?</a> for <code>javascript:</code> requests. This algorithm returns "<code>Allowed</code>" unless
-  otherwise specified.</p>
+  type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a>, and a source string as arguments,
+  and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
+    by Content Security Policy?</a> for <code>javascript:</code> requests. This
+  algorithm returns "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
      <li data-md="">
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments, and
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md="">
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing contexts</a>, a check type string ("<code>source</code>"
-  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
+  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
@@ -2188,7 +2227,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   characters; internationalized domain names cannot be entered directly as part
   of a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp②">serialized CSP</a>, but instead MUST be Punycode-encoded <a data-link-type="biblio" href="#biblio-rfc3492">[RFC3492]</a>. For example, the domain <code>üüüüüü.de</code> MUST be represented as <code>xn--tdaaaaaa.de</code>.</p>
     <p class="note" role="note"><span>Note:</span> Though IP address do match the grammar above, only <code>127.0.0.1</code> will actually match a URL when used in a source
-  expression (see <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> for details). The security
+  expression (see <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> for details). The security
   properties of IP addresses are suspect, and authors ought to prefer hostnames
   whenever possible.</p>
     <p class="note" role="note"><span>Note:</span> The <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value②">base64-value</a> grammar allows both <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4">base64</a> and <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-5" id="ref-for-section-5">base64url</a> encoding. These encodings are treated as equivalant when
@@ -2198,9 +2237,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
-  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
+  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
-  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> has been violated.</p>
+  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
@@ -2210,8 +2249,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   which violated the policy.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
   enforcement caused the violation.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
@@ -2227,7 +2266,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   characters of an inline script, event handler, or style that caused an violation. Violations
   which stem from an external file will not include a sample in the violation report.</p>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
+    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
      <li data-md="">
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
@@ -2253,7 +2292,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, policy, and directive" data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a string
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> (<var>policy</var>), and a string
   (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
@@ -2269,10 +2308,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="policy-delivery"><span class="secno">3. </span><span class="content"> Policy Delivery </span><a class="self-link" href="#policy-delivery"></a></h2>
-    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
+    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
   representation</a> via an HTTP response header field whose value is a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp③">serialized CSP</a>. This mechanism is defined in detail in <a href="#csp-header">§3.1 The Content-Security-Policy HTTP Response Header Field</a> and <a href="#cspro-header">§3.2 The Content-Security-Policy-Report-Only HTTP Response Header Field</a>, and the integration with Fetch
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
@@ -2363,7 +2402,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
   user agent needs to <a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#parse-serialized-policy" id="ref-for-parse-serialized-policy②">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
@@ -2407,7 +2446,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, policy, and directive</a> on <var>request</var>, <var>policy</var>, and <var>violates</var>.</p>
       </ol>
@@ -2426,7 +2465,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.1.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then:</p>
         <ol>
@@ -2494,18 +2533,18 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
      <li data-md="">
-      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> objects which are
+      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> algorithm.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md="">
       <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑥">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a> as the <code>object</code>.</p>
      <li data-md="">
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
      <li data-md="">
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
   new <code>Document</code> object</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithms in order to
-  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
+  bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
      <li data-md="">
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
@@ -2514,7 +2553,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
+      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
      <li data-md="">
       <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
      <li data-md="">
@@ -2571,7 +2610,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> by embedding a frame or popping up a new window containing content it
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
@@ -2663,7 +2702,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <ol>
          <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check">inline check</a> returns
-  "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, and <var>source</var>,
+  "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>,
   skip to the next <var>directive</var>.</p>
          <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
@@ -2862,9 +2901,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></dfn> {
   <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" id="dom-securitypolicyviolationeventdisposition-report"><code>"report"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -3204,31 +3243,27 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is not <code>frame-src</code> or <code>worker-src</code>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is not <code>frame-src</code> or <code>worker-src</code>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var>, return "<code>Allowed</code>"</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
@@ -3272,33 +3307,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is "":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3313,8 +3344,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-d1d47ff9">
-     <a class="self-link" href="#example-d1d47ff9"></a> The following header: 
+    <div class="example" id="example-327c55f5">
+     <a class="self-link" href="#example-327c55f5"></a> The following header: 
 <pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3326,31 +3357,35 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
                          <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
                          <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
                          <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②">script-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-2a1475cd">
-     <a class="self-link" href="#example-2a1475cd"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-8536160a">
+     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>; <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> https://example.com
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> https://example.com;
-                         <a data-link-type="dfn" href="#style-src" id="ref-for-style-src①">style-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3359,38 +3394,38 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is "<code>script-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> is "<code>child-src</code>" , return "<code>Allowed</code>".</p>
-     <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var>.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is <code>null</code>, return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> is <var>name</var>, return "<code>Allowed</code>".</p>
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+  comparison.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="default-src Inline Check" data-level="6.1.3.3" id="default-src-inline"><span class="secno">6.1.3.3. </span><span class="content"> <code>default-src</code> Inline Check </span><a class="self-link" href="#default-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
      <li data-md="">
-      <p>If <var>name</var> is "<code>frame-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md="">
-      <p>If <var>name</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②①">name</a> is "<code>script-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②②">name</a> is "<code>child-src</code>" , return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
@@ -3419,33 +3454,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is "<code>font</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is "<code>font</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3467,35 +3498,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context③">nested browsing
-  context</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "<code>document</code>" and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context②">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing
-  context</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3507,7 +3532,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑤">serialized-source-list</a>
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">requests</a> which load images. More formally, this
-  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
+  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
     <div class="example" id="example-ad572c5c">
      <a class="self-link" href="#example-ad572c5c"></a> Given a page with the following Content Security Policy: 
 <pre>Content-Security-Policy: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src②">img-src</a> https://example.com/
@@ -3519,33 +3544,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⓪">destination</a> is "<code>image</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①①">destination</a> is "<code>image</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3567,33 +3588,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①②">destination</a> is "<code>manifest</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①③">destination</a> is "<code>manifest</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3618,35 +3635,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①④">destination</a> is one of "<code>audio</code>", "<code>video</code>",
-  or "<code>track</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑤">destination</a> is one of "<code>audio</code>", "<code>video</code>",
-  or "<code>track</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3668,33 +3679,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator③">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator④">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
-  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
+  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3720,13 +3727,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   on the specified <code>type</code>), it MUST be blocked if <code>object-src</code>'s value is <code>'none'</code>, but will otherwise be allowed.</p>
     <p class="note" role="note"><span>Note:</span> The <code>object-src</code> directive acts upon any request made on behalf of
   an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element②">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element①">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet①"><code>applet</code></a> element. This includes requests
-  which would populate the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a> generated by the
+  which would populate the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context③">nested browsing context</a> generated by the
   former two (also including navigations). This is true even when the data is
   semantically equivalent to content which would otherwise be restricted by
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
-    <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> delivered along
+    <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing context</a>, and not as an embedded
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3734,33 +3741,29 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑥">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑦">destination</a> is "<code>object</code>" or "<code>embed</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3803,117 +3806,133 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②④">name</a> is "<code>worker-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑤">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑧">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source expressions</a> in
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> grammar.</p>
-       <li data-md="">
-        <p>If <var>integrity expressions</var> is not empty:</p>
-        <ol>
-         <li data-md="">
-          <p>Let <var>integrity sources</var> be the result of executing the algorithm
-  defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
-         <li data-md="">
-          <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
-  the remaining substeps.</p>
-         <li data-md="">
-          <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
-         <li data-md="">
-          <p>For each <var>source</var> in <var>integrity sources</var>:</p>
-          <ol>
-           <li data-md="">
-            <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> does not
-  contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
-  for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
-  for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
-  integrity match</var> to <code>false</code>.</p>
-          </ol>
-         <li data-md="">
-          <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
-  "<code>Allowed</code>".</p>
-        </ol>
-        <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> specified by
-  this directive. We rely on the browser’s enforcement of Subresource
-  Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
-       <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>:</p>
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
-          <p>Otherwise, return "<code>Allowed</code>".</p>
-          <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
-  in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-        </ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p>If the result of executing <a href="#effective-directive-for-a-request">§6.6.1.11 Get the effective directive for request</a> on <var>request</var> is "<code>worker-src</code>", and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑥">name</a> is "<code>worker-src</code>" or a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑦">name</a> is "<code>child-src</code>", return "<code>Allowed</code>".</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①⑨">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
-  "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> contains
-  "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
-  return "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
-      </ol>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>Return "<code>Allowed</code>".</p>
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>":</p>
-      <ol>
-       <li data-md="">
-        <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.12" id="directive-style-src"><span class="secno">6.1.12. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.</p>
+    <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
+    <ul>
+     <li data-md="">
+      <p><code>script-src-elem</code> only applies to "<code>script</code>" and "<code>navigation</code>" inline checks
+(and is ignored for "<code>script attribute</code>" inline checks).</p>
+     <li data-md="">
+      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
+execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
+     <li data-md="">
+      <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
+The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
+    </ul>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "script-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the <code>script-src</code> directive for relevant checks.</p>
+    <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md="">
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md="">
@@ -3925,13 +3944,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>.</p>
      <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
   implicitly by not specifying a <code>style-src</code> (or <code>default-src</code>) directive,
-  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> that matches
+  or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> that matches
   the inline block.</p>
      <li data-md="">
       <p>The following CSS algorithms are gated on the <code>unsafe-eval</code> source
@@ -3949,57 +3968,53 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
       <p class="issue" id="issue-ba1a0a35"><a class="self-link" href="#issue-ba1a0a35"></a> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a></p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.12.1" id="style-src-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⓪">destination</a> is "<code>style</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is "<code>Matches</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.12.2" id="style-src-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②①">destination</a> is "<code>style</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.1.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is "<code>Matches</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Does Not Match</code>", return
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.12.3" id="style-src-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), and a string (<var>source</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md="">
-      <p>If <var>type</var> is "<code>style</code>" or "<code>style attribute</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-element-to-source-list">§6.6.2.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>, <var>type</var>,
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4007,12 +4022,89 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
-    <h4 class="heading settled" data-level="6.1.13" id="directive-worker-src"><span class="secno">6.1.13. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-elem"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+  "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
+    <p>The syntax for the directive’s name and value is described by the following ABNF:</p>
+<pre>directive-name  = "style-src-attr"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+</pre>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
+    <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
+  and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
@@ -4027,37 +4119,31 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.13.1" id="worker-src-pre-request"><span class="secno">6.1.13.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②②">destination</a> is one of
-  "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
-      <ol start="4">
-       <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.13.2" id="worker-src-post-request"><span class="secno">6.1.13.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
+    <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
-      <p class="assertion">Assert: <var>policy</var> is unused.</p>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②③">destination</a> is one of
-  "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
-      <ol>
-       <li data-md="">
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.1.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md="">
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
-      </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4069,7 +4155,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①③">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑦">serialized-source-list</a>
 </pre>
     <p>The following algorithm is called during HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url①">set the frozen base url</a> algorithm in order to monitor and enforce this directive:</p>
     <h5 class="heading settled algorithm" data-algorithm="Is base allowed for document?" data-level="6.2.1.1" id="allow-base-for-document"><span class="secno">6.2.1.1. </span><span class="content"> Is <var>base</var> allowed for <var>document</var>? </span><a class="self-link" href="#allow-base-for-document"></a></h5>
@@ -4082,13 +4168,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
        <li data-md="">
-        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑧">name</a> is
+        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>.</p>
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
        <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md="">
-        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
+        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
          <li data-md="">
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global
@@ -4150,22 +4236,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> algorithm is as
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②④">destination</a> is either "<code>object</code>"
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is either "<code>object</code>"
   or "<code>embed</code>":</p>
       <ol>
        <li data-md="">
         <p>Let <var>type</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">extracting a
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md="">
-        <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>, return "<code>Blocked</code>".</p>
+        <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4173,7 +4259,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
     Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
@@ -4181,7 +4267,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①⓪">CSP list</a>:</p>
       <ol>
        <li data-md="">
-        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
+        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
          <li data-md="">
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
@@ -4194,8 +4280,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
            <li data-md="">
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md="">
-            <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
+            <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4218,7 +4304,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4226,12 +4312,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑤">destination</a> is one of
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is one of
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
        <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4245,7 +4331,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4254,7 +4340,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <section class="wip">
@@ -4277,7 +4363,7 @@ directive-value = ""
     <h5 class="heading settled algorithm" data-algorithm="disown-opener Initialization" data-level="6.2.4.1" id="disown-opener-init"><span class="secno">6.2.4.1. </span><span class="content"> <code>disown-opener</code> Initialization </span><a class="self-link" href="#disown-opener-init"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization③">initialization</a> algorithm is as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md="">
       <p class="assertion">Assert: <var>response</var> and <var>policy</var> are unused.</p>
@@ -4292,11 +4378,11 @@ directive-value = ""
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4306,7 +4392,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md="">
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4322,25 +4408,25 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①②">meta</a></code> element.</p>
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
-  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directive</a>.</p>
+  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md="">
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
      <li data-md="">
-      <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑦">nested browsing context</a>, return "<code>Allowed</code>".</p>
+      <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
       <p>Let <var>current</var> be <var>target</var>.</p>
      <li data-md="">
@@ -4352,8 +4438,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md="">
-        <p>If <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+        <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md="">
@@ -4365,7 +4451,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑥">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4386,12 +4472,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     </div>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "navigate-to"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4399,41 +4485,41 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="assertion">Assert: <var>source</var> and <var>target</var> are unused as 'navigate-to'
   is concerned with the details of the request.</p>
      <li data-md="">
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑦">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
-  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
+  wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md="">
       <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
      <li data-md="">
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑧">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
      <li data-md="">
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑨">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
-  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
-  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>, return "<code>Allowed</code>".</p>
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
   already checked the navigation in <a href="#navigate-to-pre-navigate">§6.3.3.1 navigate-to Pre-Navigation Check</a>.</p>
      <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md="">
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.1.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
@@ -4482,14 +4568,94 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>
-    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
+    <p>New directives SHOULD use the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a>, <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②⓪">post-request check</a>, <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check③">response
   check</a>, and <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization④">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.</p>
-    <h3 class="heading settled" data-level="6.6" id="algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
-    <h4 class="heading settled" data-level="6.6.1" id="matching-urls"><span class="secno">6.6.1. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
-    <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.1.1" id="does-request-violate-policy"><span class="secno">6.6.1.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>), this
-  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives④⓪">directive</a> if the request violates the
+    <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
+    <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+       <li data-md="">
+        <p>If <var>integrity expressions</var> is not empty:</p>
+        <ol>
+         <li data-md="">
+          <p>Let <var>integrity sources</var> be the result of executing the algorithm
+  defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
+         <li data-md="">
+          <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
+  the remaining substeps.</p>
+         <li data-md="">
+          <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
+         <li data-md="">
+          <p>For each <var>source</var> in <var>integrity sources</var>:</p>
+          <ol>
+           <li data-md="">
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
+  contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
+  for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
+  for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
+  integrity match</var> to <code>false</code>.</p>
+          </ol>
+         <li data-md="">
+          <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
+  "<code>Allowed</code>".</p>
+        </ol>
+        <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
+  Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
+       <li data-md="">
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+  expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
+  the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
+        <ol>
+         <li data-md="">
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
+          <p>Otherwise, return "<code>Allowed</code>".</p>
+          <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
+  in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
+        </ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
+  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
+      <ol>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
+  "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
+  "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
+  return "<code>Allowed</code>".</p>
+       <li data-md="">
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
+  "<code>Blocked</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
      <li data-md="">
@@ -4498,15 +4664,15 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>violates</var>.</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.1.2" id="match-nonce-to-source-list"><span class="secno">6.6.1.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4524,17 +4690,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.1.3" id="match-request-to-source-list"><span class="secno">6.6.1.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
+    <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives④①">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑧">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> is reasonable.</p>
-    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.1.4" id="match-response-to-source-list"><span class="secno">6.6.1.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.1.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives④②">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a> is reasonable.</p>
-    <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.1.5" id="match-url-to-source-list"><span class="secno">6.6.1.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
+    <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
@@ -4553,14 +4719,14 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
        <li data-md="">
-        <p>If <a href="#match-url-to-source-expression">§6.6.1.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
+        <p>If <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
   executed upon <var>url</var>, <var>expression</var>, <var>origin</var>, and <var>redirect count</var>, return
   "<code>Matches</code>".</p>
       </ol>
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.1.6" id="match-url-to-source-expression"><span class="secno">6.6.1.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.2.6" id="match-url-to-source-expression"><span class="secno">6.6.2.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑨">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
   returns "<code>Matches</code>" if <var>url</var> matches <var>expression</var>, and "<code>Does Not Match</code>"
   otherwise.</p>
@@ -4642,7 +4808,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.1.7" id="match-schemes"><span class="secno">6.6.1.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
@@ -4666,7 +4832,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.1.8" id="match-hosts"><span class="secno">6.6.1.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.2.8" id="match-hosts"><span class="secno">6.6.2.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
   string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part②"><code>host-part</code></a> could
   potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a>. For example, we say that
@@ -4702,7 +4868,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.1.9" id="match-ports"><span class="secno">6.6.1.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
   strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
@@ -4727,7 +4893,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.1.10" id="match-paths"><span class="secno">6.6.1.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.2.10" id="match-paths"><span class="secno">6.6.2.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
   For example, we say that "/subdirectory/" <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match①"><code>path-part</code> matches</a> "/subdirectory/file".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>path A</var> matching <var>path B</var> does not mean that <var>path B</var> will match <var>path A</var>.</p>
@@ -4772,94 +4938,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
      <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.6.1.11" id="effective-directive-for-a-request"><span class="secno">6.6.1.11. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h5>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⑨">name</a> of the request’s <dfn data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive<a class="self-link" href="#request-effective-directive"></a></dfn>:</p>
-    <ol>
-     <li data-md="">
-      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②⑥">destination</a>, and execute
-  the associated steps:</p>
-      <dl>
-       <dt data-md="">""
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator⑤">initiator</a> is
-  the empty string, return <code>connect-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>manifest</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>manifest-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>object</code>"
-       <dt data-md="">"<code>embed</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>object-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>prefetch</code>"
-       <dt data-md="">"<code>prerender</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>prefetch-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>document</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context③">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑧">nested browsing context</a>, return <code>frame-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>audio</code>"
-       <dt data-md="">"<code>track</code>"
-       <dt data-md="">"<code>video</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>media-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>font</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>font-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>image</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>img-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>style</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>style-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>script</code>"
-       <dt data-md="">"<code>xslt</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>script-src</code>.</p>
-        </ol>
-       <dt data-md="">"<code>sharedworker</code>"
-       <dt data-md="">"<code>worker</code>"
-       <dd data-md="">
-        <ol>
-         <li data-md="">
-          <p>Return <code>worker-src</code>.</p>
-        </ol>
-      </dl>
-     <li data-md="">
-      <p>Return <code>null</code>.</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.6.2" id="matching-elements"><span class="secno">6.6.2. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
-    <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.2.1" id="is-element-nonceable"><span class="secno">6.6.2.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
+    <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
+    <h5 class="heading settled algorithm" data-algorithm="Is element nonceable?" data-level="6.6.3.1" id="is-element-nonceable"><span class="secno">6.6.3.1. </span><span class="content"> Is <var>element</var> nonceable? </span><a class="self-link" href="#is-element-nonceable"></a></h5>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a></code> (<var>element</var>), this algorithm returns "<code>Nonceable</code>" if
   a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑤"><code>nonce-source</code></a> expression can match the element (as discussed
   in <a href="#security-nonce-stealing">§7.2 Nonce Stealing</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
@@ -4894,7 +4975,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑥">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
-    <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.2.2" id="allow-all-inline"><span class="secno">6.6.2.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.3.2" id="allow-all-inline"><span class="secno">6.6.3.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
     <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
     <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
@@ -4938,18 +5019,18 @@ http://example.com 'unsafe-inline' 'nonce-abc'
 http://example.com 'strict-dynamic' 'unsafe-inline'
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.2.3" id="match-element-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
+    <h5 class="heading settled algorithm" data-algorithm="Does element match source list for type and source?" data-level="6.6.3.3" id="match-element-to-source-list"><span class="secno">6.6.3.3. </span><span class="content"> Does <var>element</var> match source list for <var>type</var> and <var>source</var>? </span><a class="self-link" href="#match-element-to-source-list"></a></h5>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
     <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
   is embedded. See the integration points in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
     <ol>
      <li data-md="">
-      <p>If <a href="#allow-all-inline">§6.6.2.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
+      <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
   return "<code>Matches</code>".</p>
      <li data-md="">
-      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
+      <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
       <ol>
        <li data-md="">
         <p>For each <var>expression</var> in <var>list</var>:</p>
@@ -5012,6 +5093,234 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
+    <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
+    <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
+    <ol>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
+     <li data-md="">
+      <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>",
+  return <code>prefetch-src</code>.</p>
+     <li data-md="">
+      <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a>, and execute
+  the associated steps:</p>
+      <dl>
+       <dt data-md="">"<code>manifest</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>manifest-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>object</code>"
+       <dt data-md="">"<code>embed</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>object-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>document</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, return <code>frame-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>audio</code>"
+       <dt data-md="">"<code>track</code>"
+       <dt data-md="">"<code>video</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>media-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>font</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>font-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>image</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>img-src</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>xslt</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>serviceworker</code>"
+       <dt data-md="">"<code>sharedworker</code>"
+       <dt data-md="">"<code>worker</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>worker-src</code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>null</code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
+    <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> of the effective directive.</p>
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
+  the directive that is most relevant to a particular type of inline check.</p>
+    <ol>
+     <li data-md="">
+      <p>Switch on <var>type</var>:</p>
+      <dl>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>navigation</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>script attribute</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>script-src-attr</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-elem</code>.</p>
+        </ol>
+       <dt data-md="">"<code>style attribute</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p>Return <code>style-src-attr</code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>null</code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Get fetch directive fallback list" data-level="6.7.3" id="directive-fallback-list"><span class="secno">6.7.3. </span><span class="content"> Get fetch directive fallback list </span><a class="self-link" href="#directive-fallback-list"></a></h4>
+    <p>Will return an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">ordered set</a> of the fallback <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directives</a> for a specific <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a>.
+  The returned <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">ordered set</a> is sorted from most relevant to least relevant
+  and it includes the effective directive itself.</p>
+    <p>Given a string (<var>directive name</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Switch on <var>directive name</var>:</p>
+      <dl>
+       <dt data-md="">"<code>script-src-elem</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>script-src-attr</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-elem</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>style-src-attr</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>worker-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "worker-src", "child-src", "script-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>connect-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "connect-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>manifest-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "manifest-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>prefetch-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "prefetch-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>object-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "object-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>frame-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "frame-src", "child-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>media-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "media-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>font-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "font-src", "default-src" >></code>.</p>
+        </ol>
+       <dt data-md="">"<code>image-src</code>"
+       <dd data-md="">
+        <ol>
+         <li data-md="">
+          <p><code>&lt;&lt; "image-src", "default-src" >></code>.</p>
+        </ol>
+      </dl>
+     <li data-md="">
+      <p>Return <code>&lt;&lt; >></code>.</p>
+    </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Should fetch directive execute" data-level="6.7.4" id="should-directive-execute"><span class="secno">6.7.4. </span><span class="content"> Should fetch directive execute </span><a class="self-link" href="#should-directive-execute"></a></h4>
+    <p>This algorithm is used for <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives③">fetch directives</a> to decide whether a directive
+  should execute or defer to a different directive that is better suited.
+  For example: if the <var>effective directive name</var> is <code>worker-src</code> (meaning that
+  we are currently checking a worker request), a <code>default-src</code> directive
+  should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
+    <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md="">
+      <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
+     <li data-md="">
+      <p>For each <var>fallback directive</var> in <var>directive fallback list</var>:</p>
+      <ol>
+       <li data-md="">
+        <p>If <var>directive name</var> is <var>fallback directive</var>, Return "<code>Yes</code>".</p>
+       <li data-md="">
+        <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
+      </ol>
+     <li data-md="">
+      <p>Return "<code>No</code>".</p>
+    </ol>
    </section>
    <section>
     <h2 class="heading settled" data-level="7" id="security-considerations"><span class="secno">7. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
@@ -5019,7 +5328,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5045,7 +5354,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
   second <code>src</code> attribute which is helpfully discarded as duplicate by the parser.</p>
-    <p>The <a href="#is-element-nonceable">§6.6.2.1 Is element nonceable?</a> algorithm attempts to mitigate this specific
+    <p>The <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm attempts to mitigate this specific
   attack by walking through <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element③">style</a></code> element attributes, looking for the
   string "<code>&lt;script</code>" or "<code>&lt;style</code>" in their names or values.</p>
     <h3 class="heading settled" data-level="7.3" id="security-nonce-retargeting"><span class="secno">7.3. </span><span class="content">Nonce Retargeting</span><a class="self-link" href="#security-nonce-retargeting"></a></h3>
@@ -5062,7 +5371,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
     <h3 class="heading settled" data-level="7.4" id="security-css-parsing"><span class="secno">7.4. </span><span class="content">CSS Parsing</span><a class="self-link" href="#security-css-parsing"></a></h3>
-    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src②">style-src</a> directive restricts the locations from which the
+    <p>The <a data-link-type="dfn" href="#style-src" id="ref-for-style-src">style-src</a> directive restricts the locations from which the
   protected resource can load styles. However, if the user agent uses a lax CSS
   parsing algorithm, an attacker might be able to trick the user agent into
   accepting malicious "stylesheets" hosted by an otherwise trustworthy origin.</p>
@@ -5107,7 +5416,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>The relatively long thread <a href="https://lists.w3.org/Archives/Public/public-webappsec/2014Feb/0036.html">"Remove paths from CSP?"</a> from public-webappsec@w3.org has more detailed discussion around alternate proposals.</p>
     <h3 class="heading settled" data-level="7.7" id="security-secure-upgrades"><span class="secno">7.7. </span><span class="content">Secure Upgrades</span><a class="self-link" href="#security-secure-upgrades"></a></h3>
     <p>To mitigate one variant of history-scanning attacks like Yan Zhu’s <a href="http://diracdeltas.github.io/sniffly/">Sniffly</a>, CSP will not allow pages to lock
-  themselves into insecure URLs via policies like <code>script-src http://example.com</code>. As described in <a href="#match-schemes">§6.6.1.7 scheme-part matching</a>, the scheme portion of a source expression will always allow upgrading to a
+  themselves into insecure URLs via policies like <code>script-src http://example.com</code>. As described in <a href="#match-schemes">§6.6.2.7 scheme-part matching</a>, the scheme portion of a source expression will always allow upgrading to a
   secure variant.</p>
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
@@ -5173,12 +5482,12 @@ Content-Security-Policy: connect-src http://example.com/;
   Security Policy simpler to deploy for existing applications who have a high
   degree of confidence in the scripts they load directly, but low confidence in
   their ability to provide a reasonable list of resources to load up front.</p>
-    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
+    <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
      <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5193,7 +5502,7 @@ Content-Security-Policy: connect-src http://example.com/;
   page’s policy.</p>
     <div class="example" id="example-78705861">
      <a class="self-link" href="#example-78705861"></a> Suppose MegaCorp, Inc. deploys the following policy: 
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑥">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
@@ -5229,7 +5538,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
-<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑦">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
+<pre><a data-link-type="dfn" href="https://www.w3.org/TR/CSP3/#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>:  <a data-link-type="dfn" href="#script-src" id="ref-for-script-src④">script-src</a> <a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes③">'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='
 </pre>
      </div>
      <p>The capabilities <code>'unsafe-hashes'</code> provides is useful for legacy sites, but should be
@@ -5283,7 +5592,7 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5351,15 +5660,15 @@ document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&
      <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑧"><code>script-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
      <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src③"><code>style-src</code></a>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-style-src">§6.1.12 style-src</a>)</p>
+      <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
      <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md="">
-      <p>This document (see <a href="#directive-worker-src">§6.1.13 worker-src</a>)</p>
+      <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
     <p>The permanent message header field registry should be updated
@@ -5438,8 +5747,8 @@ rest of Google’s CSP Cabal.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#source-list-allows-all-inline-behavior">allow all inline behavior</a><span>, in §6.6.2.2</span>
-   <li><a href="#source-list-allows-all-inline-behavior">allows all inline behavior</a><span>, in §6.6.2.2</span>
+   <li><a href="#source-list-allows-all-inline-behavior">allow all inline behavior</a><span>, in §6.6.3.2</span>
+   <li><a href="#source-list-allows-all-inline-behavior">allows all inline behavior</a><span>, in §6.6.3.2</span>
    <li><a href="#grammardef-ancestor-source">ancestor-source</a><span>, in §6.3.2</span>
    <li><a href="#grammardef-ancestor-source-list">ancestor-source-list</a><span>, in §6.3.2</span>
    <li><a href="#grammardef-base64-value">base64-value</a><span>, in §2.3.1</span>
@@ -5493,7 +5802,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     effective directive
     <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.6.1.11</span>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
      <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li>
@@ -5517,7 +5826,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-hash-source">hash-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-host-char">host-char</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-host-part">host-part</a><span>, in §2.3.1</span>
-   <li><a href="#host-part-match">host-part match</a><span>, in §6.6.1.8</span>
+   <li><a href="#host-part-match">host-part match</a><span>, in §6.6.2.8</span>
    <li><a href="#grammardef-host-source">host-source</a><span>, in §2.3.1</span>
    <li><a href="#img-src">img-src</a><span>, in §6.1.6</span>
    <li><a href="#directive-initialization">initialization</a><span>, in §2.3</span>
@@ -5550,7 +5859,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</a><span>, in §2.2.1</span>
    <li><a href="#abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</a><span>, in §2.2.2</span>
    <li><a href="#grammardef-path-part">path-part</a><span>, in §2.3.1</span>
-   <li><a href="#path-part-match">path-part match</a><span>, in §6.6.1.10</span>
+   <li><a href="#path-part-match">path-part match</a><span>, in §6.6.2.10</span>
    <li><a href="#plugin-types">plugin-types</a><span>, in §6.2.2</span>
    <li><a href="#plugin-types-post-request-check">plugin-types Post-Request Check</a><span>, in §6.2.2</span>
    <li>
@@ -5560,7 +5869,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#violation-policy">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li><a href="#grammardef-port-part">port-part</a><span>, in §2.3.1</span>
-   <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.1.9</span>
+   <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.2.9</span>
    <li><a href="#directive-post-request-check">post-request check</a><span>, in §2.3</span>
    <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.9</span>
    <li><a href="#directive-pre-navigation-check">pre-navigation check</a><span>, in §2.3</span>
@@ -5587,9 +5896,11 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#sandbox">sandbox</a><span>, in §6.2.3</span>
    <li><a href="#grammardef-scheme-part">scheme-part</a><span>, in §2.3.1</span>
-   <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.1.7</span>
+   <li><a href="#scheme-part-match">scheme-part match</a><span>, in §6.6.2.7</span>
    <li><a href="#grammardef-scheme-source">scheme-source</a><span>, in §2.3.1</span>
    <li><a href="#script-src">script-src</a><span>, in §6.1.11</span>
+   <li><a href="#script-src-attr">script-src-attr</a><span>, in §6.1.13</span>
+   <li><a href="#script-src-elem">script-src-elem</a><span>, in §6.1.12</span>
    <li><a href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a><span>, in §5.1</span>
    <li><a href="#enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a><span>, in §5.1</span>
    <li><a href="#dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
@@ -5624,7 +5935,9 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#grammardef-strict-dynamic">'strict-dynamic'</a><span>, in §2.3.1</span>
-   <li><a href="#style-src">style-src</a><span>, in §6.1.12</span>
+   <li><a href="#style-src">style-src</a><span>, in §6.1.14</span>
+   <li><a href="#style-src-attr">style-src-attr</a><span>, in §6.1.16</span>
+   <li><a href="#style-src-elem">style-src-elem</a><span>, in §6.1.15</span>
    <li><a href="#grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-eval">'unsafe-eval'</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-unsafe-hashes">'unsafe-hashes'</a><span>, in §2.3.1</span>
@@ -5639,7 +5952,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
    <li><a href="#violation-report">violation report</a><span>, in §5</span>
-   <li><a href="#worker-src">worker-src</a><span>, in §6.1.13</span>
+   <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
    <a href="https://www.w3.org/TR/CSP3/#header-content-security-policy">https://www.w3.org/TR/CSP3/#header-content-security-policy</a><b>Referenced in:</b>
@@ -5666,31 +5979,31 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.12. style-src</a>
+    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
    <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.12. style-src</a>
+    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -5710,7 +6023,7 @@ rest of Google’s CSP Cabal.</p>
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-document①①">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-document①②">6.1.12. style-src</a>
+    <li><a href="#ref-for-document①②">6.1.14. style-src</a>
     <li><a href="#ref-for-document①③">6.2.1. base-uri</a>
     <li><a href="#ref-for-document①④">6.2.1.1. 
     Is base allowed for document? </a>
@@ -5728,16 +6041,26 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-element">2.3. Directives</a>
     <li><a href="#ref-for-element①">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-element②">6.1.11.3. 
+    <li><a href="#ref-for-element②">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-element③">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-element③">6.1.12.3. 
+    <li><a href="#ref-for-element④">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑤">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-element④">6.2.2.2. 
+    <li><a href="#ref-for-element⑦">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-element⑧">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-element⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-element⑤">6.6.2.1. 
+    <li><a href="#ref-for-element①⓪">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-element⑥">6.6.2.3. 
+    <li><a href="#ref-for-element①①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -5881,15 +6204,19 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.12.1. 
+    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.12.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.2. 
+    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
     Does nonce match source list? </a>
    </ul>
   </aside>
@@ -5917,7 +6244,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-concept-request-current-url①">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-current-url①">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -5927,53 +6254,17 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-request-destination">5.3. 
     Report a violation </a>
     <li><a href="#ref-for-concept-request-destination①">6.1.1. child-src</a> <a href="#ref-for-concept-request-destination②">(2)</a>
-    <li><a href="#ref-for-concept-request-destination③">6.1.2.1. 
-    connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination④">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑤">6.1.4.1. 
-    font-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑥">6.1.4.2. 
-    font-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑦">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑧">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑨">6.1.6. img-src</a>
-    <li><a href="#ref-for-concept-request-destination①⓪">6.1.6.1. 
-    img-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①①">6.1.6.2. 
-    img-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①②">6.1.7.1. 
-    manifest-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①③">6.1.7.2. 
-    manifest-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①④">6.1.8.1. 
-    media-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑤">6.1.8.2. 
-    media-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑥">6.1.10.1. 
-    object-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑦">6.1.10.2. 
-    object-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑧">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination①⑨">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-destination②⓪">6.1.12.1. 
-    style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②①">6.1.12.2. 
-    style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②②">6.1.13.1. 
-    worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②③">6.1.13.2. 
-    worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-destination②④">6.2.2.1. 
+    <li><a href="#ref-for-concept-request-destination③">6.1.6. img-src</a>
+    <li><a href="#ref-for-concept-request-destination④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request-destination②⑤">6.2.3.1. 
+    <li><a href="#ref-for-concept-request-destination⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request-destination②⑥">6.6.1.11. 
-    Get the effective directive for request </a>
+    <li><a href="#ref-for-concept-request-destination⑥">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-destination⑦">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request-destination⑧">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request-destination⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
@@ -6027,23 +6318,15 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request-initiator①">6.1.2.1. 
-    connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-initiator②">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-initiator③">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-initiator④">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-initiator⑤">6.6.1.11. 
-    Get the effective directive for request </a>
+    <li><a href="#ref-for-concept-request-initiator①">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request-initiator②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-integrity-metadata">
    <a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-integrity-metadata">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
+    <li><a href="#ref-for-concept-request-integrity-metadata">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-request-keepalive-flag">
@@ -6097,7 +6380,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://fetch.spec.whatwg.org/#network-scheme">https://fetch.spec.whatwg.org/#network-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network-scheme">1.3. Changes from Level 2</a> <a href="#ref-for-network-scheme①">(2)</a>
-    <li><a href="#ref-for-network-scheme②">6.6.1.6. 
+    <li><a href="#ref-for-network-scheme②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-network-scheme③">(2)</a>
    </ul>
   </aside>
@@ -6106,9 +6389,9 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-origin">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request-origin①">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-origin①">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-origin②">6.6.1.4. 
+    <li><a href="#ref-for-concept-request-origin②">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6117,18 +6400,18 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-parser-metadata①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-parser-metadata②">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-concept-request-parser-metadata①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request-parser-metadata②">6.6.1.2. 
+    Script directives post-request check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-redirect-count">
    <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-redirect-count">6.6.1.3. 
+    <li><a href="#ref-for-concept-request-redirect-count">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-redirect-count①">6.6.1.4. 
+    <li><a href="#ref-for-concept-request-redirect-count①">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6219,37 +6502,51 @@ rest of Google’s CSP Cabal.</p>
     script-src Pre-request check </a>
     <li><a href="#ref-for-concept-request④③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
+    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
+    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.13.1. 
+    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.13.2. 
+    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.2.2.1. 
+    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.6.1.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑤⑧">(2)</a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.4. 
+    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.11. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥①">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
+    Get the effective directive for inline checks </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response">
@@ -6295,36 +6592,42 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑦">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.12. style-src</a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
+    <li><a href="#ref-for-concept-response②⑨">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-concept-response③⓪">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-response③①">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③①">6.1.13.2. 
+    <li><a href="#ref-for-concept-response③②">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-concept-response③③">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③②">6.2.2.1. 
+    <li><a href="#ref-for-concept-response③④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.2.3.1. 
+    <li><a href="#ref-for-concept-response③⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③④">6.2.3.2. 
+    <li><a href="#ref-for-concept-response③⑥">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.4.1. 
+    <li><a href="#ref-for-concept-response③⑦">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-concept-response③⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑦">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response③⑧">(2)</a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.2. 
+    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
+    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④⓪">6.6.1.4. 
+    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-request-destination-script-like">
    <a href="https://fetch.spec.whatwg.org/#request-destination-script-like">https://fetch.spec.whatwg.org/#request-destination-script-like</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-destination-script-like">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-request-destination-script-like①">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-request-destination-script-like">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-request-destination-script-like①">6.6.1.2. 
+    Script directives post-request check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
@@ -6340,11 +6643,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">https://fetch.spec.whatwg.org/#concept-request-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-target-browsing-context">6.1.1. child-src</a>
-    <li><a href="#ref-for-concept-request-target-browsing-context①">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request-target-browsing-context②">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request-target-browsing-context③">6.6.1.11. 
+    <li><a href="#ref-for-concept-request-target-browsing-context①">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -6363,7 +6662,7 @@ rest of Google’s CSP Cabal.</p>
     in target be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-response-url⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response-url⑥">6.6.1.4. 
+    <li><a href="#ref-for-concept-response-url⑥">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -6378,10 +6677,10 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parser-inserted">1.3. Changes from Level 2</a>
-    <li><a href="#ref-for-parser-inserted①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-parser-inserted②">6.1.11.2. 
-    script-src Post-request check </a>
+    <li><a href="#ref-for-parser-inserted①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-parser-inserted②">6.6.1.2. 
+    Script directives post-request check </a>
     <li><a href="#ref-for-parser-inserted③">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-parser-inserted④">(2)</a> <a href="#ref-for-parser-inserted⑤">(3)</a>
    </ul>
@@ -6397,7 +6696,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
@@ -6424,7 +6723,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -6534,15 +6833,15 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-case-sensitive">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-case-sensitive">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-case-sensitive①">(2)</a>
-    <li><a href="#ref-for-case-sensitive②">6.6.1.2. 
+    <li><a href="#ref-for-case-sensitive">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-case-sensitive①">(2)</a>
+    <li><a href="#ref-for-case-sensitive②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-case-sensitive③">6.6.1.9. 
+    <li><a href="#ref-for-case-sensitive③">6.6.2.9. 
     port-part matching </a>
-    <li><a href="#ref-for-case-sensitive④">6.6.1.10. 
+    <li><a href="#ref-for-case-sensitive④">6.6.2.10. 
     path-part matching </a>
-    <li><a href="#ref-for-case-sensitive⑤">6.6.2.3. 
+    <li><a href="#ref-for-case-sensitive⑤">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-case-sensitive⑥">(2)</a>
    </ul>
   </aside>
@@ -6601,7 +6900,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-parse-error-duplicate-attribute">
    <a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.2.1. 
+    <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.3.1. 
     Is element nonceable? </a>
    </ul>
   </aside>
@@ -6700,7 +6999,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.12. style-src</a>
+    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
@@ -6724,14 +7023,10 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">6.1.1. child-src</a> <a href="#ref-for-nested-browsing-context①">(2)</a>
     <li><a href="#ref-for-nested-browsing-context②">6.1.5. frame-src</a>
-    <li><a href="#ref-for-nested-browsing-context③">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-nested-browsing-context④">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-nested-browsing-context⑤">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context⑥">(2)</a>
-    <li><a href="#ref-for-nested-browsing-context⑦">6.3.2.1. 
+    <li><a href="#ref-for-nested-browsing-context③">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
+    <li><a href="#ref-for-nested-browsing-context⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-nested-browsing-context⑧">6.6.1.11. 
+    <li><a href="#ref-for-nested-browsing-context⑥">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -6798,7 +7093,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-script-parse-error">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-script-parse-error">6.6.2.1. 
+    <li><a href="#ref-for-concept-script-parse-error">6.6.3.1. 
     Is element nonceable? </a>
    </ul>
   </aside>
@@ -6909,7 +7204,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-origin-scheme">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-origin-scheme">6.6.1.6. 
+    <li><a href="#ref-for-concept-origin-scheme">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-origin-scheme①">(2)</a>
    </ul>
   </aside>
@@ -6920,9 +7215,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script②">3.3. 
     The &lt;meta> element </a>
     <li><a href="#ref-for-script③">6.1.11. script-src</a> <a href="#ref-for-script④">(2)</a>
-    <li><a href="#ref-for-script⑤">6.6.2.1. 
+    <li><a href="#ref-for-script⑤">6.6.3.1. 
     Is element nonceable? </a> <a href="#ref-for-script⑥">(2)</a>
-    <li><a href="#ref-for-script⑦">6.6.2.3. 
+    <li><a href="#ref-for-script⑦">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-script⑧">(2)</a>
     <li><a href="#ref-for-script⑨">7.2. Nonce Stealing</a> <a href="#ref-for-script①⓪">(2)</a> <a href="#ref-for-script①①">(3)</a>
     <li><a href="#ref-for-script①②">8.2. 
@@ -6954,8 +7249,8 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-style-element">6.1.12. style-src</a>
-    <li><a href="#ref-for-the-style-element①">6.6.2.3. 
+    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
+    <li><a href="#ref-for-the-style-element①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
     <li><a href="#ref-for-the-style-element③">7.2. Nonce Stealing</a>
    </ul>
@@ -6993,30 +7288,30 @@ rest of Google’s CSP Cabal.</p>
     The &lt;meta> element </a>
     <li><a href="#ref-for-ascii-case-insensitive①">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-ascii-case-insensitive②">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-ascii-case-insensitive③">6.2.2.1. 
+    <li><a href="#ref-for-ascii-case-insensitive②">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive④">6.2.2.2. 
+    <li><a href="#ref-for-ascii-case-insensitive③">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑤">6.3.3.1. 
+    <li><a href="#ref-for-ascii-case-insensitive④">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑥">6.3.3.2. 
+    <li><a href="#ref-for-ascii-case-insensitive⑤">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑦">6.6.1.5. 
+    <li><a href="#ref-for-ascii-case-insensitive⑥">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-ascii-case-insensitive⑦">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑧">6.6.1.6. 
+    <li><a href="#ref-for-ascii-case-insensitive⑧">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑨">6.6.1.7. 
+    <li><a href="#ref-for-ascii-case-insensitive⑨">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-ascii-case-insensitive①⓪">(2)</a> <a href="#ref-for-ascii-case-insensitive①①">(3)</a> <a href="#ref-for-ascii-case-insensitive①②">(4)</a> <a href="#ref-for-ascii-case-insensitive①③">(5)</a> <a href="#ref-for-ascii-case-insensitive①④">(6)</a> <a href="#ref-for-ascii-case-insensitive①⑤">(7)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑥">6.6.1.8. 
+    <li><a href="#ref-for-ascii-case-insensitive①⑥">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-ascii-case-insensitive①⑦">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑧">6.6.2.1. 
+    <li><a href="#ref-for-ascii-case-insensitive①⑧">6.6.3.1. 
     Is element nonceable? </a> <a href="#ref-for-ascii-case-insensitive①⑨">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive②⓪">6.6.2.2. 
+    <li><a href="#ref-for-ascii-case-insensitive②⓪">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-ascii-case-insensitive②①">6.6.2.3. 
+    <li><a href="#ref-for-ascii-case-insensitive②①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-ascii-case-insensitive②②">(2)</a> <a href="#ref-for-ascii-case-insensitive②③">(3)</a> <a href="#ref-for-ascii-case-insensitive②④">(4)</a>
    </ul>
   </aside>
@@ -7026,13 +7321,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ascii-string">2.2. Policies</a> <a href="#ref-for-ascii-string①">(2)</a>
     <li><a href="#ref-for-ascii-string②">2.3. Directives</a>
     <li><a href="#ref-for-ascii-string③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-ascii-string④">6.6.1.7. 
+    <li><a href="#ref-for-ascii-string④">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-ascii-string⑤">(2)</a> <a href="#ref-for-ascii-string⑥">(3)</a>
-    <li><a href="#ref-for-ascii-string⑦">6.6.1.8. 
+    <li><a href="#ref-for-ascii-string⑦">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-ascii-string⑧">(2)</a> <a href="#ref-for-ascii-string⑨">(3)</a>
-    <li><a href="#ref-for-ascii-string①⓪">6.6.1.9. 
+    <li><a href="#ref-for-ascii-string①⓪">6.6.2.9. 
     port-part matching </a> <a href="#ref-for-ascii-string①①">(2)</a>
-    <li><a href="#ref-for-ascii-string①②">6.6.1.10. 
+    <li><a href="#ref-for-ascii-string①②">6.6.2.10. 
     path-part matching </a> <a href="#ref-for-ascii-string①③">(2)</a>
    </ul>
   </aside>
@@ -7089,6 +7384,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
     <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-ordered-set④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ordered-set">
@@ -7097,6 +7394,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
     <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-ordered-set④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
@@ -7120,7 +7419,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-strictly-split">2.2.1. 
     Parse a serialized CSP </a>
-    <li><a href="#ref-for-strictly-split①">6.6.1.10. 
+    <li><a href="#ref-for-strictly-split①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
@@ -7177,7 +7476,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-section-3.2.2">
    <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-section-3.2.2">6.6.1.8. 
+    <li><a href="#ref-for-section-3.2.2">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -7203,7 +7502,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://tools.ietf.org/html/rfc4648#section-4">https://tools.ietf.org/html/rfc4648#section-4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-4①">6.6.2.3. 
+    <li><a href="#ref-for-section-4①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-section-4②">(2)</a>
    </ul>
   </aside>
@@ -7211,7 +7510,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://tools.ietf.org/html/rfc4648#section-5">https://tools.ietf.org/html/rfc4648#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-5①">6.6.2.3. 
+    <li><a href="#ref-for-section-5①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -7293,7 +7592,7 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.13. worker-src</a>
+    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
@@ -7306,21 +7605,21 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#termref-for-">6.6.2.3. 
+    <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
@@ -7334,9 +7633,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-url⑥">6.3.1. form-action</a>
     <li><a href="#ref-for-url⑦">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-url⑧">6.3.3. navigate-to</a>
-    <li><a href="#ref-for-url⑨">6.6.1.5. 
+    <li><a href="#ref-for-url⑨">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-url①⓪">6.6.1.6. 
+    <li><a href="#ref-for-url①⓪">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
@@ -7350,23 +7649,23 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-default-port">
    <a href="https://url.spec.whatwg.org/#default-port">https://url.spec.whatwg.org/#default-port</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-port">6.6.1.6. 
+    <li><a href="#ref-for-default-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-default-port①">6.6.1.9. 
+    <li><a href="#ref-for-default-port①">6.6.2.9. 
     port-part matching </a> <a href="#ref-for-default-port②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-host">
    <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-host">6.6.1.8. 
+    <li><a href="#ref-for-concept-url-host">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-ipv6">
    <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-ipv6">6.6.1.8. 
+    <li><a href="#ref-for-concept-ipv6">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -7377,32 +7676,32 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
     <li><a href="#ref-for-concept-url-origin①">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-url-origin②">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-origin②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-path">
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-path">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-path">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-path①">6.6.1.10. 
+    <li><a href="#ref-for-concept-url-path①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-percent-decode">
    <a href="https://url.spec.whatwg.org/#percent-decode">https://url.spec.whatwg.org/#percent-decode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percent-decode">6.6.1.10. 
+    <li><a href="#ref-for-percent-decode">6.6.2.10. 
     path-part matching </a> <a href="#ref-for-percent-decode①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-port">
    <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-port">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-port①">6.6.1.9. 
+    <li><a href="#ref-for-concept-url-port①">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -7416,11 +7715,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-url-scheme②">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-url-scheme③">6.6.1.6. 
+    <li><a href="#ref-for-concept-url-scheme③">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a> <a href="#ref-for-concept-url-scheme⑨">(7)</a> <a href="#ref-for-concept-url-scheme①⓪">(8)</a>
-    <li><a href="#ref-for-concept-url-scheme①①">6.6.1.7. 
+    <li><a href="#ref-for-concept-url-scheme①①">6.6.2.7. 
     scheme-part matching </a>
-    <li><a href="#ref-for-concept-url-scheme①②">6.6.1.9. 
+    <li><a href="#ref-for-concept-url-scheme①②">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -7945,97 +8244,121 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-content-security-policy-object④">(2)</a>
     <li><a href="#ref-for-content-security-policy-object⑤">2.2.2. 
     Parse a serialized CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a> <a href="#ref-for-content-security-policy-object①②">(7)</a>
-    <li><a href="#ref-for-content-security-policy-object①③">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①④">(2)</a> <a href="#ref-for-content-security-policy-object①⑤">(3)</a> <a href="#ref-for-content-security-policy-object①⑥">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object①⑦">2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a> <a href="#ref-for-content-security-policy-object①②">(7)</a> <a href="#ref-for-content-security-policy-object①③">(8)</a>
+    <li><a href="#ref-for-content-security-policy-object①④">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①⑤">(2)</a> <a href="#ref-for-content-security-policy-object①⑥">(3)</a> <a href="#ref-for-content-security-policy-object①⑦">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object①⑧">2.4.1. 
     Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑧">2.4.2. 
+    <li><a href="#ref-for-content-security-policy-object①⑨">2.4.2. 
     Create a violation object for request, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑨">3. 
-    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②⓪">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②①">4.1. 
+    <li><a href="#ref-for-content-security-policy-object②⓪">3. 
+    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②①">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object②②">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-content-security-policy-object②②">4.2. 
-    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②③">(2)</a> <a href="#ref-for-content-security-policy-object②④">(3)</a> <a href="#ref-for-content-security-policy-object②⑤">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑥">4.2.1. 
+    <li><a href="#ref-for-content-security-policy-object②③">4.2. 
+    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②④">(2)</a> <a href="#ref-for-content-security-policy-object②⑤">(3)</a> <a href="#ref-for-content-security-policy-object②⑥">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object②⑦">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object②⑦">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object②⑧">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑨">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object②⑧">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object②⑨">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⓪">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object③①">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③①">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object③②">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③②">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object③③">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③③">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object③④">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③④">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object④①">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object④②">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④①">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object④③">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④②">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object④④">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④③">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④④">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.10. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.3. 
+    script-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.13.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.3. 
+    style-src Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.13.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.2.4.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.4.1. 
     disown-opener Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.6.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    Should fetch directive execute </a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8185,32 +8508,36 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directives①⑥">6.1.1.2. 
     child-src Post-request check </a>
     <li><a href="#ref-for-directives①⑦">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directives①⑧">(2)</a> <a href="#ref-for-directives①⑨">(3)</a> <a href="#ref-for-directives②⓪">(4)</a> <a href="#ref-for-directives②①">(5)</a>
-    <li><a href="#ref-for-directives②②">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directives②③">(2)</a> <a href="#ref-for-directives②④">(3)</a> <a href="#ref-for-directives②⑤">(4)</a> <a href="#ref-for-directives②⑥">(5)</a>
-    <li><a href="#ref-for-directives②⑦">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directives②⑧">(2)</a>
-    <li><a href="#ref-for-directives②⑨">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directives③⓪">(2)</a>
-    <li><a href="#ref-for-directives③①">6.2.1.1. 
-    Is base allowed for document? </a> <a href="#ref-for-directives③②">(2)</a>
-    <li><a href="#ref-for-directives③③">6.2.2.2. 
+    default-src Pre-request check </a>
+    <li><a href="#ref-for-directives①⑧">6.1.3.2. 
+    default-src Post-request check </a>
+    <li><a href="#ref-for-directives①⑨">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directives②⓪">6.2.1.1. 
+    Is base allowed for document? </a> <a href="#ref-for-directives②①">(2)</a>
+    <li><a href="#ref-for-directives②②">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directives③④">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives③⑤">(2)</a>
-    <li><a href="#ref-for-directives③⑥">6.3.2.2. 
+    <li><a href="#ref-for-directives②③">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives②④">(2)</a>
+    <li><a href="#ref-for-directives②⑤">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-directives③⑦">6.3.3.1. 
+    <li><a href="#ref-for-directives②⑥">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-directives③⑧">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directives③⑨">(2)</a>
-    <li><a href="#ref-for-directives④⓪">6.6.1.1. 
+    <li><a href="#ref-for-directives②⑦">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directives②⑧">(2)</a>
+    <li><a href="#ref-for-directives②⑨">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-directives③⓪">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-directives③①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directives④①">6.6.1.3. 
+    <li><a href="#ref-for-directives③②">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-directives④②">6.6.1.4. 
+    <li><a href="#ref-for-directives③③">6.6.2.4. 
     Does response to request match source list? </a>
+    <li><a href="#ref-for-directives③④">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-directives③⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-name">
@@ -8230,21 +8557,23 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-name⑧">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑨">(2)</a>
     <li><a href="#ref-for-directive-name①⓪">6.1.1.1. 
-    child-src Pre-request check </a> <a href="#ref-for-directive-name①①">(2)</a>
-    <li><a href="#ref-for-directive-name①②">6.1.1.2. 
-    child-src Post-request check </a> <a href="#ref-for-directive-name①③">(2)</a>
-    <li><a href="#ref-for-directive-name①④">6.1.3.1. 
-    default-src Pre-request check </a> <a href="#ref-for-directive-name①⑤">(2)</a> <a href="#ref-for-directive-name①⑥">(3)</a> <a href="#ref-for-directive-name①⑦">(4)</a> <a href="#ref-for-directive-name①⑧">(5)</a>
-    <li><a href="#ref-for-directive-name①⑨">6.1.3.2. 
-    default-src Post-request check </a> <a href="#ref-for-directive-name②⓪">(2)</a> <a href="#ref-for-directive-name②①">(3)</a> <a href="#ref-for-directive-name②②">(4)</a> <a href="#ref-for-directive-name②③">(5)</a>
-    <li><a href="#ref-for-directive-name②④">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-name②⑤">(2)</a>
-    <li><a href="#ref-for-directive-name②⑥">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-name②⑦">(2)</a>
-    <li><a href="#ref-for-directive-name②⑧">6.2.1.1. 
+    child-src Pre-request check </a>
+    <li><a href="#ref-for-directive-name①①">6.1.1.2. 
+    child-src Post-request check </a>
+    <li><a href="#ref-for-directive-name①②">6.1.3.1. 
+    default-src Pre-request check </a>
+    <li><a href="#ref-for-directive-name①③">6.1.3.2. 
+    default-src Post-request check </a>
+    <li><a href="#ref-for-directive-name①④">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directive-name①⑤">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-name②⑨">6.6.1.11. 
+    <li><a href="#ref-for-directive-name①⑥">6.7.1. 
     Get the effective directive for request </a>
+    <li><a href="#ref-for-directive-name①⑦">6.7.2. 
+    Get the effective directive for inline checks </a>
+    <li><a href="#ref-for-directive-name①⑧">6.7.4. 
+    Should fetch directive execute </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-value">
@@ -8272,69 +8601,84 @@ rest of Google’s CSP Cabal.</p>
     default-src Pre-request check </a>
     <li><a href="#ref-for-directive-value①④">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑤">6.1.4.1. 
+    <li><a href="#ref-for-directive-value①⑤">6.1.3.3. 
+    default-src Inline Check </a>
+    <li><a href="#ref-for-directive-value①⑥">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑥">6.1.4.2. 
+    <li><a href="#ref-for-directive-value①⑦">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑦">6.1.5.1. 
+    <li><a href="#ref-for-directive-value①⑧">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑧">6.1.5.2. 
+    <li><a href="#ref-for-directive-value①⑨">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑨">6.1.6.1. 
+    <li><a href="#ref-for-directive-value②⓪">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⓪">6.1.6.2. 
+    <li><a href="#ref-for-directive-value②①">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②①">6.1.7.1. 
+    <li><a href="#ref-for-directive-value②②">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②②">6.1.7.2. 
+    <li><a href="#ref-for-directive-value②③">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②③">6.1.8.1. 
+    <li><a href="#ref-for-directive-value②④">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②④">6.1.8.2. 
+    <li><a href="#ref-for-directive-value②⑤">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑤">6.1.9.1. 
+    <li><a href="#ref-for-directive-value②⑥">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑥">6.1.9.2. 
+    <li><a href="#ref-for-directive-value②⑦">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑦">6.1.10.1. 
+    <li><a href="#ref-for-directive-value②⑧">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑧">6.1.10.2. 
+    <li><a href="#ref-for-directive-value②⑨">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑨">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-directive-value③⓪">(2)</a> <a href="#ref-for-directive-value③①">(3)</a> <a href="#ref-for-directive-value③②">(4)</a> <a href="#ref-for-directive-value③③">(5)</a>
-    <li><a href="#ref-for-directive-value③④">6.1.11.2. 
-    script-src Post-request check </a> <a href="#ref-for-directive-value③⑤">(2)</a> <a href="#ref-for-directive-value③⑥">(3)</a>
-    <li><a href="#ref-for-directive-value③⑦">6.1.11.3. 
+    <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑧">6.1.12.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑨">(2)</a>
-    <li><a href="#ref-for-directive-value④⓪">6.1.12.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value④①">(2)</a>
-    <li><a href="#ref-for-directive-value④②">6.1.12.3. 
+    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
+    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
+    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value④③">6.1.13.1. 
+    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
+    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
+    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
+    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
+    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
+    style-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.13.2. 
+    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.2.1.1. 
+    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑥">6.2.2.1. 
+    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.2.2. 
+    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.3.1. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤③">(2)</a>
-    <li><a href="#ref-for-directive-value⑤④">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
+    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
+    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
+    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">
@@ -8389,14 +8733,18 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
+    script-src-elem Pre-request check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑤">6.1.13.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑥">6.1.15.1. 
+    style-src-elem Pre-request Check </a>
+    <li><a href="#ref-for-directive-pre-request-check①⑦">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑥">6.5. 
+    <li><a href="#ref-for-directive-pre-request-check①⑧">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑦">6.6.1.1. 
+    <li><a href="#ref-for-directive-pre-request-check①⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directive-pre-request-check①⑧">6.6.1.3. 
+    <li><a href="#ref-for-directive-pre-request-check②⓪">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -8431,14 +8779,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
+    script-src-elem Post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑥">6.1.13.2. 
+    <li><a href="#ref-for-directive-post-request-check①⑦">6.1.15.2. 
+    style-src-elem Post-request Check </a>
+    <li><a href="#ref-for-directive-post-request-check①⑧">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑦">6.2.2.1. 
+    <li><a href="#ref-for-directive-post-request-check①⑨">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-post-request-check①⑧">6.5. 
+    <li><a href="#ref-for-directive-post-request-check②⓪">6.5. 
     Directives Defined in Other Documents </a>
-    <li><a href="#ref-for-directive-post-request-check①⑨">6.6.1.4. 
+    <li><a href="#ref-for-directive-post-request-check②①">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check②②">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -8464,10 +8818,20 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-inline-check①">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-inline-check②">6.1.11.3. 
+    <li><a href="#ref-for-directive-inline-check②">6.1.3.3. 
+    default-src Inline Check </a> <a href="#ref-for-directive-inline-check③">(2)</a>
+    <li><a href="#ref-for-directive-inline-check④">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-inline-check③">6.1.12.3. 
+    <li><a href="#ref-for-directive-inline-check⑤">6.1.12.3. 
+    script-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑥">6.1.13.1. 
+    script-src-attr Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑦">6.1.14.3. 
     style-src Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑧">6.1.15.3. 
+    style-src-elem Inline Check </a>
+    <li><a href="#ref-for-directive-inline-check⑨">6.1.16.1. 
+    style-src-attr Inline Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-initialization">
@@ -8475,7 +8839,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-directive-initialization①">6.1.12.3. 
+    <li><a href="#ref-for-directive-initialization①">6.1.14.3. 
     style-src Inline Check </a>
     <li><a href="#ref-for-directive-initialization②">6.2.3.2. 
     sandbox Initialization </a>
@@ -8522,19 +8886,19 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
     <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
-    <li><a href="#ref-for-source-lists①⓪">6.1.13. worker-src</a>
+    <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-source-lists①②">6.6.1.2. 
+    <li><a href="#ref-for-source-lists①②">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-source-lists①③">6.6.1.3. 
+    <li><a href="#ref-for-source-lists①③">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-source-lists①④">6.6.1.4. 
+    <li><a href="#ref-for-source-lists①④">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-source-lists①⑤">6.6.1.5. 
+    <li><a href="#ref-for-source-lists①⑤">6.6.2.5. 
     Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-source-lists①⑥">6.6.2.2. 
+    <li><a href="#ref-for-source-lists①⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-lists①⑦">(2)</a> <a href="#ref-for-source-lists①⑧">(3)</a> <a href="#ref-for-source-lists①⑨">(4)</a> <a href="#ref-for-source-lists②⓪">(5)</a>
-    <li><a href="#ref-for-source-lists②①">6.6.2.3. 
+    <li><a href="#ref-for-source-lists②①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
@@ -8545,13 +8909,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-expression①">2.3.1. Source Lists</a>
     <li><a href="#ref-for-source-expression②">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-source-expression③">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-source-expression④">(2)</a> <a href="#ref-for-source-expression⑤">(3)</a> <a href="#ref-for-source-expression⑥">(4)</a>
-    <li><a href="#ref-for-source-expression⑦">6.3.3.1. 
+    <li><a href="#ref-for-source-expression③">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-source-expression⑧">6.3.3.2. 
+    <li><a href="#ref-for-source-expression④">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-source-expression⑨">6.6.1.6. 
+    <li><a href="#ref-for-source-expression⑤">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-source-expression⑥">(2)</a> <a href="#ref-for-source-expression⑦">(3)</a> <a href="#ref-for-source-expression⑧">(4)</a>
+    <li><a href="#ref-for-source-expression⑨">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
     <li><a href="#ref-for-source-expression①⓪">8.4. 
       Allowing external JavaScript via hashes </a>
@@ -8571,11 +8935,15 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. worker-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.2.1. base-uri</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.3.1. form-action</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.3.3. navigate-to</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①④">6.1.15. style-src-elem</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑤">6.1.16. style-src-attr</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑥">6.1.17. worker-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑦">6.2.1. base-uri</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑧">6.3.1. form-action</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-none">
@@ -8596,7 +8964,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-scheme-source①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-scheme-source②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-scheme-source②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-scheme-source③">(2)</a>
     <li><a href="#ref-for-grammardef-scheme-source④">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8607,7 +8975,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-host-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-host-source①">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-host-source②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-host-source②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-host-source③">(2)</a> <a href="#ref-for-grammardef-host-source④">(3)</a>
     <li><a href="#ref-for-grammardef-host-source⑤">7.3. Nonce Retargeting</a>
     <li><a href="#ref-for-grammardef-host-source⑥">8.2. 
@@ -8618,9 +8986,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-scheme-part">#grammardef-scheme-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-part">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-scheme-part①">(2)</a>
-    <li><a href="#ref-for-grammardef-scheme-part②">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-scheme-part②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-scheme-part③">(2)</a> <a href="#ref-for-grammardef-scheme-part④">(3)</a> <a href="#ref-for-grammardef-scheme-part⑤">(4)</a>
-    <li><a href="#ref-for-grammardef-scheme-part⑥">6.6.1.7. 
+    <li><a href="#ref-for-grammardef-scheme-part⑥">6.6.2.7. 
     scheme-part matching </a>
    </ul>
   </aside>
@@ -8628,9 +8996,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-host-part">#grammardef-host-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-host-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-host-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-grammardef-host-part②">6.6.1.8. 
+    <li><a href="#ref-for-grammardef-host-part②">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
@@ -8644,9 +9012,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-port-part">#grammardef-port-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-port-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-port-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-port-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-grammardef-port-part②">6.6.1.9. 
+    <li><a href="#ref-for-grammardef-port-part②">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
@@ -8654,9 +9022,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-path-part">#grammardef-path-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-path-part">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-path-part①">6.6.1.6. 
+    <li><a href="#ref-for-grammardef-path-part①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-grammardef-path-part②">(2)</a>
-    <li><a href="#ref-for-grammardef-path-part③">6.6.1.10. 
+    <li><a href="#ref-for-grammardef-path-part③">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
@@ -8664,15 +9032,15 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-keyword-source">#grammardef-keyword-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-keyword-source">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-keyword-source①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-keyword-source②">6.3.3.1. 
+    <li><a href="#ref-for-grammardef-keyword-source①">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source③">6.3.3.2. 
+    <li><a href="#ref-for-grammardef-keyword-source②">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-grammardef-keyword-source④">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-keyword-source③">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-keyword-source④">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-keyword-source⑤">(2)</a> <a href="#ref-for-grammardef-keyword-source⑥">(3)</a>
-    <li><a href="#ref-for-grammardef-keyword-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-keyword-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-keyword-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8682,9 +9050,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a>
-    <li><a href="#ref-for-grammardef-self②④">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑤">8.2. 
+    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
+    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
@@ -8693,7 +9061,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-inline">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-grammardef-unsafe-inline①">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-unsafe-inline①">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-grammardef-unsafe-inline②">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline③">7.1. Nonce Reuse</a> <a href="#ref-for-grammardef-unsafe-inline④">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-inline⑤">8.2. 
@@ -8710,11 +9078,11 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-strict-dynamic">
    <b><a href="#grammardef-strict-dynamic">#grammardef-strict-dynamic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-strict-dynamic">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
-    <li><a href="#ref-for-grammardef-strict-dynamic②">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-grammardef-strict-dynamic③">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-strict-dynamic">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
+    <li><a href="#ref-for-grammardef-strict-dynamic②">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-grammardef-strict-dynamic③">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
     <li><a href="#ref-for-grammardef-strict-dynamic④">8.2. 
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-grammardef-strict-dynamic⑤">(2)</a> <a href="#ref-for-grammardef-strict-dynamic⑥">(3)</a>
@@ -8723,7 +9091,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-unsafe-hashes">
    <b><a href="#grammardef-unsafe-hashes">#grammardef-unsafe-hashes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashes①">(2)</a>
     <li><a href="#ref-for-grammardef-unsafe-hashes②">8.3. 
       Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a>
@@ -8753,14 +9121,14 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source③">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-nonce-source④">6.6.1.2. 
+    <li><a href="#ref-for-grammardef-nonce-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-nonce-source④">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.2.1. 
+    <li><a href="#ref-for-grammardef-nonce-source⑤">6.6.3.1. 
     Is element nonceable? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-nonce-source⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-nonce-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-nonce-source⑧">7.1. Nonce Reuse</a>
     <li><a href="#ref-for-grammardef-nonce-source⑨">8.2. 
@@ -8771,11 +9139,11 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-base64-value">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-base64-value①">(2)</a> <a href="#ref-for-grammardef-base64-value②">(3)</a> <a href="#ref-for-grammardef-base64-value③">(4)</a>
-    <li><a href="#ref-for-grammardef-base64-value④">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-base64-value⑤">6.6.1.2. 
+    <li><a href="#ref-for-grammardef-base64-value④">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-base64-value⑤">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-grammardef-base64-value⑥">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-base64-value⑥">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-base64-value⑦">(2)</a>
    </ul>
   </aside>
@@ -8784,12 +9152,12 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
-    <li><a href="#ref-for-grammardef-hash-source③">6.1.11.1. 
-    script-src Pre-request check </a> <a href="#ref-for-grammardef-hash-source④">(2)</a>
-    <li><a href="#ref-for-grammardef-hash-source⑤">6.1.12. style-src</a>
-    <li><a href="#ref-for-grammardef-hash-source⑥">6.6.2.2. 
+    <li><a href="#ref-for-grammardef-hash-source③">6.1.14. style-src</a>
+    <li><a href="#ref-for-grammardef-hash-source④">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-grammardef-hash-source⑤">(2)</a>
+    <li><a href="#ref-for-grammardef-hash-source⑥">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-hash-source⑦">6.6.3.3. 
     Does element match source list for type and source? </a>
     <li><a href="#ref-for-grammardef-hash-source⑧">8.2. 
     Usage of "'strict-dynamic'" </a>
@@ -8801,9 +9169,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-hash-algorithm">#grammardef-hash-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-algorithm">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-hash-algorithm①">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-grammardef-hash-algorithm②">6.6.2.3. 
+    <li><a href="#ref-for-grammardef-hash-algorithm①">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-grammardef-hash-algorithm②">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-hash-algorithm③">(2)</a> <a href="#ref-for-grammardef-hash-algorithm④">(3)</a>
    </ul>
   </aside>
@@ -9168,8 +9536,10 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#fetch-directives">#fetch-directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-directives">6.1.3. default-src</a> <a href="#ref-for-fetch-directives①">(2)</a>
-    <li><a href="#ref-for-fetch-directives②">6.6.1.11. 
+    <li><a href="#ref-for-fetch-directives②">6.7.1. 
     Get the effective directive for request </a>
+    <li><a href="#ref-for-fetch-directives③">6.7.4. 
+    Should fetch directive execute </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="child-src">
@@ -9274,29 +9644,51 @@ rest of Google’s CSP Cabal.</p>
     Content Security Policy Directives </a>
     <li><a href="#ref-for-script-src①">6.1. 
     Fetch Directives </a>
-    <li><a href="#ref-for-script-src②">6.1.3. default-src</a> <a href="#ref-for-script-src③">(2)</a> <a href="#ref-for-script-src④">(3)</a>
-    <li><a href="#ref-for-script-src⑤">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src⑥">(2)</a>
-    <li><a href="#ref-for-script-src⑦">8.3. 
+    <li><a href="#ref-for-script-src②">8.2. 
+    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script-src③">(2)</a>
+    <li><a href="#ref-for-script-src④">8.3. 
       Usage of "'unsafe-hashes'" </a>
-    <li><a href="#ref-for-script-src⑧">10.1. 
+    <li><a href="#ref-for-script-src⑤">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-elem">
+   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="script-src-attr">
+   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
    <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-style-src">6.1.3. default-src</a> <a href="#ref-for-style-src①">(2)</a>
-    <li><a href="#ref-for-style-src②">7.4. CSS Parsing</a>
-    <li><a href="#ref-for-style-src③">10.1. 
+    <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
+    <li><a href="#ref-for-style-src①">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-elem">
+   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="style-src-attr">
+   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.13. worker-src</a>
+    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
     <li><a href="#ref-for-worker-src③">10.1. 
     Directive Registry </a>
    </ul>
@@ -9426,44 +9818,51 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="scheme-part-match">
    <b><a href="#scheme-part-match">#scheme-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scheme-part-match">6.6.1.6. 
+    <li><a href="#ref-for-scheme-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-scheme-part-match①">(2)</a>
-    <li><a href="#ref-for-scheme-part-match②">6.6.1.7. 
+    <li><a href="#ref-for-scheme-part-match②">6.6.2.7. 
     scheme-part matching </a> <a href="#ref-for-scheme-part-match③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="host-part-match">
    <b><a href="#host-part-match">#host-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-host-part-match">6.6.1.6. 
+    <li><a href="#ref-for-host-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-host-part-match①">6.6.1.8. 
+    <li><a href="#ref-for-host-part-match①">6.6.2.8. 
     host-part matching </a> <a href="#ref-for-host-part-match②">(2)</a> <a href="#ref-for-host-part-match③">(3)</a> <a href="#ref-for-host-part-match④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="port-part-matches">
    <b><a href="#port-part-matches">#port-part-matches</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-port-part-matches">6.6.1.6. 
+    <li><a href="#ref-for-port-part-matches">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-port-part-matches①">6.6.1.9. 
+    <li><a href="#ref-for-port-part-matches①">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="path-part-match">
    <b><a href="#path-part-match">#path-part-match</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-path-part-match">6.6.1.6. 
+    <li><a href="#ref-for-path-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-path-part-match①">6.6.1.10. 
+    <li><a href="#ref-for-path-part-match①">6.6.2.10. 
     path-part matching </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="source-list-allows-all-inline-behavior">
    <b><a href="#source-list-allows-all-inline-behavior">#source-list-allows-all-inline-behavior</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-source-list-allows-all-inline-behavior">6.6.2.2. 
+    <li><a href="#ref-for-source-list-allows-all-inline-behavior">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-list-allows-all-inline-behavior①">(2)</a> <a href="#ref-for-source-list-allows-all-inline-behavior②">(3)</a> <a href="#ref-for-source-list-allows-all-inline-behavior③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="request-effective-directive">
+   <b><a href="#request-effective-directive">#request-effective-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-request-effective-directive">6.7.2. 
+    Get the effective directive for inline checks </a>
    </ul>
   </aside>
 <script>/* script-var-click-highlighting */

--- a/index.src.html
+++ b/index.src.html
@@ -529,10 +529,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       "`Allowed`" unless otherwise specified.
 
   4.  An <dfn for="directive" export>inline check</dfn>, which takes an {{Element}} a
-      type string, and a source string as arguments, and is executed during
-      [[#should-block-inline]] and during [[#should-block-navigation-request]] for
-      `javascript:` requests. This algorithm returns "`Allowed`" unless
-      otherwise specified.
+      type string, a <a for="/">policy</a>, and a source string as arguments,
+      and is executed during [[#should-block-inline]] and during
+      [[#should-block-navigation-request]] for `javascript:` requests. This
+      algorithm returns "`Allowed`" unless otherwise specified.
 
   5.  An <dfn for="directive" export>initialization</dfn>, which takes a {{Document}}
       or <a for="/">global object</a>, a <a>response</a>, and a <a for="/">policy</a>
@@ -1274,7 +1274,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
         1.  For each |directive| in |policy|'s <a for="policy">directive set</a>:
 
             1.  If |directive|'s <a for="directive">inline check</a> returns
-                "`Allowed`" when executed upon |element|, |type|, and |source|,
+                "`Allowed`" when executed upon |element|, |type|, |policy| and |source|,
                 skip to the next |directive|.
 
             2.  Otherwise, let |violation| be the result of executing
@@ -1859,12 +1859,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is not `frame-src` or `worker-src`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `child-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a directive whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  Return the result of executing the <a for="directive">pre-request
+  3.  Return the result of executing the <a for="directive">pre-request
       check</a> for the <a>directive</a> whose <a for="directive">name</a>
       is |name| on |request| and |policy|, using this directive's
       <a for="directive">value</a> for the comparison.
@@ -1881,12 +1879,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is not `frame-src` or `worker-src`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `child-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a directive whose <a for="directive">name</a>
-      is |name|, return "`Allowed`"
-
-  4.  Return the result of executing the <a for="directive">post-request
+  3.  Return the result of executing the <a for="directive">post-request
       check</a> for the <a>directive</a> whose <a for="directive">name</a>
       is |name| on |request|, |response|, and |policy|, using this directive's
       <a for="directive">value</a> for the comparison.
@@ -1955,16 +1951,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing
+      [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
-      <a for="request">destination</a> is "":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `connect-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="connect-src-post-request">
     `connect-src` Post-request check
@@ -1975,17 +1972,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing
+      [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
-      <a for="request">destination</a> is "":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `connect-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-default-src">`default-src`</h4>
 
@@ -2023,8 +2021,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> <a grammar>'self'</a>;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> <a grammar>'self'</a>;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2037,7 +2037,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2051,8 +2051,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> https://example.com;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> https://example.com;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2073,19 +2075,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is `null`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a <a>directive</a> whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  If |name| is "`frame-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
-
-  5.  If |name| is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`script-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`" , return "`Allowed`".
-
-  6.  Otherwise, return the result of executing the
+  3.  Return the result of executing the
       <a for="directive">pre-request check</a> for the <a>directive</a> whose
       <a for="directive">name</a> is |name| on |request| and |policy|, using
       this directive's <a for="directive">value</a> for the comparison.
@@ -2102,22 +2095,34 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
 
-  2.  If |name| is `null`, return "`Allowed`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If |policy| contains a <a>directive</a> whose <a for="directive">name</a>
-      is |name|, return "`Allowed`".
-
-  4.  If |name| is "`frame-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
-
-  5.  If |name| is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`script-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`" , return "`Allowed`".
-
-  6.  Otherwise, return the result of executing the
+  3.  Return the result of executing the
       <a for="directive">post-request check</a> for the <a>directive</a> whose
       <a for="directive">name</a> is |name| on |request|, |response|, and
       |policy|, using this directive's <a for="directive">value</a> for the
+      comparison.
+
+  <h5 algorithm id="default-src-inline">
+    `default-src` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `default-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Otherwise, return the result of executing the
+      <a for="directive">inline check</a> for the <a>directive</a> whose
+      <a for="directive">name</a> is |name| on |element|, |type|, |policy|
+      and |source|, using this directive's <a for="directive">value</a> for the
       comparison.
 
   <h4 id="directive-font-src">`font-src`</h4>
@@ -2161,15 +2166,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`font`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `font-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="font-src-post-request">
     `font-src` Post-request check
@@ -2180,16 +2187,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`font`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `font-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-frame-src">`frame-src`</h4>
 
@@ -2226,17 +2235,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`document`" and
-      <a for="request">target browsing context</a> is a <a>nested browsing
-      context</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="frame-src-post-request">
     `frame-src` Post-request check
@@ -2247,18 +2256,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`document`" and
-      <a for="request">target browsing context</a> is a <a>nested browsing
-      context</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-img-src">`img-src`</h4>
 
@@ -2298,15 +2307,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`image`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `img-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="img-src-post-request">
     `img-src` Post-request check
@@ -2317,16 +2328,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`image`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `frame-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-manifest-src">`manifest-src`</h4>
 
@@ -2362,15 +2375,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="manifest-src-post-request">
     `manifest-src` Post-request check
@@ -2381,16 +2396,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`manifest`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-media-src">`media-src`</h4>
 
@@ -2429,16 +2446,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
-      or "`track`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `media-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="media-src-post-request">
     `media-src` Post-request check
@@ -2449,17 +2467,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of "`audio`", "`video`",
-      or "`track`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `media-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-prefetch-src">`prefetch-src`</h4>
 
@@ -2496,14 +2515,16 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on |request| and this
-          directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on |request| and this
+      directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="prefetch-src-post-request">
     `prefetch-src` Post-request check
@@ -2514,14 +2535,16 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
-          and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
+      and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
 
   <h4 id="directive-object-src">`object-src`</h4>
@@ -2583,15 +2606,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `object-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="object-src-post-request">
     `object-src` Post-request check
@@ -2602,16 +2627,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`object`" or "`embed`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `object-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h4 id="directive-script-src">`script-src`</h4>
 
@@ -2660,69 +2687,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  If the result of executing [[#effective-directive-for-a-request]] on |request|
-      is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`worker-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
-
-      2.  Let |integrity expressions| be the set of <a>source expressions</a> in
-          this directive's <a for="directive">value</a> that match the
-          <a grammar>hash-source</a> grammar.
-
-      3.  If |integrity expressions| is not empty:
-
-          1.  Let |integrity sources| be the result of executing the algorithm
-              defined in [[SRI#parse-metadata]] on |request|'s
-              <a for="request">integrity metadata</a>. [[!SRI]]
-
-          2.  If |integrity sources| is "`no metadata`" or an empty set, skip
-              the remaining substeps.
-
-          3.  Let |bypass due to integrity match| be `true`.
-
-          4.  For each |source| in |integrity sources|:
-
-              1.  If this directive's <a for="directive">value</a> does not
-                  contain a <a>source expression</a> whose
-                  <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
-                  for |source|'s `hash-algo` component, and whose
-                  <a grammar>base64-value</a> is a <a>case-sensitive</a> match
-                  for |source|'s `base64-value`, then set |bypass due to
-                  integrity match| to `false`.
-
-          5.  If |bypass due to integrity match| is `true`, return
-              "`Allowed`".
-
-          Note: Here, we verify only that the |request| contains a set of
-          <a for="request">integrity metadata</a> which is a subset of the
-          <a grammar>hash-source</a> <a>source expressions</a> specified by
-          this directive. We rely on the browser's enforcement of Subresource
-          Integrity [[!SRI]] to block non-matching resources upon response.
-
-      3.  If this directive's <a for="directive">value</a> contains a <a>source
-          expression</a> that is an <a>ASCII case-insensitive</a> match for
-          the "<a grammar>`'strict-dynamic'`</a>" <a grammar>keyword-source</a>:
-
-          1.  If the |request|'s <a for="request">parser metadata</a> is
-              <a>"parser-inserted"</a>, return "`Blocked`".
-
-              Otherwise, return "`Allowed`".
-
-              Note: "<a grammar>`'strict-dynamic'`</a>" is explained in more detail
-              in [[#strict-dynamic-usage]].
-
-      4.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
-
-  3.  Return "`Allowed`".
+  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
 
   <h5 algorithm id="script-src-post-request">
     `script-src` Post-request check
@@ -2733,29 +2704,14 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  If the result of executing [[#effective-directive-for-a-request]] on |request|
-      is "`worker-src`", and |policy| contains a <a>directive</a> whose
-      <a for="directive">name</a> is "`worker-src`" or a <a>directive</a> whose
-      <a for="directive">name</a> is "`child-src`", return "`Allowed`".
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
-
-      2.  If this directive's <a for="directive">value</a> contains
-          "<a grammar>`'strict-dynamic'`</a>", and |request|'s
-          <a for="request">parser metadata</a> is not <a>"parser-inserted"</a>,
-          return "`Allowed`".
-
-      3.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
-
-  3.  Return "`Allowed`".
+  3.  Return the result of executing [[#script-post-request]] on |request|,
+      |response| and this directive.
 
   <h5 algorithm id="script-src-inline">
     `script-src` Inline Check
@@ -2763,17 +2719,134 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
 
-  1.  If |type| is "`script`", "`script attribute`" or "`navigation`":
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
 
-      1.  Assert: |element| is not `null` or |type| is "`navigation`".
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
 
-      2.  If the result of executing [[#match-element-to-source-list]] on
-          |element|, this directive's <a for="directive">value</a>, |type|,
-          and |source|, is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src` and |policy| is "`No`", return "`Allowed`".
 
-  2.  Return "`Allowed`".
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-script-src-elem">`script-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.
+
+  As such, the following differences exist when comparing to `script-src`:
+  * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
+    (and is ignored for "`script attribute`" inline checks).
+  * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
+    execution sink checks that are gated on the "`unsafe-eval`" check.
+  * `script-src-elem` is not used as a fallback for the `worker-src` directive.
+    The `worker-src` checks still fall back on the `script-src` directive.
+
+  <h5 algorithm id="script-src-elem-pre-request">
+    `script-src-elem` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
+
+  <h5 algorithm id="script-src-elem-post-request">
+    `script-src-elem` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-post-request]] on |request|,
+      |response| and this directive.
+
+  <h5 algorithm id="script-src-elem-inline">
+    `script-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-script-src-attr">`script-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the `script-src` directive for relevant checks.
+
+  <h5 algorithm id="script-src-attr-inline">
+    `script-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
 
   <h4 id="directive-style-src">`style-src`</h4>
 
@@ -2829,20 +2902,22 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`style`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
 
-      2.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  4.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  5.  Return "`Allowed`".
 
   <h5 algorithm id="style-src-post-request">
     `style-src` Post-request Check
@@ -2853,21 +2928,23 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is "`style`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-nonce-to-source-list]] on
-          |request|'s <a for="request">cryptographic nonce metadata</a> and this
-          directive's <a for="directive">value</a> is "`Matches`", return
-          "`Allowed`".
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
 
-      2.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  4.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  5.  Return "`Allowed`".
 
   <h5 algorithm id="style-src-inline">
     `style-src` Inline Check
@@ -2875,21 +2952,143 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), and a string (|source|):
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
 
-  1.  If |type| is "`style`" or "`style attribute`":
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
 
-      1.  If the result of executing [[#match-element-to-source-list]] on
-          |element|, this directive's <a for="directive">value</a>, |type|,
-          and |source|, is "`Does Not Match`", return "`Blocked`".
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  Return "`Allowed`".
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
 
   This directive's <a for="directive">initialization</a> algorithm is as follows:
 
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
+
+  <h4 id="directive-style-src-elem">`style-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.
+
+  <h5 algorithm id="style-src-elem-pre-request">
+    `style-src-elem` Pre-request Check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-post-request">
+    `style-src-elem` Post-request Check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-inline">
+    `style-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h4 id="directive-style-src-attr">`style-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-attr</dfn> directive governs the behaviour of style attributes.
+
+  <h5 algorithm id="style-src-attr-inline">
+    `style-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 
@@ -2929,16 +3128,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of
-      "`serviceworker`", "`sharedworker`", or "`worker`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `worker-src` and |policy| is "`No`", return "`Allowed`".
 
-      4.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and this directive's <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h5 algorithm id="worker-src-post-request">
     `worker-src` Post-request Check
@@ -2949,17 +3149,18 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
   <a for="/">policy</a> (|policy|):
 
-  1.  Assert: |policy| is unused.
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
 
-  2.  If |request|'s <a for="request">destination</a> is one of
-      "`serviceworker`", "`sharedworker`", or "`worker`":
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `worker-src` and |policy| is "`No`", return "`Allowed`".
 
-      1.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and this directive's
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
 
-  3.  Return "`Allowed`".
+  4.  Return "`Allowed`".
 
   <h3 id="directives-document">
     Document Directives
@@ -3560,7 +3761,102 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   check</a>, and <a for="directive">initialization</a> hooks in order to
   integrate themselves into Fetch and HTML.
 
-  <h3 id="algorithms">Matching Algorithms</h3>
+  <h3 id="matching-algorithms">Matching Algorithms</h3>
+
+  <h4 id="script-checks">Script directive checks</h4>
+
+  <h5 algorithm id="script-pre-request">
+    Script directives pre-request check
+  </h5>
+
+  Given a <a for="/">request</a> (|request|) and a <a>directive</a> (|directive|):
+
+  1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+
+      1.  If the result of executing [[#match-nonce-to-source-list]] on
+          |request|'s <a for="request">cryptographic nonce metadata</a> and this
+          directive's <a for="directive">value</a> is "`Matches`", return
+          "`Allowed`".
+
+      2.  Let |integrity expressions| be the set of <a>source expressions</a> in
+          |directive|'s <a for="directive">value</a> that match the
+          <a grammar>hash-source</a> grammar.
+
+      3.  If |integrity expressions| is not empty:
+
+          1.  Let |integrity sources| be the result of executing the algorithm
+              defined in [[SRI#parse-metadata]] on |request|'s
+              <a for="request">integrity metadata</a>. [[!SRI]]
+
+          2.  If |integrity sources| is "`no metadata`" or an empty set, skip
+              the remaining substeps.
+
+          3.  Let |bypass due to integrity match| be `true`.
+
+          4.  For each |source| in |integrity sources|:
+
+              1.  If |directive|'s <a for="directive">value</a> does not
+                  contain a <a>source expression</a> whose
+                  <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
+                  for |source|'s `hash-algo` component, and whose
+                  <a grammar>base64-value</a> is a <a>case-sensitive</a> match
+                  for |source|'s `base64-value`, then set |bypass due to
+                  integrity match| to `false`.
+
+          5.  If |bypass due to integrity match| is `true`, return
+              "`Allowed`".
+
+          Note: Here, we verify only that the |request| contains a set of
+          <a for="request">integrity metadata</a> which is a subset of the
+          <a grammar>hash-source</a> <a>source expressions</a> specified by
+          |directive|. We rely on the browser's enforcement of Subresource
+          Integrity [[!SRI]] to block non-matching resources upon response.
+
+      3.  If |directive|'s <a for="directive">value</a> contains a <a>source
+          expression</a> that is an <a>ASCII case-insensitive</a> match for
+          the "<a grammar>`'strict-dynamic'`</a>" <a grammar>keyword-source</a>:
+
+          1.  If the |request|'s <a for="request">parser metadata</a> is
+              <a>"parser-inserted"</a>, return "`Blocked`".
+
+              Otherwise, return "`Allowed`".
+
+              Note: "<a grammar>`'strict-dynamic'`</a>" is explained in more detail
+              in [[#strict-dynamic-usage]].
+
+      4.  If the result of executing [[#match-request-to-source-list]] on
+          |request| and |directive|'s <a for="directive">value</a> is
+          "`Does Not Match`", return "`Blocked`".
+
+  2.  Return "`Allowed`".
+
+  <h5 algorithm id="script-post-request">
+    Script directives post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a>directive</a> (|directive|):
+
+  1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
+
+      1.  If the result of executing [[#match-nonce-to-source-list]] on
+          |request|'s <a for="request">cryptographic nonce metadata</a> and this
+          directive's <a for="directive">value</a> is "`Matches`", return
+          "`Allowed`".
+
+      2.  If |directive|'s <a for="directive">value</a> contains
+          "<a grammar>`'strict-dynamic'`</a>", and |request|'s
+          <a for="request">parser metadata</a> is not <a>"parser-inserted"</a>,
+          return "`Allowed`".
+
+      3.  If the result of executing [[#match-response-to-source-list]] on
+          |response|, |request|, and |directive|'s
+          <a for="directive">value</a> is "`Does Not Match`", return
+          "`Blocked`".
+
+  2.  Return "`Allowed`".
 
   <h4 id="matching-urls">URL Matching</h4>
 
@@ -3903,69 +4199,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     9.  Return "`Matches`".
   </ol>
 
-
-  <h5 id="effective-directive-for-a-request" algorithm>
-    Get the effective directive for |request|
-  </h5>
-
-  Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
-  a <a for="/">request</a> (|request|), the following algorithm returns either
-  `null` or the <a for="directive">name</a> of the request's
-  <dfn for="request" export>effective directive</dfn>:
-
-  1.  Switch on |request|'s <a for="request">destination</a>, and execute
-      the associated steps:
-
-      : ""
-      ::
-        1.  If the |request|'s <a for="request">initiator</a> is
-            the empty string, return `connect-src`.
-      : "`manifest`"
-      ::
-        1.  Return `manifest-src`.
-      : "`object`"
-      : "`embed`"
-      ::
-        1.  Return `object-src`.
-      : "`prefetch`"
-      : "`prerender`"
-      ::
-        1.  Return `prefetch-src`.
-      : "`document`"
-      ::
-        1.  If the |request|'s <a for="request">target browsing context</a>
-            is a <a>nested browsing context</a>, return `frame-src`.
-
-      : "`audio`"
-      : "`track`"
-      : "`video`"
-      ::
-        1.  Return `media-src`.
-
-      : "`font`"
-      ::
-        1.  Return `font-src`.
-
-      : "`image`"
-      ::
-        1.  Return `img-src`.
-
-      : "`style`"
-      ::
-        1.  Return `style-src`.
-
-      : "`script`"
-      : "`xslt`"
-      ::
-        1. Return `script-src`.
-
-      : "`sharedworker`"
-      : "`worker`"
-      ::
-        1. Return `worker-src`.
-
-  2.  Return `null`.
-
   <h4 id="matching-elements">Element Matching Algorithms</h4>
 
   <h5 id="is-element-nonceable" algorithm>
@@ -4151,6 +4384,190 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       navigations.
 
   6.  Return "`Does Not Match`".
+
+  <h3 id="directive-algorithms">Directive Algorithms</h3>
+
+  <h4 id="effective-directive-for-a-request" algorithm>
+    Get the effective directive for |request|
+  </h4>
+
+  Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
+  a <a for="/">request</a> (|request|), the following algorithm returns either
+  `null` or the <a for="directive">name</a> of the request's
+  <dfn for="request" export>effective directive</dfn>:
+
+  1.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
+      <a for="request">destination</a> is "", return `connect-src`.
+
+  2.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`",
+      return `prefetch-src`.
+
+  2.  Switch on |request|'s <a for="request">destination</a>, and execute
+      the associated steps:
+
+      : "`manifest`"
+      ::
+        1.  Return `manifest-src`.
+      : "`object`"
+      : "`embed`"
+      ::
+        1.  Return `object-src`.
+      : "`document`"
+      ::
+        1.  If the |request|'s <a for="request">target browsing context</a>
+            is a <a>nested browsing context</a>, return `frame-src`.
+
+      : "`audio`"
+      : "`track`"
+      : "`video`"
+      ::
+        1.  Return `media-src`.
+
+
+      : "`font`"
+      ::
+        1.  Return `font-src`.
+
+      : "`image`"
+      ::
+        1.  Return `img-src`.
+
+      : "`style`"
+      ::
+        1.  Return `style-src-elem`.
+
+      : "`script`"
+      : "`xslt`"
+      ::
+        1. Return `script-src-elem`.
+
+      : "`serviceworker`"
+      : "`sharedworker`"
+      : "`worker`"
+      ::
+        1. Return `worker-src`.
+
+  2.  Return `null`.
+
+  <h4 id="effective-directive-for-inline-check" algorithm>
+    Get the effective directive for inline checks
+  </h4>
+
+  Given a string (|type|), this algorithm returns the <a for="directive">name</a>
+  of the effective directive.
+
+  Note: While the <a for="request">effective directive</a> is only defined for
+  <a for="/">requests</a>, in this algorithm it is used similarly to mean
+  the directive that is most relevant to a particular type of inline check.
+
+  1.  Switch on |type|:
+
+      : "`script`"
+      : "`navigation`"
+      ::
+        1.  Return `script-src-elem`.
+      : "`script attribute`"
+      ::
+        1.  Return `script-src-attr`.
+      : "`style`"
+      ::
+        1.  Return `style-src-elem`.
+      : "`style attribute`"
+      ::
+        1.  Return `style-src-attr`.
+  2.  Return `null`.
+
+  <h4 id="directive-fallback-list" algorithm>
+    Get fetch directive fallback list
+  </h4>
+
+  Will return an <a>ordered set</a> of the fallback <a>directives</a> for a specific <a>directive</a>.
+  The returned <a>ordered set</a> is sorted from most relevant to least relevant
+  and it includes the effective directive itself.
+
+  Given a string (|directive name|):
+
+  1.  Switch on |directive name|:
+
+      : "`script-src-elem`"
+      ::
+        1.  `<< "script-src-elem", "script-src", "default-src" >>`.
+
+      : "`script-src-attr`"
+      ::
+        1.  `<< "script-src-attr", "script-src", "default-src" >>`.
+
+      : "`style-src-elem`"
+      ::
+        1.  `<< "style-src-elem", "style-src", "default-src" >>`.
+
+      : "`style-src-attr`"
+      ::
+        1.  `<< "style-src-attr", "style-src", "default-src" >>`.
+
+      : "`worker-src`"
+      ::
+        1.  `<< "worker-src", "child-src", "script-src", "default-src" >>`.
+
+      : "`connect-src`"
+      ::
+        1.  `<< "connect-src", "default-src" >>`.
+
+      : "`manifest-src`"
+      ::
+        1.  `<< "manifest-src", "default-src" >>`.
+
+      : "`prefetch-src`"
+      ::
+        1.  `<< "prefetch-src", "default-src" >>`.
+
+      : "`object-src`"
+      ::
+        1.  `<< "object-src", "default-src" >>`.
+
+      : "`frame-src`"
+      ::
+        1.  `<< "frame-src", "child-src", "default-src" >>`.
+
+      : "`media-src`"
+      ::
+        1.  `<< "media-src", "default-src" >>`.
+
+      : "`font-src`"
+      ::
+        1.  `<< "font-src", "default-src" >>`.
+
+      : "`image-src`"
+      ::
+        1.  `<< "image-src", "default-src" >>`.
+
+  2.  Return `<< >>`.
+
+  <h4 id="should-directive-execute" algorithm>
+    Should fetch directive execute
+  </h4>
+
+  This algorithm is used for <a>fetch directives</a> to decide whether a directive
+  should execute or defer to a different directive that is better suited.
+  For example: if the |effective directive name| is `worker-src` (meaning that
+  we are currently checking a worker request), a `default-src` directive
+  should not execute if a `worker-src` or `script-src` directive exists.
+
+  Given a string (|effective directive name|), a string (|directive name|) and
+  a <a for="/">policy</a> (|policy|):
+
+  1.  Let |directive fallback list| be the result of executing [[#directive-fallback-list]]
+      on |effective directive name|.
+
+  2.  For each |fallback directive| in |directive fallback list|:
+
+      1.  If |directive name| is |fallback directive|, Return "`Yes`".
+
+      2.  If |policy| contains a directive whose <a for="directive">name</a>
+          is |fallback directive|,  Return "`No`".
+
+  3.  Return "`No`".
+
 </section>
 
 <!-- Big text: Security -->

--- a/index.src.html
+++ b/index.src.html
@@ -2021,8 +2021,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> <a grammar>'self'</a>;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> <a grammar>'self'</a>;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2035,7 +2037,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2049,8 +2051,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src</a> https://example.com;
-                               <a>style-src</a> <a grammar>'self'</a>;
+                               <a>script-src-elem</a> https://example.com;
+                               <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>style-src-elem</a> <a grammar>'self'</a>;
+                               <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2732,6 +2736,118 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   5.  Return "`Allowed`".
 
+  <h4 id="directive-script-src-elem">`script-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
+  except for script attributes.
+
+  As such, the following differences exist when comparing to `script-src`:
+  * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
+    (and is ignored for "`script attribute`" inline checks).
+  * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
+    execution sink checks that are gated on the "`unsafe-eval`" check.
+  * `script-src-elem` is not used as a fallback for the `worker-src` directive.
+    The `worker-src` checks still fall back on the `script-src` directive.
+
+  <h5 algorithm id="script-src-elem-pre-request">
+    `script-src-elem` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
+
+  <h5 algorithm id="script-src-elem-post-request">
+    `script-src-elem` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  Return the result of executing [[#script-post-request]] on |request|,
+      |response| and this directive.
+
+  <h5 algorithm id="script-src-elem-inline">
+    `script-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-script-src-attr">`script-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "script-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>script-src-attr</dfn> directive applies to event handlers and, if present,
+  it will superseed the `script-src` directive for relevant checks.
+
+  <h5 algorithm id="script-src-attr-inline">
+    `script-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Assert: |element| is not `null` or |type| is "`navigation`".
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `script-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
   <h4 id="directive-style-src">`style-src`</h4>
 
   The <dfn export>style-src</dfn> directive restricts the locations from which style
@@ -2856,6 +2972,123 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
+
+  <h4 id="directive-style-src-elem">`style-src-elem`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-elem"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-elem</dfn> directive governs the behaviour of styles
+  except for styles defined in inline attributes.
+
+  <h5 algorithm id="style-src-elem-pre-request">
+    `style-src-elem` Pre-request Check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-request-to-source-list]] on
+      |request| and this directive's <a for="directive">value</a> is
+      "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-post-request">
+    `style-src-elem` Post-request Check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-nonce-to-source-list]] on
+      |request|'s <a for="request">cryptographic nonce metadata</a> and this
+      directive's <a for="directive">value</a> is "`Matches`", return
+      "`Allowed`".
+
+  4.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, and this directive's
+      <a for="directive">value</a> is "`Does Not Match`", return
+      "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h5 algorithm id="style-src-elem-inline">
+    `style-src-elem` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h4 id="directive-style-src-attr">`style-src-attr`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "style-src-attr"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>style-src-attr</dfn> directive governs the behaviour of style attributes.
+
+  <h5 algorithm id="style-src-attr-inline">
+    `style-src-attr` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
+  (|policy|) and a string (|source|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `style-src-attr` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 
@@ -4201,12 +4434,12 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`style`"
       ::
-        1.  Return `style-src`.
+        1.  Return `style-src-elem`.
 
       : "`script`"
       : "`xslt`"
       ::
-        1. Return `script-src`.
+        1. Return `script-src-elem`.
 
       : "`serviceworker`"
       : "`sharedworker`"
@@ -4231,15 +4464,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`script`"
       : "`navigation`"
+      ::
+        1.  Return `script-src-elem`.
       : "`script attribute`"
       ::
-        1.  Return `script-src`.
-
+        1.  Return `script-src-attr`.
       : "`style`"
+      ::
+        1.  Return `style-src-elem`.
       : "`style attribute`"
       ::
-        1.  Return `style-src`.
-
+        1.  Return `style-src-attr`.
   2.  Return `null`.
 
   <h4 id="directive-fallback-list" algorithm>
@@ -4254,13 +4489,21 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Switch on |directive name|:
 
-      : "`script-src`"
+      : "`script-src-elem`"
       ::
-        1.  `<< script-src", "default-src" >>`.
+        1.  `<< "script-src-elem", "script-src", "default-src" >>`.
 
-      : "`style-src`"
+      : "`script-src-attr`"
       ::
-        1.  `<< "style-src", "default-src" >>`.
+        1.  `<< "script-src-attr", "script-src", "default-src" >>`.
+
+      : "`style-src-elem`"
+      ::
+        1.  `<< "style-src-elem", "style-src", "default-src" >>`.
+
+      : "`style-src-attr`"
+      ::
+        1.  `<< "style-src-attr", "style-src", "default-src" >>`.
 
       : "`worker-src`"
       ::

--- a/index.src.html
+++ b/index.src.html
@@ -364,6 +364,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   13. Reports generated for inline violations will contain a <a for="violation">sample</a>
       attribute if the relevant directive contains the <a grammar>`'report-sample'`</a>
       expression.
+
+  14. Extra directives are added that provide granularity for script and style
+      attributes and elements. As such these new directives <a>`script-src-elem`</a>,
+      <a>`script-src-attr`</a>, <a>`style-src-elem`</a> and <a>`style-src-attr`</a>
+      are added.
 </section>
 
 <!-- Big Text: Framework -->
@@ -2021,10 +2026,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> <a grammar>'self'</a>;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> <a grammar>'self'</a>;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2037,7 +2040,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2051,10 +2054,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> https://example.com;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> https://example.com;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2746,9 +2747,12 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   </pre>
 
   The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.
+  except for script attributes which are covered by `script-src-attr`.
+  While in most cases policy authors will find it easier to simply use `script-src`,
+  there are scenarios in which it it useful to be able to apply a policy that
+  does not apply to event handlers.
 
-  As such, the following differences exist when comparing to `script-src`:
+  The following differences exist when comparing to `script-src`:
   * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
     (and is ignored for "`script attribute`" inline checks).
   * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
@@ -4901,7 +4905,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
         &lt;button id="action" onclick="doSubmit()"&gt;
       </pre>
 
-      Rather than reducing security by specifying "`'unsafe-inline'`", they decide to use
+      Rather than reducing security severly by specifying "`'unsafe-inline'`", they decide to use
       "`'unsafe-hashes'`" along with a hash source expression, as follows:
 
       <pre>
@@ -4917,6 +4921,24 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     `<script>transferAllMyMoney()</script>`. Developers should be careful to balance the risk of
     allowing specific scripts to execute against the deployment advantages that allowing inline
     event handlers might provide.
+
+    Using the new `script-src-elem` and `script-src-attr`, a policy can be written
+    that is compatible with CSP2 or older user agents while keeping the `'unsafe-hashes'`
+    features.
+
+    <div class="example">
+      MegaCorp, Inc. wants to ensure that the above policy does not break the site
+      if user agents don't implement CSP3 features. The presence of a
+      hash source disables inline behaviour in CSP2 so the `onclick` action is blocked.
+
+      In order to achieve this, the following policy is developed:
+      <pre>
+        <a>Content-Security-Policy</a>:
+          <a>script-src</a> <a grammar>'unsafe-inline'</a>;
+          <a>script-src-attr</a> <a grammar>'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=';
+          <a>script-src-elem</a> 'nonce-abc'; # or some other appropriate reasonable policy.
+      </pre>
+    </div>
   </section>
 
   <section>

--- a/index.src.html
+++ b/index.src.html
@@ -2021,10 +2021,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> <a grammar>'self'</a>;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> <a grammar>'self'</a>;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2037,7 +2035,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     script requests. That is, the following header:
 
     <pre>
-      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src-elem</a> https://example.com
+      <a>Content-Security-Policy</a>: <a>default-src</a> <a grammar>'self'</a>; <a>script-src</a> https://example.com
     </pre>
 
     will have the same behavior as the following header:
@@ -2051,10 +2049,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                                <a>media-src</a> <a grammar>'self'</a>;
                                <a>prefetch-src</a> <a grammar>'self'</a>;
                                <a>object-src</a> <a grammar>'self'</a>;
-                               <a>script-src-elem</a> https://example.com;
-                               <a>script-src-attr</a> <a grammar>'self'</a>;
-                               <a>style-src-elem</a> <a grammar>'self'</a>;
-                               <a>style-src-attr</a> <a grammar>'self'</a>;
+                               <a>script-src</a> https://example.com;
+                               <a>style-src</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
     </pre>
 
@@ -2736,118 +2732,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   5.  Return "`Allowed`".
 
-  <h4 id="directive-script-src-elem">`script-src-elem`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "script-src-elem"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>script-src-elem</dfn> directive applies to all script requests and inline checks
-  except for script attributes.
-
-  As such, the following differences exist when comparing to `script-src`:
-  * `script-src-elem` only applies to "`script`" and "`navigation`" inline checks
-    (and is ignored for "`script attribute`" inline checks).
-  * `script-src-elem`'s <a for="directive">value</a> is not used for JavaScript
-    execution sink checks that are gated on the "`unsafe-eval`" check.
-  * `script-src-elem` is not used as a fallback for the `worker-src` directive.
-    The `worker-src` checks still fall back on the `script-src` directive.
-
-  <h5 algorithm id="script-src-elem-pre-request">
-    `script-src-elem` Pre-request check
-  </h5>
-
-  This directive's <a for="directive">pre-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
-
-  <h5 algorithm id="script-src-elem-post-request">
-    `script-src-elem` Post-request check
-  </h5>
-
-  This directive's <a for="directive">post-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  Return the result of executing [[#script-post-request]] on |request|,
-      |response| and this directive.
-
-  <h5 algorithm id="script-src-elem-inline">
-    `script-src-elem` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Assert: |element| is not `null` or |type| is "`navigation`".
-
-  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  3.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  4.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h4 id="directive-script-src-attr">`script-src-attr`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "script-src-attr"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>script-src-attr</dfn> directive applies to event handlers and, if present,
-  it will superseed the `script-src` directive for relevant checks.
-
-  <h5 algorithm id="script-src-attr-inline">
-    `script-src-attr` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Assert: |element| is not `null` or |type| is "`navigation`".
-
-  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  3.  If the result of executing [[#should-directive-execute]] on |name|,
-      `script-src-attr` and |policy| is "`No`", return "`Allowed`".
-
-  4.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
   <h4 id="directive-style-src">`style-src`</h4>
 
   The <dfn export>style-src</dfn> directive restricts the locations from which style
@@ -2972,123 +2856,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   ISSUE: Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don't think CSSOM gives us any hooks here, so
   let's work with them to put something reasonable together.
-
-  <h4 id="directive-style-src-elem">`style-src-elem`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "style-src-elem"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>style-src-elem</dfn> directive governs the behaviour of styles
-  except for styles defined in inline attributes.
-
-  <h5 algorithm id="style-src-elem-pre-request">
-    `style-src-elem` Pre-request Check
-  </h5>
-
-  This directive's <a for="directive">pre-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-nonce-to-source-list]] on
-      |request|'s <a for="request">cryptographic nonce metadata</a> and this
-      directive's <a for="directive">value</a> is "`Matches`", return
-      "`Allowed`".
-
-  4.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h5 algorithm id="style-src-elem-post-request">
-    `style-src-elem` Post-request Check
-  </h5>
-
-  This directive's <a for="directive">post-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-nonce-to-source-list]] on
-      |request|'s <a for="request">cryptographic nonce metadata</a> and this
-      directive's <a for="directive">value</a> is "`Matches`", return
-      "`Allowed`".
-
-  4.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
-
-  5.  Return "`Allowed`".
-
-  <h5 algorithm id="style-src-elem-inline">
-    `style-src-elem` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-elem` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
-
-  <h4 id="directive-style-src-attr">`style-src-attr`</h4>
-
-  The syntax for the directive's name and value is described by the following ABNF:
-
-  <pre>
-    directive-name  = "style-src-attr"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  The <dfn export>style-src-attr</dfn> directive governs the behaviour of style attributes.
-
-  <h5 algorithm id="style-src-attr-inline">
-    `style-src-attr` Inline Check
-  </h5>
-
-  This directive's <a for="directive">inline check</a> algorithm is as follows:
-
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
-      on |type|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `style-src-attr` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-element-to-source-list]] on
-      |element|, this directive's <a for="directive">value</a>, |type|,
-      and |source|, is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
 
   <h4 id="directive-worker-src">`worker-src`</h4>
 
@@ -4434,12 +4201,12 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`style`"
       ::
-        1.  Return `style-src-elem`.
+        1.  Return `style-src`.
 
       : "`script`"
       : "`xslt`"
       ::
-        1. Return `script-src-elem`.
+        1. Return `script-src`.
 
       : "`serviceworker`"
       : "`sharedworker`"
@@ -4464,17 +4231,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
       : "`script`"
       : "`navigation`"
-      ::
-        1.  Return `script-src-elem`.
       : "`script attribute`"
       ::
-        1.  Return `script-src-attr`.
+        1.  Return `script-src`.
+
       : "`style`"
-      ::
-        1.  Return `style-src-elem`.
       : "`style attribute`"
       ::
-        1.  Return `style-src-attr`.
+        1.  Return `style-src`.
+
   2.  Return `null`.
 
   <h4 id="directive-fallback-list" algorithm>
@@ -4489,21 +4254,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   1.  Switch on |directive name|:
 
-      : "`script-src-elem`"
+      : "`script-src`"
       ::
-        1.  `<< "script-src-elem", "script-src", "default-src" >>`.
+        1.  `<< script-src", "default-src" >>`.
 
-      : "`script-src-attr`"
+      : "`style-src`"
       ::
-        1.  `<< "script-src-attr", "script-src", "default-src" >>`.
-
-      : "`style-src-elem`"
-      ::
-        1.  `<< "style-src-elem", "style-src", "default-src" >>`.
-
-      : "`style-src-attr`"
-      ::
-        1.  `<< "style-src-attr", "style-src", "default-src" >>`.
+        1.  `<< "style-src", "default-src" >>`.
 
       : "`worker-src`"
       ::


### PR DESCRIPTION
Added `script-src-elem`, `script-src-attr`, `style-src-elem`, `style-src-attr`.
Added example in `unsafe-hashes` for backwards compatibility.
Added to changes from Lvl 2 section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/319.html" title="Last updated on Jul 12, 2018, 2:47 PM GMT (01add29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/319/af505e8...andypaicu:01add29.html" title="Last updated on Jul 12, 2018, 2:47 PM GMT (01add29)">Diff</a>