### PR TITLE
Added {script/style}-src-{attr/elem} to the iana registry section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 090ef96cbce74475c89e94394cc8fa4fbc08b477" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="3ff48504a825497488802db3b3d0e677bc88629a" name="document-revision">
+  <meta content="db00b3e35f6b4c282cc8e798b82d08b8f450cc1e" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -5625,9 +5625,21 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
      <dt data-md><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
+     <dt data-md><a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr⑤"><code>script-src-attr</code></a>
+     <dd data-md>
+      <p>This document (see <a href="#directive-script-src-attr">§6.1.13 script-src-attr</a>)</p>
+     <dt data-md><a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem⑤"><code>script-src-elem</code></a>
+     <dd data-md>
+      <p>This document (see <a href="#directive-script-src-elem">§6.1.12 script-src-elem</a>)</p>
      <dt data-md><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
+     <dt data-md><a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr②"><code>style-src-attr</code></a>
+     <dd data-md>
+      <p>This document (see <a href="#directive-style-src-attr">§6.1.16 style-src-attr</a>)</p>
+     <dt data-md><a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem②"><code>style-src-elem</code></a>
+     <dd data-md>
+      <p>This document (see <a href="#directive-style-src-elem">§6.1.15 style-src-elem</a>)</p>
      <dt data-md><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
@@ -9596,6 +9608,8 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
     <li><a href="#ref-for-script-src-elem③">6.1.11. script-src</a> <a href="#ref-for-script-src-elem④">(2)</a>
+    <li><a href="#ref-for-script-src-elem⑤">10.1. 
+    Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="script-src-attr">
@@ -9604,6 +9618,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
     <li><a href="#ref-for-script-src-attr②">6.1.11. script-src</a> <a href="#ref-for-script-src-attr③">(2)</a>
     <li><a href="#ref-for-script-src-attr④">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-script-src-attr⑤">10.1. 
+    Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src">
@@ -9618,12 +9634,16 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
+    <li><a href="#ref-for-style-src-elem②">10.1. 
+    Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="style-src-attr">
    <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
+    <li><a href="#ref-for-style-src-attr②">10.1. 
+    Directive Registry </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="worker-src">

--- a/index.src.html
+++ b/index.src.html
@@ -5004,8 +5004,16 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   ::  This document (see [[#directive-sandbox]])
   :   <a>`script-src`</a>
   ::  This document (see [[#directive-script-src]])
+  :   <a>`script-src-attr`</a>
+  ::  This document (see [[#directive-script-src-attr]])
+  :   <a>`script-src-elem`</a>
+  ::  This document (see [[#directive-script-src-elem]])
   :   <a>`style-src`</a>
   ::  This document (see [[#directive-style-src]])
+  :   <a>`style-src-attr`</a>
+  ::  This document (see [[#directive-style-src-attr]])
+  :   <a>`style-src-elem`</a>
+  ::  This document (see [[#directive-style-src-elem]])
   :   <a>`worker-src`</a>
   ::  This document (see [[#directive-worker-src]])
 


### PR DESCRIPTION
This should have been part of https://github.com/w3c/webappsec-csp/pull/325 but was missed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/328.html" title="Last updated on Sep 12, 2018, 4:31 PM GMT (e9bb58c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/328/52b7162...andypaicu:e9bb58c.html" title="Last updated on Sep 12, 2018, 4:31 PM GMT (e9bb58c)">Diff</a>