### PR TITLE
Various bikeshed warnings and errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,23 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a04b880cde96bf0ae2d14a0edcf2bcdcb631548b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
   <meta content="c3f850d546bf3158ca233863092de80bb467aea6" name="document-revision">
+=======
+<<<<<<< HEAD
+  <meta content="0055c7f13e06821b3f14048ca3281e1d33b449c6" name="document-revision">
+=======
+<<<<<<< HEAD
+  <meta content="0421c1f3ef37566eb9e17f83e73fa6d134b8226f" name="document-revision">
+=======
+<<<<<<< HEAD
+  <meta content="db00b3e35f6b4c282cc8e798b82d08b8f450cc1e" name="document-revision">
+=======
+  <meta content="52b71625bd6ed7123615e9d7c159f9ad805a5ba7" name="document-revision">
+>>>>>>> bikeshed warnings and errors
+>>>>>>> bikeshed warnings and errors
+>>>>>>> bikeshed warnings and errors
+>>>>>>> bikeshed warnings and errors
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -3264,7 +3280,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①">serialized-source-list</a>
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⓪">requests</a> which transmit or receive data from
-  other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute" id="ref-for-AElementPingAttribute">ping</a></code>. This directive <em>also</em> controls
+  other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping" id="ref-for-dom-a-ping">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
     <div class="example" id="example-c53bdcd0">
@@ -5004,7 +5020,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
         <ol>
          <li data-md>
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑦"><code>nonce-source</code></a> grammar,
-  and <var>element</var> has a <code class="idl"><a data-link-type="idl">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
+  and <var>element</var> has a <code><a data-link-type="element-sub">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑧">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a></code>, not to
@@ -5477,7 +5493,7 @@ Content-Security-Policy: connect-src http://example.com/;
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
-    will not be blocked because of the matching <code class="idl"><a data-link-type="idl">nonce</a></code> attribute.</p>
+    will not be blocked because of the matching <code><a data-link-type="element-sub">nonce</a></code> attribute.</p>
      <p>If <code>script.js</code> contains the following code:</p>
 <pre class="highlight"><c- a>var</c-> s <c- o>=</c-> document<c- p>.</c->createElement<c- p>(</c-><c- t>'script'</c-><c- p>);</c->
 s<c- p>.</c->src <c- o>=</c-> <c- t>'https://othercdn.not-example.net/dependency.js'</c-><c- p>;</c->
@@ -7064,6 +7080,12 @@ rest of Google’s CSP Cabal.</p>
     Is element nonceable? </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-a-ping">
+   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping">https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-a-ping">6.1.2. connect-src</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-plugin-document">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document</a><b>Referenced in:</b>
    <ul>
@@ -7577,12 +7599,6 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-AElementPingAttribute">
-   <a href="https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute">https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-AElementPingAttribute">6.1.2. connect-src</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-url">
    <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
@@ -7879,6 +7895,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
      <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
      <li><span class="dfn-paneled" id="term-for-concept-script-parse-error" style="color:initial">parse error</span>
+     <li><span class="dfn-paneled" id="term-for-dom-a-ping" style="color:initial">ping</span>
      <li><span class="dfn-paneled" id="term-for-plugin-document" style="color:initial">plugin document</span>
      <li><span class="dfn-paneled" id="term-for-prepare-a-script" style="color:initial">prepare a script</span>
      <li><span class="dfn-paneled" id="term-for-process-a-navigate-fetch" style="color:initial">process a navigate fetch</span>
@@ -7979,16 +7996,11 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-serviceworkerglobalscope" style="color:initial">ServiceWorkerGlobalScope</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[SHA2]</a> defines the following terms:
+    <a data-link-type="biblio">[sha2]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-" style="color:initial">sha-256</span>
      <li><span class="dfn-paneled" id="term-for-①" style="color:initial">sha-384</span>
      <li><span class="dfn-paneled" id="term-for-②" style="color:initial">sha-512</span>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[SVG2]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-AElementPingAttribute" style="color:initial">ping</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -8070,12 +8082,8 @@ rest of Google’s CSP Cabal.</p>
    <dd>M. Nottingham. <a href="https://tools.ietf.org/html/rfc8288">Web Linking</a>. October 2017. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc8288">https://tools.ietf.org/html/rfc8288</a>
    <dt id="biblio-service-workers-2">[SERVICE-WORKERS-2]
    <dd>Service Workers URL: <a href="https://w3c.github.io/ServiceWorker/">https://w3c.github.io/ServiceWorker/</a>
-   <dt id="biblio-sha2">[SHA2]
-   <dd><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">FIPS PUB 180-4, Secure Hash Standard</a>. URL: <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf</a>
    <dt id="biblio-sri">[SRI]
    <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
-   <dt id="biblio-svg2">[SVG2]
-   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 7 August 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]

--- a/index.html
+++ b/index.html
@@ -1216,10 +1216,13 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   <meta content="c3f850d546bf3158ca233863092de80bb467aea6" name="document-revision">
 =======
 =======
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+=======
+>>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
 <<<<<<< HEAD
   <meta content="0055c7f13e06821b3f14048ca3281e1d33b449c6" name="document-revision">
 =======
@@ -1244,7 +1247,13 @@ Possible extra rowspan handling
   <meta content="ad0695a78eb683e2d2c39b82f31df87bfe39a8ee" name="document-revision">
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+<<<<<<< HEAD
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+=======
+=======
+  <meta content="085539294a0bb1b0d04aabc26317cc02b7077785" name="document-revision">
+>>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
+>>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1536,6 +1545,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
 <<<<<<< HEAD
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-17">17 September 2018</time></span></h2>
 =======
 <<<<<<< HEAD
@@ -1544,6 +1554,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-13">13 September 2018</time></span></h2>
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
 >>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
+>>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.html
+++ b/index.html
@@ -1214,46 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version a04b880cde96bf0ae2d14a0edcf2bcdcb631548b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-  <meta content="c3f850d546bf3158ca233863092de80bb467aea6" name="document-revision">
-=======
-=======
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
-=======
->>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
-<<<<<<< HEAD
-  <meta content="0055c7f13e06821b3f14048ca3281e1d33b449c6" name="document-revision">
-=======
-=======
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
-<<<<<<< HEAD
-  <meta content="0421c1f3ef37566eb9e17f83e73fa6d134b8226f" name="document-revision">
-=======
-<<<<<<< HEAD
-  <meta content="db00b3e35f6b4c282cc8e798b82d08b8f450cc1e" name="document-revision">
-=======
-  <meta content="52b71625bd6ed7123615e9d7c159f9ad805a5ba7" name="document-revision">
->>>>>>> bikeshed warnings and errors
->>>>>>> bikeshed warnings and errors
-<<<<<<< HEAD
->>>>>>> bikeshed warnings and errors
-<<<<<<< HEAD
->>>>>>> bikeshed warnings and errors
-=======
-=======
-=======
-  <meta content="ad0695a78eb683e2d2c39b82f31df87bfe39a8ee" name="document-revision">
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
-<<<<<<< HEAD
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
-=======
-=======
-  <meta content="085539294a0bb1b0d04aabc26317cc02b7077785" name="document-revision">
->>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
->>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
+  <meta content="9cd15db6ac837bfdf4329a9e8ed1cb70cd676863" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1544,19 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-17">17 September 2018</time></span></h2>
-=======
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-13">13 September 2018</time></span></h2>
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
->>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
->>>>>>> Renamed <{HTMLOrSVGElement/nonce}>to <{htmlsvg-global/nonce}>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-19">19 September 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.html
+++ b/index.html
@@ -1215,11 +1215,16 @@ Possible extra rowspan handling
   <meta content="Bikeshed version a04b880cde96bf0ae2d14a0edcf2bcdcb631548b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
 <<<<<<< HEAD
+<<<<<<< HEAD
   <meta content="c3f850d546bf3158ca233863092de80bb467aea6" name="document-revision">
 =======
+=======
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
 <<<<<<< HEAD
   <meta content="0055c7f13e06821b3f14048ca3281e1d33b449c6" name="document-revision">
 =======
+=======
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
 <<<<<<< HEAD
   <meta content="0421c1f3ef37566eb9e17f83e73fa6d134b8226f" name="document-revision">
 =======
@@ -1229,8 +1234,17 @@ Possible extra rowspan handling
   <meta content="52b71625bd6ed7123615e9d7c159f9ad805a5ba7" name="document-revision">
 >>>>>>> bikeshed warnings and errors
 >>>>>>> bikeshed warnings and errors
+<<<<<<< HEAD
 >>>>>>> bikeshed warnings and errors
+<<<<<<< HEAD
 >>>>>>> bikeshed warnings and errors
+=======
+=======
+=======
+  <meta content="ad0695a78eb683e2d2c39b82f31df87bfe39a8ee" name="document-revision">
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1521,7 +1535,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-17">17 September 2018</time></span></h2>
+=======
+<<<<<<< HEAD
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-13">13 September 2018</time></span></h2>
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
+>>>>>>> Replaced <{NoncedElement/nonce}> with <{HTMLOrSVGElement/nonce}>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.src.html
+++ b/index.src.html
@@ -36,6 +36,8 @@ spec:html
     text: link
     text: script
     text: style
+  type: element-attr
+    text: ping
 spec:fetch
   type: dfn
     text: main fetch
@@ -152,10 +154,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     "href": "https://tc39.github.io/ecma262/",
     "title": "ECMAScript® Language Specification",
     "publisher": "ECMA"
-  },
-  "SHA2": {
-    "href": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf",
-    "title": "FIPS PUB 180-4, Secure Hash Standard"
   },
   "REPORTING": {
     "href": "https://wicg.github.io/reporting/",
@@ -4296,7 +4294,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       1.  For each |expression| in |list|:
 
           1.  If |expression| matches the <a grammar>`nonce-source`</a> grammar,
-              and |element| has a {{NoncedElement/nonce}} attribute whose value is a
+              and |element| has a <{NoncedElement/nonce}> attribute whose value is a
               <a>case-sensitive</a> match for |expression|'s
               <a grammar>`base64-value`</a> part, return "`Matches`".
 
@@ -4828,7 +4826,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     </pre>
 
     This will generate a request for `https://cdn.example.com/script.js`, which
-    will not be blocked because of the matching {{NoncedElement/nonce}} attribute.
+    will not be blocked because of the matching <{NoncedElement/nonce}> attribute.
 
     If `script.js` contains the following code:
 

--- a/index.src.html
+++ b/index.src.html
@@ -4294,7 +4294,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       1.  For each |expression| in |list|:
 
           1.  If |expression| matches the <a grammar>`nonce-source`</a> grammar,
-              and |element| has a <{NoncedElement/nonce}> attribute whose value is a
+              and |element| has a <{HTMLOrSVGElement/nonce}> attribute whose value is a
               <a>case-sensitive</a> match for |expression|'s
               <a grammar>`base64-value`</a> part, return "`Matches`".
 
@@ -4826,7 +4826,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     </pre>
 
     This will generate a request for `https://cdn.example.com/script.js`, which
-    will not be blocked because of the matching <{NoncedElement/nonce}> attribute.
+    will not be blocked because of the matching <{HTMLOrSVGElement/nonce}> attribute.
 
     If `script.js` contains the following code:
 

--- a/index.src.html
+++ b/index.src.html
@@ -4294,7 +4294,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       1.  For each |expression| in |list|:
 
           1.  If |expression| matches the <a grammar>`nonce-source`</a> grammar,
-              and |element| has a <{HTMLOrSVGElement/nonce}> attribute whose value is a
+              and |element| has a <{htmlsvg-global/nonce}> attribute whose value is a
               <a>case-sensitive</a> match for |expression|'s
               <a grammar>`base64-value`</a> part, return "`Matches`".
 
@@ -4826,7 +4826,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     </pre>
 
     This will generate a request for `https://cdn.example.com/script.js`, which
-    will not be blocked because of the matching <{HTMLOrSVGElement/nonce}> attribute.
+    will not be blocked because of the matching <{htmlsvg-global/nonce}> attribute.
 
     If `script.js` contains the following code:
 


### PR DESCRIPTION
There are currently 3 warning/errors that occur when building the spec

`WARNING: The following locally-defined biblio entries are unused and can be removed:
SHA2`

`LINK ERROR: Multiple possible 'ping' element-sub refs for 'a'.
Arbitrarily chose https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
spec:html; type:element-attr; text:ping
spec:svg2; type:element-attr; text:ping
<{a/ping}>`

`LINK ERROR: No 'idl' refs found for 'nonce' with for='NoncedElement'.`

The first two are easily fixed.

The third one is related to https://github.com/w3c/webappsec-csp/pull/285 which I will close in favor of this. I have changed the reference to `<{NoncedElement/nonce}>` but there is some poking towards the HTML spec. @mikewest or @annevk could you help me with that? I'm not sure where to start.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/329.html" title="Last updated on Sep 19, 2018, 5:54 PM GMT (0c56b93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/329/46bc83c...andypaicu:0c56b93.html" title="Last updated on Sep 19, 2018, 5:54 PM GMT (0c56b93)">Diff</a>