### PR TITLE
websocket example url

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 090ef96cbce74475c89e94394cc8fa4fbc08b477" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="db00b3e35f6b4c282cc8e798b82d08b8f450cc1e" name="document-revision">
+  <meta content="0421c1f3ef37566eb9e17f83e73fa6d134b8226f" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-12">12 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3265,8 +3265,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute" id="ref-for-AElementPingAttribute">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
-    <div class="example" id="example-e13881a4">
-     <a class="self-link" href="#example-e13881a4"></a> JavaScript offers a few mechanisms that directly connect to an external
+    <div class="example" id="example-c53bdcd0">
+     <a class="self-link" href="#example-c53bdcd0"></a> JavaScript offers a few mechanisms that directly connect to an external
     server to send or receive information. <code>EventSource</code> maintains an open
     HTTP connection to a server in order to receive push notifications, <code>WebSockets</code> open a bidirectional communication channel between your
     browser and a server, and <code>XMLHttpRequest</code> makes arbitrary HTTP requests
@@ -3286,7 +3286,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   xhr<c- p>.</c->open<c- p>(</c-><c- t>'GET'</c-><c- p>,</c-> <c- t>'https://example.org/'</c-><c- p>);</c->
   xhr<c- p>.</c->send<c- p>();</c->
 
-  <c- a>var</c-> ws <c- o>=</c-> <c- k>new</c-> WebSocket<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
+  <c- a>var</c-> ws <c- o>=</c-> <c- k>new</c-> WebSocket<c- p>(</c-><c- u>"wss://example.org/"</c-><c- p>);</c->
 
   <c- a>var</c-> es <c- o>=</c-> <c- k>new</c-> EventSource<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
 

--- a/index.src.html
+++ b/index.src.html
@@ -1926,7 +1926,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
         xhr.open('GET', 'https://example.org/');
         xhr.send();
 
-        var ws = new WebSocket("https://example.org/");
+        var ws = new WebSocket("wss://example.org/");
 
         var es = new EventSource("https://example.org/");
 


### PR DESCRIPTION
Quick example URL fix
https://github.com/w3c/webappsec-csp/issues/286


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/330.html" title="Last updated on Sep 14, 2018, 8:20 AM GMT (f7d141d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/330/0421c1f...andypaicu:f7d141d.html" title="Last updated on Sep 14, 2018, 8:20 AM GMT (f7d141d)">Diff</a>