### PR TITLE
Remove the ISSUE that states that CSP lists are missing from workers

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1081,8 +1081,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
       active for a given context. This list is empty unless otherwise specified,
       and is populated via the [[#initialize-global-object-csp]] algorithm.
 
-      ISSUE(w3c/html#187): This concept is missing from W3C's Workers.
-
   2.  A <a for="/">global object</a>'s <dfn for="global object" id="global-object-csp-list">CSP list</dfn>
       is the result of executing [[#get-csp-of-object]] with the <a for="/">global object</a>
       as the `object`.


### PR DESCRIPTION
I believe this has been addressed in the mean-time:
https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-csp-list


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/334.html" title="Last updated on Sep 17, 2018, 4:54 PM GMT (922e369)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/334/c3f850d...andypaicu:922e369.html" title="Last updated on Sep 17, 2018, 4:54 PM GMT (922e369)">Diff</a>