### PR TITLE
Specified worker-src in script-src description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 090ef96cbce74475c89e94394cc8fa4fbc08b477" name="generator">
+  <meta content="Bikeshed version a04b880cde96bf0ae2d14a0edcf2bcdcb631548b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="0055c7f13e06821b3f14048ca3281e1d33b449c6" name="document-revision">
+  <meta content="c3f850d546bf3158ca233863092de80bb467aea6" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-14">14 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-17">17 September 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3760,7 +3760,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="script-src">script-src</dfn> directive restricts the locations from which scripts
   may be executed. This includes not only URLs loaded directly into <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script③">script</a></code> elements, but also things like inline script blocks and XSLT stylesheets <a data-link-type="biblio" href="#biblio-xslt">[XSLT]</a> which can trigger script execution. The syntax for the directive’s
   name and value is described by the following ABNF:</p>
-    <p>The <code>script-src</code> directive acts as a default fallback for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a> destinations. Unless granularity is desired <code>script-src</code> should
+    <p>The <code>script-src</code> directive acts as a default fallback for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a> destinations (including worker-specific destinations if <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②"><code>worker-src</code></a> is not present). Unless granularity is desired <code>script-src</code> should
   be used in favor of <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr②"><code>script-src-attr</code></a> and <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem③"><code>script-src-elem</code></a> as in most situations there is no particular reason to have separate lists of
   permissions for inline event handlers and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script④">script</a></code> elements.</p>
 <pre>directive-name  = "script-src"
@@ -4102,7 +4102,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <div class="example" id="example-4dad9e58">
      <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
-<pre>Content-Security-Policy: <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②">worker-src</a> https://example.com/
+<pre>Content-Security-Policy: <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③">worker-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
@@ -5640,7 +5640,7 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
      <dt data-md><a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem②"><code>style-src-elem</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-style-src-elem">§6.1.15 style-src-elem</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③"><code>worker-src</code></a>
+     <dt data-md><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src④"><code>worker-src</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
     </dl>
@@ -9650,8 +9650,9 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
-    <li><a href="#ref-for-worker-src②">6.1.17. worker-src</a>
-    <li><a href="#ref-for-worker-src③">10.1. 
+    <li><a href="#ref-for-worker-src②">6.1.11. script-src</a>
+    <li><a href="#ref-for-worker-src③">6.1.17. worker-src</a>
+    <li><a href="#ref-for-worker-src④">10.1. 
     Directive Registry </a>
    </ul>
   </aside>

--- a/index.src.html
+++ b/index.src.html
@@ -2642,7 +2642,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   name and value is described by the following ABNF:
 
   The `script-src` directive acts as a default fallback for all <a for="request/destination">script-like</a>
-  destinations. Unless granularity is desired `script-src` should
+  destinations (including worker-specific destinations if <a>`worker-src`</a>
+  is not present). Unless granularity is desired `script-src` should
   be used in favor of <a>`script-src-attr`</a> and <a>`script-src-elem`</a>
   as in most situations there is no particular reason to have separate lists of
   permissions for inline event handlers and <{script}> elements.


### PR DESCRIPTION
Related issue: https://github.com/w3c/webappsec-csp/issues/234


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/335.html" title="Last updated on Sep 17, 2018, 5:02 PM GMT (1fbd106)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/335/c3f850d...andypaicu:1fbd106.html" title="Last updated on Sep 17, 2018, 5:02 PM GMT (1fbd106)">Diff</a>