### PR TITLE
Fixing whitespace issues and 2 comments in the area

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-<<<<<<< HEAD
   <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
 <<<<<<< HEAD
   <meta content="6ee5a338b8c7262e5f7b4a894a196c642b6213c7" name="document-revision">
 =======
@@ -1225,6 +1225,9 @@ Possible extra rowspan handling
   <meta content="5668a60a0b983bc32c42d4891af42d5c1a00ffbe" name="document-revision">
 >>>>>>> Fixing whitespace issues
 >>>>>>> Fixing whitespace issues
+=======
+  <meta content="4196a15cf24c9eff6b2e74c0dd09aff460bd2d1c" name="document-revision">
+>>>>>>> Review changes
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1515,11 +1518,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-26">26 September 2018</time></span></h2>
->>>>>>> Fixing whitespace issues
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2036,13 +2035,20 @@ of security-relevant policy decisions.</p>
     <h2 class="heading settled" data-level="2" id="framework"><span class="secno">2. </span><span class="content">Framework</span><a class="self-link" href="#framework"></a></h2>
     <h3 class="heading settled" data-level="2.1" id="framework-infrastructure"><span class="secno">2.1. </span><span class="content">Infrastructure</span><a class="self-link" href="#framework-infrastructure"></a></h3>
     <p>This document uses ABNF grammar to specify syntax, as defined in <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>. It also relies on
-  the <code>#rule</code> ABNF extension defined in <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a>.</p>
+  the <code>#rule</code> ABNF extension defined in <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a>,
+  with the modification that <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a> is replaced with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace">optional-ascii-whitespace</a>. That is, the <code>#rule</code> used in this
+  document is defined as:</p>
+<pre>1#element => element *( <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace①">optional-ascii-whitespace</a> "," <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace②">optional-ascii-whitespace</a> element )
+</pre>
+    <p>and for n >= 1 and m > 1:</p>
+<pre>&lt;n>#&lt;m>element => element &lt;n-1>*&lt;m-1>( <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace③">optional-ascii-whitespace</a> "," <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace④">optional-ascii-whitespace</a> element )
+</pre>
     <p>This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
     <p>The following definitions are used to improve readability of other definitions in this document.</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-optional-ascii-whitespace">Optional ASCII whitespace</dfn> = *(<a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a>)
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-required-ascii-whitespace">Required ASCII whitespace</dfn> = 1*(<a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>)
-; <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace②">ASCII whitespace</a> is defined in the <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#" id="termref-for-">INFRA</a> standard.
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-optional-ascii-whitespace">optional-ascii-whitespace</dfn> = *( %x09 / %x0A / %x0C / %x0D / %x20 )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-required-ascii-whitespace">required-ascii-whitespace</dfn> = 1*( %x09 / %x0A / %x0C / %x0D / %x20 )
+; These productions match the definition of <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a> from the <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#" id="termref-for-">INFRA</a> standard.
 </pre>
     <h3 class="heading settled" data-level="2.2" id="framework-policy"><span class="secno">2.2. </span><span class="content">Policies</span><a class="self-link" href="#framework-policy"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
@@ -2057,16 +2063,15 @@ of security-relevant policy decisions.</p>
     <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
   series of <a data-link-type="dfn" href="#serialized-directive" id="ref-for-serialized-directive">serialized directives</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a>
-                    ; The '#' rule is the one defined in section 7 of RFC 7230
-                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a>
-                    ; and with ";" replacing ","
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> =
+    <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a> *( <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace⑤">optional-ascii-whitespace</a> ";" [ <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace⑥">optional-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive①">serialized-directive</a> ] )
 </pre>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
   series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp">serialized CSPs</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn data-dfn-type="grammar" data-export id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
-                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace①">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3①">OWS</a>
+                    ; but it incorporates the modifications specified
+                    ; in section 2.1 of this document.
 </pre>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP" data-level="2.2.1" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a serialized CSP </span><a class="self-link" href="#parse-serialized-policy"></a></h4>
     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
@@ -2085,7 +2090,7 @@ of security-relevant policy decisions.</p>
        <li data-md>
         <p>If <var>token</var> is an empty string, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
        <li data-md>
-        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace③">ASCII whitespace</a>.</p>
+        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>.</p>
        <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
         <p>In this case, the user agent SHOULD notify developers that a duplicate directive was
@@ -2129,9 +2134,9 @@ of security-relevant policy decisions.</p>
   non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace④">ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace②">ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                        ; Directive values may contain whitespace and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1②">VCHAR</a> characters,
                        ; excluding ";" and ",". The second half of the definition
                        ; above represents all <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1③">VCHAR</a> characters (%x21-%x7E)
@@ -2203,7 +2208,7 @@ of security-relevant policy decisions.</p>
     </ol>
     <p>A <dfn data-dfn-type="dfn" data-export id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
   whitespace-delimited series of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①">source expressions</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
                          / <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source">nonce-source</a> / <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source">hash-source</a>
 
@@ -2331,7 +2336,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
-                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace②">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3②">OWS</a>
+                    ; but it incorporates the modifications specified
+                    ; in section 2.1 of this document.
 </pre>
     <div class="example" id="example-b2d2c295">
      <a class="self-link" href="#example-b2d2c295"></a> 
@@ -2351,7 +2357,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
-                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace③">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3③">OWS</a>
+                    ; but it incorporates the modifications specified
+                    ; in section 2.1 of this document.
 </pre>
     <p>This header field allows developers to piece together their security policy in
   an iterative fashion, deploying a report-only policy based on their best
@@ -4229,7 +4236,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>
@@ -4326,7 +4333,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   the additional requirement that each token value MUST be one of the
   keywords defined by HTML specification as allowed values for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code> <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox" id="ref-for-attr-iframe-sandbox①">sandbox</a></code> attribute <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
 <pre>directive-name  = "sandbox"
-directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">Required ASCII whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
+directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
 </pre>
     <p>This directive has no reporting requirements; it will be ignored entirely when
   delivered in a <a data-link-type="http-header" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only③"><code>Content-Security-Policy-Report-Only</code></a> header, or within
@@ -4408,7 +4415,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-ancestors"
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace④">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace④">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
@@ -4541,7 +4548,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
 <pre>directive-name  = "report-uri"
-directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">Required ASCII whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
+directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
 
 ; The <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1②">uri-reference</a> grammar is defined in Section 4.1 of RFC 3986.
 </pre>
@@ -5861,7 +5868,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-nonce-source">nonce-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-none">'none'</a><span>, in §2.3.1</span>
    <li><a href="#object-src">object-src</a><span>, in §6.1.10</span>
-   <li><a href="#grammardef-optional-ascii-whitespace">Optional ASCII whitespace</a><span>, in §2.1</span>
+   <li><a href="#grammardef-optional-ascii-whitespace">optional-ascii-whitespace</a><span>, in §2.1</span>
    <li>
     originalPolicy
     <ul>
@@ -5897,7 +5904,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-report-sample">'report-sample'</a><span>, in §2.3.1</span>
    <li><a href="#report-to">report-to</a><span>, in §6.4.2</span>
    <li><a href="#report-uri">report-uri</a><span>, in §6.4.1</span>
-   <li><a href="#grammardef-required-ascii-whitespace">Required ASCII whitespace</a><span>, in §2.1</span>
+   <li><a href="#grammardef-required-ascii-whitespace">required-ascii-whitespace</a><span>, in §2.1</span>
    <li><a href="#violation-resource">resource</a><span>, in §2.4</span>
    <li><a href="#directive-response-check">response check</a><span>, in §2.3</span>
    <li>
@@ -7348,10 +7355,10 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
    <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a> <a href="#ref-for-ascii-whitespace①">(2)</a> <a href="#ref-for-ascii-whitespace②">(3)</a>
-    <li><a href="#ref-for-ascii-whitespace③">2.2.1. 
+    <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a>
+    <li><a href="#ref-for-ascii-whitespace①">2.2.1. 
     Parse a serialized CSP </a>
-    <li><a href="#ref-for-ascii-whitespace④">2.3. Directives</a>
+    <li><a href="#ref-for-ascii-whitespace②">2.3. Directives</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
@@ -7568,11 +7575,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-section-3.2.3">
    <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-section-3.2.3">2.2. Policies</a> <a href="#ref-for-section-3.2.3①">(2)</a>
-    <li><a href="#ref-for-section-3.2.3②">3.1. 
-    The Content-Security-Policy HTTP Response Header Field </a>
-    <li><a href="#ref-for-section-3.2.3③">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
+    <li><a href="#ref-for-section-3.2.3">2.1. Infrastructure</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-section-3.2.6">
@@ -8266,11 +8269,8 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-optional-ascii-whitespace">
    <b><a href="#grammardef-optional-ascii-whitespace">#grammardef-optional-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-optional-ascii-whitespace">2.2. Policies</a> <a href="#ref-for-grammardef-optional-ascii-whitespace①">(2)</a>
-    <li><a href="#ref-for-grammardef-optional-ascii-whitespace②">3.1. 
-    The Content-Security-Policy HTTP Response Header Field </a>
-    <li><a href="#ref-for-grammardef-optional-ascii-whitespace③">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
+    <li><a href="#ref-for-grammardef-optional-ascii-whitespace">2.1. Infrastructure</a> <a href="#ref-for-grammardef-optional-ascii-whitespace①">(2)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace②">(3)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace③">(4)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace④">(5)</a>
+    <li><a href="#ref-for-grammardef-optional-ascii-whitespace⑤">2.2. Policies</a> <a href="#ref-for-grammardef-optional-ascii-whitespace⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-required-ascii-whitespace">
@@ -8734,7 +8734,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-serialized-directive">
    <b><a href="#grammardef-serialized-directive">#grammardef-serialized-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-serialized-directive">2.2. Policies</a>
+    <li><a href="#ref-for-grammardef-serialized-directive">2.2. Policies</a> <a href="#ref-for-grammardef-serialized-directive①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-directive-name">

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,19 @@ Possible extra rowspan handling
 		}
 	}
 </style>
+<<<<<<< HEAD
   <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
   <meta content="6ee5a338b8c7262e5f7b4a894a196c642b6213c7" name="document-revision">
+=======
+  <meta content="e0121a0b31f15a3c6f4627d830dbe422ecf1344b" name="document-revision">
+=======
+  <meta content="Bikeshed version 465b801be4d2d8d27ff05c8248268063a2ecc8e3" name="generator">
+  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+  <meta content="5668a60a0b983bc32c42d4891af42d5c1a00ffbe" name="document-revision">
+>>>>>>> Fixing whitespace issues
+>>>>>>> Fixing whitespace issues
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1515,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-26">26 September 2018</time></span></h2>
+>>>>>>> Fixing whitespace issues
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2025,6 +2039,11 @@ of security-relevant policy decisions.</p>
   the <code>#rule</code> ABNF extension defined in <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a>.</p>
     <p>This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
+    <p>The following definitions are used to improve readability of other definitions in this document.</p>
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-optional-ascii-whitespace">Optional ASCII whitespace</dfn> = *(<a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a>)
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-required-ascii-whitespace">Required ASCII whitespace</dfn> = 1*(<a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>)
+; <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace②">ASCII whitespace</a> is defined in the <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#" id="termref-for-">INFRA</a> standard.
+</pre>
     <h3 class="heading settled" data-level="2.2" id="framework-policy"><span class="secno">2.2. </span><span class="content">Policies</span><a class="self-link" href="#framework-policy"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
   and restricted behaviors, and may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope">WorkerGlobalScope</a></code>, or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope">WorkletGlobalScope</a></code> as described in <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> and in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>.</p>
@@ -2038,13 +2057,16 @@ of security-relevant policy decisions.</p>
     <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
   series of <a data-link-type="dfn" href="#serialized-directive" id="ref-for-serialized-directive">serialized directives</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> = <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a> ";" [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3①">OWS</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive①">serialized-directive</a> ] )
-                    ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3②">OWS</a> is defined in section 3.2.3 of RFC 7230
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a>
+                    ; The '#' rule is the one defined in section 7 of RFC 7230
+                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3">OWS</a>
+                    ; and with ";" replacing ","
 </pre>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
   series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp">serialized CSPs</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn data-dfn-type="grammar" data-export id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
-                    ; The '#' rule is defined in section 7 of RFC 7230
+                    ; The '#' rule is the one defined in section 7 of RFC 7230
+                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace①">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3①">OWS</a>
 </pre>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP" data-level="2.2.1" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a serialized CSP </span><a class="self-link" href="#parse-serialized-policy"></a></h4>
     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
@@ -2063,7 +2085,7 @@ of security-relevant policy decisions.</p>
        <li data-md>
         <p>If <var>token</var> is an empty string, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
        <li data-md>
-        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a>.</p>
+        <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace③">ASCII whitespace</a>.</p>
        <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
         <p>In this case, the user agent SHOULD notify developers that a duplicate directive was
@@ -2107,14 +2129,15 @@ of security-relevant policy decisions.</p>
   non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3③">RWS</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( %x09 / %x20-%x2B / %x2D-%x3A / %x3C-%7E )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace④">ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                        ; Directive values may contain whitespace and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1②">VCHAR</a> characters,
-                       ; excluding ";" and ","
+                       ; excluding ";" and ",". The second half of the definition
+                       ; above represents all <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1③">VCHAR</a> characters (%x21-%x7E)
+                       ; without ";" and "," (%x3B and %x2C respectively)
 
-; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3④">RWS</a> is defined in section 3.2.3 of RFC7230. <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1③">ALPHA</a>, <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1④">DIGIT</a>, and
-; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑤">VCHAR</a> are defined in Appendix B.1 of RFC 5234.
+; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1④">ALPHA</a>, <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑤">DIGIT</a>, and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑥">VCHAR</a> are defined in Appendix B.1 of RFC 5234.
 </pre>
     <p><a data-link-type="dfn" href="#directives" id="ref-for-directives④">Directives</a> have a number of associated algorithms:</p>
     <ol>
@@ -2180,7 +2203,7 @@ of security-relevant policy decisions.</p>
     </ol>
     <p>A <dfn data-dfn-type="dfn" data-export id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
   whitespace-delimited series of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①">source expressions</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑤">RWS</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
                          / <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source">nonce-source</a> / <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source">hash-source</a>
 
@@ -2192,9 +2215,9 @@ of security-relevant policy decisions.</p>
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-scheme-part">scheme-part</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1">scheme</a>
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1①">scheme</a> is defined in section 3.1 of RFC 3986.
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-part">host-part</dfn>   = "*" / [ "*." ] 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char">host-char</a> *( "." 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char①">host-char</a> )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑥">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">DIGIT</a> / "-"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "*"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "-"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">DIGIT</a> / "*"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a> (but not including ";" or ",")
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3①">path-absolute</a> is defined in section 3.3 of RFC 3986.
 
 ; Keywords:
@@ -2206,7 +2229,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
 
 ; Nonces: 'nonce-[nonce goes here]'
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-nonce-source">nonce-source</dfn>  = "'nonce-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a> "'"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①①">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
 
 ; Digests: 'sha256-[digest goes here]'
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-source">hash-source</dfn>    = "'" <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm">hash-algorithm</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value①">base64-value</a> "'"
@@ -2307,6 +2330,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a>
+                    ; The '#' rule is the one defined in section 7 of RFC 7230
+                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace②">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3②">OWS</a>
 </pre>
     <div class="example" id="example-b2d2c295">
      <a class="self-link" href="#example-b2d2c295"></a> 
@@ -2325,6 +2350,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
+                    ; The '#' rule is the one defined in section 7 of RFC 7230
+                    ; but with <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace③">Optional ASCII whitespace</a> replacing <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3③">OWS</a>
 </pre>
     <p>This header field allows developers to piece together their security policy in
   an iterative fashion, deploying a report-only policy based on their best
@@ -4202,7 +4229,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑥">RWS</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>
@@ -4299,7 +4326,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   the additional requirement that each token value MUST be one of the
   keywords defined by HTML specification as allowed values for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code> <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox" id="ref-for-attr-iframe-sandbox①">sandbox</a></code> attribute <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
 <pre>directive-name  = "sandbox"
-directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑦">RWS</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
+directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">Required ASCII whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
 </pre>
     <p>This directive has no reporting requirements; it will be ignored entirely when
   delivered in a <a data-link-type="http-header" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only③"><code>Content-Security-Policy-Report-Only</code></a> header, or within
@@ -4381,7 +4408,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-ancestors"
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑧">RWS</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace④">Required ASCII whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
@@ -4514,7 +4541,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
 <pre>directive-name  = "report-uri"
-directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3" id="ref-for-section-3.2.3⑨">RWS</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
+directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">Required ASCII whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
 
 ; The <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1②">uri-reference</a> grammar is defined in Section 4.1 of RFC 3986.
 </pre>
@@ -5039,11 +5066,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
            <li data-md>
             <p>Let <var>algorithm</var> be <code>null</code>.</p>
            <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm②"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②②">ASCII case-insensitive</a> match for "sha256", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-">SHA-256</a>.</p>
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm②"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②②">ASCII case-insensitive</a> match for "sha256", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-①">SHA-256</a>.</p>
            <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm③"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②③">ASCII case-insensitive</a> match for "sha384", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-①">SHA-384</a>.</p>
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm③"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②③">ASCII case-insensitive</a> match for "sha384", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-②">SHA-384</a>.</p>
            <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm④"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②④">ASCII case-insensitive</a> match for "sha512", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-②">SHA-512</a>.</p>
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm④"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②④">ASCII case-insensitive</a> match for "sha512", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-③">SHA-512</a>.</p>
            <li data-md>
             <p>If <var>algorithm</var> is not <code>null</code>:</p>
             <ol>
@@ -5784,16 +5811,16 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-documenturi">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li>
-    effective directive
-    <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
-     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
-    </ul>
-   <li>
     effectiveDirective
     <ul>
      <li><a href="#dom-securitypolicyviolationevent-effectivedirective">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-effectivedirective">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
+    </ul>
+   <li>
+    effective directive
+    <ul>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
+     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li><a href="#violation-element">element</a><span>, in §2.4</span>
    <li><a href="#embedding-document">embedding document</a><span>, in §4.2</span>
@@ -5834,6 +5861,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-nonce-source">nonce-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-none">'none'</a><span>, in §2.3.1</span>
    <li><a href="#object-src">object-src</a><span>, in §6.1.10</span>
+   <li><a href="#grammardef-optional-ascii-whitespace">Optional ASCII whitespace</a><span>, in §2.1</span>
    <li>
     originalPolicy
     <ul>
@@ -5869,6 +5897,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-report-sample">'report-sample'</a><span>, in §2.3.1</span>
    <li><a href="#report-to">report-to</a><span>, in §6.4.2</span>
    <li><a href="#report-uri">report-uri</a><span>, in §6.4.1</span>
+   <li><a href="#grammardef-required-ascii-whitespace">Required ASCII whitespace</a><span>, in §2.1</span>
    <li><a href="#violation-resource">resource</a><span>, in §2.4</span>
    <li><a href="#directive-response-check">response check</a><span>, in §2.3</span>
    <li>
@@ -7319,8 +7348,10 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
    <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ascii-whitespace">2.2.1. 
+    <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a> <a href="#ref-for-ascii-whitespace①">(2)</a> <a href="#ref-for-ascii-whitespace②">(3)</a>
+    <li><a href="#ref-for-ascii-whitespace③">2.2.1. 
     Parse a serialized CSP </a>
+    <li><a href="#ref-for-ascii-whitespace④">2.3. Directives</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
@@ -7349,11 +7380,18 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP list </a>
    </ul>
   </aside>
+<<<<<<< HEAD
   <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
    <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
     Does element match source list for type and source? </a>
+=======
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="https://infra.spec.whatwg.org/#">https://infra.spec.whatwg.org/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">2.1. Infrastructure</a>
+>>>>>>> Fixing whitespace issues
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-is-empty">
@@ -7509,46 +7547,32 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-appendix-B.1">
    <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a>
-    <li><a href="#ref-for-appendix-B.1⑥">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑦">(2)</a> <a href="#ref-for-appendix-B.1⑧">(3)</a> <a href="#ref-for-appendix-B.1⑨">(4)</a> <a href="#ref-for-appendix-B.1①⓪">(5)</a>
+    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
+    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-appendix-B.1">
    <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a>
-    <li><a href="#ref-for-appendix-B.1⑥">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑦">(2)</a> <a href="#ref-for-appendix-B.1⑧">(3)</a> <a href="#ref-for-appendix-B.1⑨">(4)</a> <a href="#ref-for-appendix-B.1①⓪">(5)</a>
+    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
+    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-appendix-B.1">
    <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a>
-    <li><a href="#ref-for-appendix-B.1⑥">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑦">(2)</a> <a href="#ref-for-appendix-B.1⑧">(3)</a> <a href="#ref-for-appendix-B.1⑨">(4)</a> <a href="#ref-for-appendix-B.1①⓪">(5)</a>
+    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
+    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-section-3.2.3">
    <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-section-3.2.3">2.2. Policies</a> <a href="#ref-for-section-3.2.3①">(2)</a> <a href="#ref-for-section-3.2.3②">(3)</a>
-    <li><a href="#ref-for-section-3.2.3③">2.3. Directives</a> <a href="#ref-for-section-3.2.3④">(2)</a>
-    <li><a href="#ref-for-section-3.2.3⑤">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-3.2.3⑥">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-section-3.2.3⑦">6.2.3. sandbox</a>
-    <li><a href="#ref-for-section-3.2.3⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-section-3.2.3⑨">6.4.1. report-uri</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.2.3">2.2. Policies</a> <a href="#ref-for-section-3.2.3①">(2)</a> <a href="#ref-for-section-3.2.3②">(3)</a>
-    <li><a href="#ref-for-section-3.2.3③">2.3. Directives</a> <a href="#ref-for-section-3.2.3④">(2)</a>
-    <li><a href="#ref-for-section-3.2.3⑤">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-3.2.3⑥">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-section-3.2.3⑦">6.2.3. sandbox</a>
-    <li><a href="#ref-for-section-3.2.3⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-section-3.2.3⑨">6.4.1. report-uri</a>
+    <li><a href="#ref-for-section-3.2.3">2.2. Policies</a> <a href="#ref-for-section-3.2.3①">(2)</a>
+    <li><a href="#ref-for-section-3.2.3②">3.1. 
+    The Content-Security-Policy HTTP Response Header Field </a>
+    <li><a href="#ref-for-section-3.2.3③">3.2. 
+    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-section-3.2.6">
@@ -7957,7 +7981,11 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>
      <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
      <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
+<<<<<<< HEAD
      <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">convert</span>
+=======
+     <li><span class="dfn-paneled" id="term-for-" style="color:initial">infra</span>
+>>>>>>> Fixing whitespace issues
      <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
@@ -8010,7 +8038,6 @@ rest of Google’s CSP Cabal.</p>
     <a data-link-type="biblio">[RFC7230]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-section-3.2.3" style="color:initial">ows</span>
-     <li><span class="dfn-paneled" id="term-for-section-3.2.3①" style="color:initial">rws</span>
      <li><span class="dfn-paneled" id="term-for-section-3.2.6" style="color:initial">token</span>
     </ul>
    <li>
@@ -8028,9 +8055,9 @@ rest of Google’s CSP Cabal.</p>
    <li>
     <a data-link-type="biblio">[sha2]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-" style="color:initial">sha-256</span>
-     <li><span class="dfn-paneled" id="term-for-①" style="color:initial">sha-384</span>
-     <li><span class="dfn-paneled" id="term-for-②" style="color:initial">sha-512</span>
+     <li><span class="dfn-paneled" id="term-for-①" style="color:initial">sha-256</span>
+     <li><span class="dfn-paneled" id="term-for-②" style="color:initial">sha-384</span>
+     <li><span class="dfn-paneled" id="term-for-③" style="color:initial">sha-512</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -8234,6 +8261,27 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="grammardef-optional-ascii-whitespace">
+   <b><a href="#grammardef-optional-ascii-whitespace">#grammardef-optional-ascii-whitespace</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-grammardef-optional-ascii-whitespace">2.2. Policies</a> <a href="#ref-for-grammardef-optional-ascii-whitespace①">(2)</a>
+    <li><a href="#ref-for-grammardef-optional-ascii-whitespace②">3.1. 
+    The Content-Security-Policy HTTP Response Header Field </a>
+    <li><a href="#ref-for-grammardef-optional-ascii-whitespace③">3.2. 
+    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="grammardef-required-ascii-whitespace">
+   <b><a href="#grammardef-required-ascii-whitespace">#grammardef-required-ascii-whitespace</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace">2.3. Directives</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace①">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace②">6.2.2. plugin-types</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace③">6.2.3. sandbox</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace⑤">6.4.1. report-uri</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="content-security-policy-object">
@@ -8686,7 +8734,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-serialized-directive">
    <b><a href="#grammardef-serialized-directive">#grammardef-serialized-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-serialized-directive">2.2. Policies</a> <a href="#ref-for-grammardef-serialized-directive①">(2)</a>
+    <li><a href="#ref-for-grammardef-serialized-directive">2.2. Policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-directive-name">

--- a/index.html
+++ b/index.html
@@ -1212,22 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
+  <meta content="Bikeshed version 47cb5324cd11789aef12f220cf86d1780f94ab9c" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-<<<<<<< HEAD
-<<<<<<< HEAD
-  <meta content="6ee5a338b8c7262e5f7b4a894a196c642b6213c7" name="document-revision">
-=======
-  <meta content="e0121a0b31f15a3c6f4627d830dbe422ecf1344b" name="document-revision">
-=======
-  <meta content="Bikeshed version 465b801be4d2d8d27ff05c8248268063a2ecc8e3" name="generator">
-  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="5668a60a0b983bc32c42d4891af42d5c1a00ffbe" name="document-revision">
->>>>>>> Fixing whitespace issues
->>>>>>> Fixing whitespace issues
-=======
-  <meta content="4196a15cf24c9eff6b2e74c0dd09aff460bd2d1c" name="document-revision">
->>>>>>> Review changes
+  <meta content="ace2178960fb1e5d9381d715107b6b1306273b4b" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1518,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-08">8 October 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1547,8 +1534,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This document defines a mechanism by which web developers can control the
 
-resources which a particular page can fetch or execute, as well as a number
-of security-relevant policy decisions.</p>
+  resources which a particular page can fetch or execute, as well as a number
+  of security-relevant policy decisions.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -2136,7 +2123,7 @@ of security-relevant policy decisions.</p>
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace②">ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">required-ascii-whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                        ; Directive values may contain whitespace and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1②">VCHAR</a> characters,
                        ; excluding ";" and ",". The second half of the definition
                        ; above represents all <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1③">VCHAR</a> characters (%x21-%x7E)
@@ -2208,7 +2195,7 @@ of security-relevant policy decisions.</p>
     </ol>
     <p>A <dfn data-dfn-type="dfn" data-export id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
   whitespace-delimited series of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①">source expressions</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
                          / <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source">nonce-source</a> / <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source">hash-source</a>
 
@@ -4236,7 +4223,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>
@@ -4333,7 +4320,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   the additional requirement that each token value MUST be one of the
   keywords defined by HTML specification as allowed values for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code> <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox" id="ref-for-attr-iframe-sandbox①">sandbox</a></code> attribute <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
 <pre>directive-name  = "sandbox"
-directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
+directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6">token</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace④">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.6" id="ref-for-section-3.2.6①">token</a> )
 </pre>
     <p>This directive has no reporting requirements; it will be ignored entirely when
   delivered in a <a data-link-type="http-header" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only③"><code>Content-Security-Policy-Report-Only</code></a> header, or within
@@ -4415,7 +4402,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-ancestors"
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace④">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
@@ -4548,7 +4535,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
 <pre>directive-name  = "report-uri"
-directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
+directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑥">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
 
 ; The <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1②">uri-reference</a> grammar is defined in Section 4.1 of RFC 3986.
 </pre>
@@ -7358,7 +7345,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a>
     <li><a href="#ref-for-ascii-whitespace①">2.2.1. 
     Parse a serialized CSP </a>
-    <li><a href="#ref-for-ascii-whitespace②">2.3. Directives</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
@@ -7387,18 +7373,17 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-<<<<<<< HEAD
   <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
    <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
     Does element match source list for type and source? </a>
-=======
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://infra.spec.whatwg.org/#">https://infra.spec.whatwg.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.1. Infrastructure</a>
->>>>>>> Fixing whitespace issues
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-is-empty">
@@ -7984,11 +7969,8 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>
      <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
      <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
-<<<<<<< HEAD
      <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">convert</span>
-=======
      <li><span class="dfn-paneled" id="term-for-" style="color:initial">infra</span>
->>>>>>> Fixing whitespace issues
      <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
@@ -8276,12 +8258,12 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-required-ascii-whitespace">
    <b><a href="#grammardef-required-ascii-whitespace">#grammardef-required-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace">2.3. Directives</a>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace①">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace②">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace③">6.2.3. sandbox</a>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace④">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-required-ascii-whitespace⑤">6.4.1. report-uri</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace">2.3. Directives</a> <a href="#ref-for-grammardef-required-ascii-whitespace①">(2)</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace②">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace③">6.2.2. plugin-types</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace④">6.2.3. sandbox</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace⑤">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-required-ascii-whitespace⑥">6.4.1. report-uri</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="content-security-policy-object">

--- a/index.src.html
+++ b/index.src.html
@@ -140,6 +140,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     for: WorkerGlobalScope
       text: owner set; url: concept-WorkerGlobalScope-owner-set
+
+spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
+  type: grammar
+    text: ASCII whitespace; url: ascii-whitespace
+    text: INFRA; url: #
 </pre>
 <pre class="biblio">
 {
@@ -370,6 +375,13 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose [[!INFRA]].
 
+  The following definitions are used to improve readability of other definitions in this document.
+  <pre dfn-type="grammar" link-type="grammar">
+    <dfn>Optional ASCII whitespace</dfn> = *(<a>ASCII whitespace</a>)
+    <dfn>Required ASCII whitespace</dfn> = 1*(<a>ASCII whitespace</a>)
+    ; <a>ASCII whitespace</a> is defined in the <a>INFRA</a> standard.
+  </pre>
+
   <h3 id="framework-policy">Policies</h3>
 
   A <dfn export lt="content security policy object" local-lt="policy">policy</dfn> defines allowed
@@ -396,8 +408,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   series of <a>serialized directives</a>, adhering to the following ABNF grammar [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-policy</dfn> = <a>serialized-directive</a> *( <a>OWS</a> ";" [ <a>OWS</a> <a>serialized-directive</a> ] )
-                        ; <a>OWS</a> is defined in section 3.2.3 of RFC 7230
+    <dfn>serialized-policy</dfn> = 1#<a>serialized-directive</a>
+                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; but with <a>Optional ASCII whitespace</a> replacing <a>OWS</a>
+                        ; and with ";" replacing ","
   </pre>
 
   A <dfn export>serialized CSP list</dfn> is an [=ASCII string=] consisting of a comma-delimited
@@ -405,7 +419,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <pre dfn-type="grammar" link-type="grammar">
     <dfn>serialized-policy-list</dfn> = 1#<a>serialized-policy</a>
-                        ; The '#' rule is defined in section 7 of RFC 7230
+                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; but with <a>Optional ASCII whitespace</a> replacing <a>OWS</a>
   </pre>
 
   <h4 id="parse-serialized-policy" algorithm>
@@ -493,14 +508,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   whitespace-delimited tokens, and adhering to the following ABNF [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-directive</dfn> = <a>directive-name</a> [ <a>RWS</a> <a>directive-value</a> ]
+    <dfn>serialized-directive</dfn> = <a>directive-name</a> [ <a>Required ASCII whitespace</a> <a>directive-value</a> ]
     <dfn>directive-name</dfn>       = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "-" )
-    <dfn>directive-value</dfn>      = *( %x09 / %x20-%x2B / %x2D-%x3A / %x3C-%7E )
+    <dfn>directive-value</dfn>      = *( <a>ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                            ; Directive values may contain whitespace and <a>VCHAR</a> characters,
-                           ; excluding ";" and ","
+                           ; excluding ";" and ",". The second half of the definition
+                           ; above represents all <a>VCHAR</a> characters (%x21-%x7E)
+                           ; without ";" and "," (%x3B and %x2C respectively)
 
-    ; <a>RWS</a> is defined in section 3.2.3 of RFC7230. <a>ALPHA</a>, <a>DIGIT</a>, and
-    ; <a>VCHAR</a> are defined in Appendix B.1 of RFC 5234.
+    ; <a>ALPHA</a>, <a>DIGIT</a>, and <a>VCHAR</a> are defined in Appendix B.1 of RFC 5234.
   </pre>
 
   <a>Directives</a> have a number of associated algorithms:
@@ -577,7 +593,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-source-list</dfn> = ( <a>source-expression</a> *( <a>RWS</a> <a>source-expression</a> ) ) / "<dfn>'none'</dfn>"
+    <dfn>serialized-source-list</dfn> = ( <a>source-expression</a> *( <a>Required ASCII whitespace</a> <a>source-expression</a> ) ) / "<dfn>'none'</dfn>"
     <dfn>source-expression</dfn>      = <a>scheme-source</a> / <a>host-source</a> / <a>keyword-source</a>
                              / <a>nonce-source</a> / <a>hash-source</a>
 
@@ -591,7 +607,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
     <dfn>host-char</dfn>   = <a>ALPHA</a> / <a>DIGIT</a> / "-"
     <dfn>port-part</dfn>   = 1*<a>DIGIT</a> / "*"
-    <dfn>path-part</dfn>   = <a>path-absolute</a>
+    <dfn>path-part</dfn>   = <a>path-absolute</a> (but not including ";" or ",")
                   ; <a>path-absolute</a> is defined in section 3.3 of RFC 3986.
 
     ; Keywords:
@@ -783,6 +799,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <pre>
     Content-Security-Policy = 1#<a grammar>serialized-policy</a>
+                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; but with <a grammar>Optional ASCII whitespace</a> replacing <a grammar>OWS</a>
   </pre>
 
   <div class="example">
@@ -815,6 +833,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <pre>
     Content-Security-Policy-Report-Only = 1#<a grammar>serialized-policy</a>
+                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; but with <a grammar>Optional ASCII whitespace</a> replacing <a grammar>OWS</a>
   </pre>
 
   This header field allows developers to piece together their security policy in
@@ -3246,7 +3266,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     directive-name  = "plugin-types"
     directive-value = <a>media-type-list</a>
 
-    <dfn>media-type-list</dfn> = <a>media-type</a> *( <a>RWS</a> <a>media-type</a> )
+    <dfn>media-type-list</dfn> = <a>media-type</a> *( <a>Required ASCII whitespace</a> <a>media-type</a> )
     <dfn>media-type</dfn> = <a>type</a> "/" <a>subtype</a>
     ; <a>type</a> and <a>subtype</a> are defined in RFC 2045
   </pre>
@@ -3364,7 +3384,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <pre dfn-type="grammar" link-type="grammar">
     directive-name  = "sandbox"
-    directive-value = "" / <a>token</a> *( <a>RWS</a> <a>token</a> )
+    directive-value = "" / <a>token</a> *( <a>Required ASCII whitespace</a> <a>token</a> )
   </pre>
 
   This directive has no reporting requirements; it will be ignored entirely when
@@ -3477,7 +3497,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     directive-name  = "frame-ancestors"
     directive-value = <a>ancestor-source-list</a>
 
-    <dfn>ancestor-source-list</dfn> = ( <a>ancestor-source</a> *( <a>RWS</a> <a>ancestor-source</a>) ) / "<a>'none'</a>"
+    <dfn>ancestor-source-list</dfn> = ( <a>ancestor-source</a> *( <a>Required ASCII whitespace</a> <a>ancestor-source</a>) ) / "<a>'none'</a>"
     <dfn>ancestor-source</dfn>      = <a>scheme-source</a> / <a>host-source</a> / "<a>'self'</a>"
   </pre>
 
@@ -3693,7 +3713,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 
   <pre link-type="grammar">
     directive-name  = "report-uri"
-    directive-value = <a>uri-reference</a> *( <a>RWS</a> <a>uri-reference</a> )
+    directive-value = <a>uri-reference</a> *( <a>Required ASCII whitespace</a> <a>uri-reference</a> )
 
     ; The <a>uri-reference</a> grammar is defined in Section 4.1 of RFC 3986.
   </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -370,16 +370,29 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   This document uses ABNF grammar to specify syntax, as defined in [[!RFC5234]]. It also relies on
   the `#rule` ABNF extension defined in
-  <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of [[!RFC7230]].
+  <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of [[!RFC7230]],
+  with the modification that <a grammar>OWS</a> is replaced with
+  <a grammar>optional-ascii-whitespace</a>. That is, the `#rule` used in this
+  document is defined as:
+
+  <pre>
+    1#element => element *( <a grammar>optional-ascii-whitespace</a> "," <a grammar>optional-ascii-whitespace</a> element )
+  </pre>
+
+  and for n >= 1 and m > 1:
+
+  <pre>
+    &lt;n&gt;#&lt;m&gt;element => element &lt;n-1&gt;*&lt;m-1&gt;( <a grammar>optional-ascii-whitespace</a> "," <a grammar>optional-ascii-whitespace</a> element )
+  </pre>
 
   This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose [[!INFRA]].
 
   The following definitions are used to improve readability of other definitions in this document.
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>Optional ASCII whitespace</dfn> = *(<a>ASCII whitespace</a>)
-    <dfn>Required ASCII whitespace</dfn> = 1*(<a>ASCII whitespace</a>)
-    ; <a>ASCII whitespace</a> is defined in the <a>INFRA</a> standard.
+    <dfn>optional-ascii-whitespace</dfn> = *( %x09 / %x0A / %x0C / %x0D / %x20 )
+    <dfn>required-ascii-whitespace</dfn> = 1*( %x09 / %x0A / %x0C / %x0D / %x20 )
+    ; These productions match the definition of <a>ASCII whitespace</a> from the <a>INFRA</a> standard.
   </pre>
 
   <h3 id="framework-policy">Policies</h3>
@@ -408,10 +421,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   series of <a>serialized directives</a>, adhering to the following ABNF grammar [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-policy</dfn> = 1#<a>serialized-directive</a>
-                        ; The '#' rule is the one defined in section 7 of RFC 7230
-                        ; but with <a>Optional ASCII whitespace</a> replacing <a>OWS</a>
-                        ; and with ";" replacing ","
+    <dfn>serialized-policy</dfn> =
+        <a>serialized-directive</a> *( <a>optional-ascii-whitespace</a> ";" [ <a>optional-ascii-whitespace</a> <a>serialized-directive</a> ] )
   </pre>
 
   A <dfn export>serialized CSP list</dfn> is an [=ASCII string=] consisting of a comma-delimited
@@ -420,7 +431,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <pre dfn-type="grammar" link-type="grammar">
     <dfn>serialized-policy-list</dfn> = 1#<a>serialized-policy</a>
                         ; The '#' rule is the one defined in section 7 of RFC 7230
-                        ; but with <a>Optional ASCII whitespace</a> replacing <a>OWS</a>
+                        ; but it incorporates the modifications specified
+                        ; in section 2.1 of this document.
   </pre>
 
   <h4 id="parse-serialized-policy" algorithm>
@@ -508,7 +520,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   whitespace-delimited tokens, and adhering to the following ABNF [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-directive</dfn> = <a>directive-name</a> [ <a>Required ASCII whitespace</a> <a>directive-value</a> ]
+    <dfn>serialized-directive</dfn> = <a>directive-name</a> [ <a>required-ascii-whitespace</a> <a>directive-value</a> ]
     <dfn>directive-name</dfn>       = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "-" )
     <dfn>directive-value</dfn>      = *( <a>ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                            ; Directive values may contain whitespace and <a>VCHAR</a> characters,
@@ -593,7 +605,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-    <dfn>serialized-source-list</dfn> = ( <a>source-expression</a> *( <a>Required ASCII whitespace</a> <a>source-expression</a> ) ) / "<dfn>'none'</dfn>"
+    <dfn>serialized-source-list</dfn> = ( <a>source-expression</a> *( <a>required-ascii-whitespace</a> <a>source-expression</a> ) ) / "<dfn>'none'</dfn>"
     <dfn>source-expression</dfn>      = <a>scheme-source</a> / <a>host-source</a> / <a>keyword-source</a>
                              / <a>nonce-source</a> / <a>hash-source</a>
 
@@ -800,7 +812,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <pre>
     Content-Security-Policy = 1#<a grammar>serialized-policy</a>
                         ; The '#' rule is the one defined in section 7 of RFC 7230
-                        ; but with <a grammar>Optional ASCII whitespace</a> replacing <a grammar>OWS</a>
+                        ; but it incorporates the modifications specified
+                        ; in section 2.1 of this document.
   </pre>
 
   <div class="example">
@@ -834,7 +847,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <pre>
     Content-Security-Policy-Report-Only = 1#<a grammar>serialized-policy</a>
                         ; The '#' rule is the one defined in section 7 of RFC 7230
-                        ; but with <a grammar>Optional ASCII whitespace</a> replacing <a grammar>OWS</a>
+                        ; but it incorporates the modifications specified
+                        ; in section 2.1 of this document.
   </pre>
 
   This header field allows developers to piece together their security policy in
@@ -3266,7 +3280,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     directive-name  = "plugin-types"
     directive-value = <a>media-type-list</a>
 
-    <dfn>media-type-list</dfn> = <a>media-type</a> *( <a>Required ASCII whitespace</a> <a>media-type</a> )
+    <dfn>media-type-list</dfn> = <a>media-type</a> *( <a>required-ascii-whitespace</a> <a>media-type</a> )
     <dfn>media-type</dfn> = <a>type</a> "/" <a>subtype</a>
     ; <a>type</a> and <a>subtype</a> are defined in RFC 2045
   </pre>
@@ -3384,7 +3398,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   <pre dfn-type="grammar" link-type="grammar">
     directive-name  = "sandbox"
-    directive-value = "" / <a>token</a> *( <a>Required ASCII whitespace</a> <a>token</a> )
+    directive-value = "" / <a>token</a> *( <a>required-ascii-whitespace</a> <a>token</a> )
   </pre>
 
   This directive has no reporting requirements; it will be ignored entirely when
@@ -3497,7 +3511,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     directive-name  = "frame-ancestors"
     directive-value = <a>ancestor-source-list</a>
 
-    <dfn>ancestor-source-list</dfn> = ( <a>ancestor-source</a> *( <a>Required ASCII whitespace</a> <a>ancestor-source</a>) ) / "<a>'none'</a>"
+    <dfn>ancestor-source-list</dfn> = ( <a>ancestor-source</a> *( <a>required-ascii-whitespace</a> <a>ancestor-source</a>) ) / "<a>'none'</a>"
     <dfn>ancestor-source</dfn>      = <a>scheme-source</a> / <a>host-source</a> / "<a>'self'</a>"
   </pre>
 
@@ -3713,7 +3727,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   <pre link-type="grammar">
     directive-name  = "report-uri"
-    directive-value = <a>uri-reference</a> *( <a>Required ASCII whitespace</a> <a>uri-reference</a> )
+    directive-value = <a>uri-reference</a> *( <a>required-ascii-whitespace</a> <a>uri-reference</a> )
 
     ; The <a>uri-reference</a> grammar is defined in Section 4.1 of RFC 3986.
   </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -522,7 +522,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <pre dfn-type="grammar" link-type="grammar">
     <dfn>serialized-directive</dfn> = <a>directive-name</a> [ <a>required-ascii-whitespace</a> <a>directive-value</a> ]
     <dfn>directive-name</dfn>       = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "-" )
-    <dfn>directive-value</dfn>      = *( <a>ASCII whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
+    <dfn>directive-value</dfn>      = *( <a>required-ascii-whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                            ; Directive values may contain whitespace and <a>VCHAR</a> characters,
                            ; excluding ";" and ",". The second half of the definition
                            ; above represents all <a>VCHAR</a> characters (%x21-%x7E)


### PR DESCRIPTION
This replaces the usage of `OWS/RWS` with equivalent `ASCII whitespace` expressions to ensure consistency in parsing algorithms.
A small clarification is added to `path-absolute`
A small modification and comment update is added to `directive-value`

Fixes https://github.com/w3c/webappsec-csp/issues/307
Fixes https://github.com/w3c/webappsec-csp/issues/303
Fixes https://github.com/w3c/webappsec-csp/issues/5

And is also necessary to solve https://github.com/webcompat/web-bugs/issues/18902#issuecomment-422710128


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/340.html" title="Last updated on Oct 8, 2018, 10:08 AM GMT (bb2997e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/340/84cc0d9...andypaicu:bb2997e.html" title="Last updated on Oct 8, 2018, 10:08 AM GMT (bb2997e)">Diff</a>