### PR TITLE
Convert string to UTF-8 before applying hash algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,15 @@ Possible extra rowspan handling
 		}
 	}
 </style>
+<<<<<<< HEAD
   <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
   <meta content="e0121a0b31f15a3c6f4627d830dbe422ecf1344b" name="document-revision">
+=======
+  <meta content="Bikeshed version 465b801be4d2d8d27ff05c8248268063a2ecc8e3" name="generator">
+  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+  <meta content="61c6f7d7d1e0415daa1e95292e7cac6f58484dea" name="document-revision">
+>>>>>>> Convert string to UTF-8 before applying hash algorithms
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1511,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-27">27 September 2018</time></span></h2>
+>>>>>>> Convert string to UTF-8 before applying hash algorithms
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4997,8 +5007,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
-    <p class="note" role="note"><span>Note:</span> <var>source</var> will be interpreted with the encoding of the page in which it
-  is embedded. See the integration points in <a href="#html-integration">§4.2 Integration with HTML</a> for more detail.</p>
+    <p class="note" role="note"><span>Note:</span> Regardless of the encoding of the page, <var>source</var> will be converted to <code>UTF-8</code> before applying any hashing algorithms.</p>
     <ol>
      <li data-md>
       <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
@@ -5028,6 +5037,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
      <li data-md>
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>unsafe-hashes flag</var> is <code>true</code>:</p>
       <ol>
+       <li data-md>
+        <p>Let <var>source</var> be the result of executing <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode" id="ref-for-utf-8-encode">UTF-8 encode</a> on the result of executing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">javascript-string-convert</a> on <var>source</var>.</p>
        <li data-md>
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
@@ -6148,6 +6159,13 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-realm">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
+   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-utf-8-encode">6.6.3.3. 
+    Does element match source list for type and source? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-body">
@@ -7346,6 +7364,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-list-is-empty">2.3. Directives</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
+   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
+    Does element match source list for type and source? </a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
@@ -7818,6 +7843,11 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-realm" style="color:initial">realm</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[ENCODING]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-utf-8-encode" style="color:initial">utf-8 encode</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-request-body" style="color:initial">body</span>
@@ -7937,6 +7967,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
      <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
      <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
+     <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">javascript-string-convert</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set①" style="color:initial">set</span>
@@ -8055,6 +8086,8 @@ rest of Google’s CSP Cabal.</p>
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecma262">[ECMA262]
    <dd>Brian Terlson; Allen Wirfs-Brock. <a href="https://tc39.github.io/ecma262/">ECMAScript® Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
+   <dt id="biblio-encoding">[ENCODING]
+   <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]

--- a/index.html
+++ b/index.html
@@ -1213,6 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
 <<<<<<< HEAD
+<<<<<<< HEAD
   <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
   <meta content="e0121a0b31f15a3c6f4627d830dbe422ecf1344b" name="document-revision">
@@ -1221,6 +1222,11 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
   <meta content="61c6f7d7d1e0415daa1e95292e7cac6f58484dea" name="document-revision">
 >>>>>>> Convert string to UTF-8 before applying hash algorithms
+=======
+  <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
+  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+  <meta content="9053dcec9a877c944cbf8ea576cb8d5fecf7500f" name="document-revision">
+>>>>>>> Review changes
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1512,10 +1518,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
 <<<<<<< HEAD
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
 =======
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-27">27 September 2018</time></span></h2>
 >>>>>>> Convert string to UTF-8 before applying hash algorithms
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
+>>>>>>> Review changes
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5007,7 +5017,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> (<var>element</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②①">source list</a> (<var>list</var>), a string
   (<var>type</var>), and a string (<var>source</var>), this algorithm returns "<code>Matches</code>" or
   "<code>Does Not Match</code>".</p>
-    <p class="note" role="note"><span>Note:</span> Regardless of the encoding of the page, <var>source</var> will be converted to <code>UTF-8</code> before applying any hashing algorithms.</p>
+    <p class="note" role="note"><span>Note:</span> Regardless of the encoding of the document, <var>source</var> will be converted
+  to <code>UTF-8</code> before applying any hashing algorithms.</p>
     <ol>
      <li data-md>
       <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
@@ -5038,7 +5049,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>unsafe-hashes flag</var> is <code>true</code>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>source</var> be the result of executing <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode" id="ref-for-utf-8-encode">UTF-8 encode</a> on the result of executing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">javascript-string-convert</a> on <var>source</var>.</p>
+        <p>Set <var>source</var> to the result of executing <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode" id="ref-for-utf-8-encode">UTF-8 encode</a> on the result of executing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">JavaScript string converting</a> on <var>source</var>.</p>
        <li data-md>
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
@@ -7358,17 +7369,17 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list-is-empty">2.3. Directives</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
    <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
     Does element match source list for type and source? </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-is-empty">
+   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-is-empty">2.3. Directives</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list">
@@ -7966,8 +7977,8 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>
      <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
      <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
+     <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">convert</span>
      <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
-     <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">javascript-string-convert</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set①" style="color:initial">set</span>

--- a/index.html
+++ b/index.html
@@ -1212,21 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-<<<<<<< HEAD
-<<<<<<< HEAD
   <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="e0121a0b31f15a3c6f4627d830dbe422ecf1344b" name="document-revision">
-=======
-  <meta content="Bikeshed version 465b801be4d2d8d27ff05c8248268063a2ecc8e3" name="generator">
-  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="61c6f7d7d1e0415daa1e95292e7cac6f58484dea" name="document-revision">
->>>>>>> Convert string to UTF-8 before applying hash algorithms
-=======
-  <meta content="Bikeshed version dff342f4b23fb230b71436fb31b55f5f169715bd" name="generator">
-  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="9053dcec9a877c944cbf8ea576cb8d5fecf7500f" name="document-revision">
->>>>>>> Review changes
+  <meta content="6ee5a338b8c7262e5f7b4a894a196c642b6213c7" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1517,15 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
-<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-09-27">27 September 2018</time></span></h2>
->>>>>>> Convert string to UTF-8 before applying hash algorithms
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-04">4 October 2018</time></span></h2>
->>>>>>> Review changes
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/index.src.html
+++ b/index.src.html
@@ -140,10 +140,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     for: WorkerGlobalScope
       text: owner set; url: concept-WorkerGlobalScope-owner-set
-
-spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
-  type: dfn
-    text: javascript-string-convert; url: javascript-string-convert
 </pre>
 <pre class="biblio">
 {
@@ -4292,8 +4288,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   (|type|), and a string (|source|), this algorithm returns "`Matches`" or
   "`Does Not Match`".
 
-  Note: Regardless of the encoding of the page, |source| will be converted to `UTF-8`
-  before applying any hashing algorithms.
+  Note: Regardless of the encoding of the document, |source| will be converted
+  to `UTF-8` before applying any hashing algorithms.
 
   1.  If [[#allow-all-inline]] returns "`Allows`" given |list| and |type|,
       return "`Matches`".
@@ -4323,8 +4319,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   5.  If |type| is "`script`" or "`style`", or |unsafe-hashes flag| is
       `true`:
 
-      1.  Let |source| be the result of executing <a>UTF-8 encode</a>
-          on the result of executing <a>javascript-string-convert</a>
+      1.  Set |source| to the result of executing <a>UTF-8 encode</a>
+          on the result of executing <a for="JavaScript string" data-lt="convert">JavaScript string converting</a>
           on |source|.
 
       2.  For each |expression| in |list|:

--- a/index.src.html
+++ b/index.src.html
@@ -140,6 +140,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     for: WorkerGlobalScope
       text: owner set; url: concept-WorkerGlobalScope-owner-set
+
+spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
+  type: dfn
+    text: javascript-string-convert; url: javascript-string-convert
 </pre>
 <pre class="biblio">
 {
@@ -4288,8 +4292,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   (|type|), and a string (|source|), this algorithm returns "`Matches`" or
   "`Does Not Match`".
 
-  Note: |source| will be interpreted with the encoding of the page in which it
-  is embedded. See the integration points in [[#html-integration]] for more detail.
+  Note: Regardless of the encoding of the page, |source| will be converted to `UTF-8`
+  before applying any hashing algorithms.
 
   1.  If [[#allow-all-inline]] returns "`Allows`" given |list| and |type|,
       return "`Matches`".
@@ -4319,7 +4323,11 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   5.  If |type| is "`script`" or "`style`", or |unsafe-hashes flag| is
       `true`:
 
-      1.  For each |expression| in |list|:
+      1.  Let |source| be the result of executing <a>UTF-8 encode</a>
+          on the result of executing <a>javascript-string-convert</a>
+          on |source|.
+
+      2.  For each |expression| in |list|:
 
           1.  If |expression| matches the <a grammar>`hash-source`</a> grammar:
 
@@ -4349,7 +4357,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
                       Note: This replacement normalizes hashes expressed in [=base64url
                       encoding=] into [=base64 encoding=] for matching.
 
-                  2.  If |actual| is a <a>case-sensitive</a> match for |expected|, return
+                  3.  If |actual| is a <a>case-sensitive</a> match for |expected|, return
                       "`Matches`".
 
       Note: Hashes apply to inline <{script}> and inline <{style}>. If the


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/109


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/342.html" title="Last updated on Oct 4, 2018, 9:20 AM GMT (6637dd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/342/f39f3a3...andypaicu:6637dd7.html" title="Last updated on Oct 4, 2018, 9:20 AM GMT (6637dd7)">Diff</a>