### PR TITLE
Fixed text for form-action prenavigate

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 47cb5324cd11789aef12f220cf86d1780f94ab9c" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="7c675fc237e300c574f41101f502f51c6398c71a" name="document-revision">
+  <meta content="24ca8417f5d1326d1c589833ba0e9e39678f4ed0" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -4377,9 +4377,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
-  more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
-  delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>form-action</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
+  submission violates the <code>form-action</code> directive’s constraints, and "<code>Allowed</code>"
+  otherwise. This constitutes the <code>form-action</code> directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
      <li data-md>
       <p class="assertion">Assert: <var>source</var>, <var>target</var>, and <var>policy</var> are unused in this algorithm, as <code>form-action</code> is concerned only with details of the outgoing request.</p>

--- a/index.src.html
+++ b/index.src.html
@@ -3479,10 +3479,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|), a string |navigation type| ("`form-submission`" or
   "`other`"), two <a>browsing contexts</a> (|source| and |target|), and a
-  <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if one or
-  more of the ancestors of |target| violate the `frame-ancestors` directive
-  delivered with the response, and "`Allowed`" otherwise. This constitutes the
-  `form-action`' directive's <a>pre-navigation check</a>:
+  <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if a form
+  submission violates the `form-action` directive's constraints, and "`Allowed`"
+  otherwise. This constitutes the `form-action` directive's <a>pre-navigation check</a>:
 
   <ol class="algorithm">
     1.  Assert: |source|, |target|, and |policy| are unused in this algorithm, as


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/257


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/345.html" title="Last updated on Oct 8, 2018, 10:48 AM GMT (056aad2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/345/24ca841...andypaicu:056aad2.html" title="Last updated on Oct 8, 2018, 10:48 AM GMT (056aad2)">Diff</a>