### PR TITLE
Directive names should be lowercased (basically case-insensitive)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 47cb5324cd11789aef12f220cf86d1780f94ab9c" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="24ca8417f5d1326d1c589833ba0e9e39678f4ed0" name="document-revision">
+  <meta content="8c85e6728f3f097dfe30c663671abef51cda3402" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2079,9 +2079,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <li data-md>
         <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>.</p>
        <li data-md>
+        <p>Set <var>directive name</var> to be the result of running <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase" id="ref-for-ascii-lowercase">ASCII lowercase</a> on <var>directive name</var>.</p>
+        <p class="note" role="note"><span>Note:</span> Directive names are case-insensitive, that is: <code>script-SRC 'none'</code> and <code>ScRiPt-sRc 'none'</code> are virtually identical.</p>
+       <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
-        <p>In this case, the user agent SHOULD notify developers that a duplicate directive was
-  ignored. A console warning might be appropriate, for example.</p>
+        <p class="note" role="note"><span>Note:</span> In this case, the user agent SHOULD notify developers that a duplicate
+  directive was ignored. A console warning might be appropriate, for example.</p>
        <li data-md>
         <p>Let <var>directive value</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>token</var> on
   ASCII whitespace</a>.</p>
@@ -7331,6 +7334,13 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#ref-for-ascii-case-insensitive②②">(2)</a> <a href="#ref-for-ascii-case-insensitive②③">(3)</a> <a href="#ref-for-ascii-case-insensitive②④">(4)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
+   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ascii-lowercase">2.2.1. 
+    Parse a serialized CSP </a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-ascii-string">
    <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
@@ -7972,6 +7982,7 @@ rest of Google’s CSP Cabal.</p>
     <ul>
      <li><span class="dfn-paneled" id="term-for-set-append" style="color:initial">append <small>(for set)</small></span>
      <li><span class="dfn-paneled" id="term-for-ascii-case-insensitive" style="color:initial">ascii case-insensitive</span>
+     <li><span class="dfn-paneled" id="term-for-ascii-lowercase" style="color:initial">ascii lowercase</span>
      <li><span class="dfn-paneled" id="term-for-ascii-string" style="color:initial">ascii string</span>
      <li><span class="dfn-paneled" id="term-for-ascii-whitespace" style="color:initial">ascii whitespace</span>
      <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 47cb5324cd11789aef12f220cf86d1780f94ab9c" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="8c85e6728f3f097dfe30c663671abef51cda3402" name="document-revision">
+  <meta content="7f94bd6fdabe3f3209cd4089eeb9129939ba90a5" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2080,7 +2080,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>.</p>
        <li data-md>
         <p>Set <var>directive name</var> to be the result of running <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase" id="ref-for-ascii-lowercase">ASCII lowercase</a> on <var>directive name</var>.</p>
-        <p class="note" role="note"><span>Note:</span> Directive names are case-insensitive, that is: <code>script-SRC 'none'</code> and <code>ScRiPt-sRc 'none'</code> are virtually identical.</p>
+        <p class="note" role="note"><span>Note:</span> Directive names are case-insensitive, that is: <code>script-SRC 'none'</code> and <code>ScRiPt-sRc 'none'</code> are equivalent.</p>
        <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
         <p class="note" role="note"><span>Note:</span> In this case, the user agent SHOULD notify developers that a duplicate

--- a/index.src.html
+++ b/index.src.html
@@ -460,20 +460,26 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         3.  Let |directive name| be the result of [=collecting a sequence of code points=] from
             |token| which are not [=ASCII whitespace=].
 
-        4.  If |policy|'s [=policy/directive set=] contains a [=directive=] whose [=directive/name=]
+        4.  Set |directive name| to be the result of running <a>ASCII lowercase</a>
+            on |directive name|.
+
+            Note: Directive names are case-insensitive, that is: `script-SRC 'none'` and
+            `ScRiPt-sRc 'none'` are virtually identical.
+
+        5.  If |policy|'s [=policy/directive set=] contains a [=directive=] whose [=directive/name=]
             is |directive name|, [=iteration/continue=].
 
-            In this case, the user agent SHOULD notify developers that a duplicate directive was
-            ignored. A console warning might be appropriate, for example.
+            Note: In this case, the user agent SHOULD notify developers that a duplicate
+            directive was ignored. A console warning might be appropriate, for example.
 
-        5.  Let |directive value| be the result of
+        6.  Let |directive value| be the result of
             <a lt="split a string on ASCII whitespace">splitting |token| on
             ASCII whitespace</a>.
 
-        6.  Let |directive| be a new [=directive=] whose [=directive/name=] is |directive name|, and
+        7.  Let |directive| be a new [=directive=] whose [=directive/name=] is |directive name|, and
             [=directive/value=] is |directive value|.
 
-        7.  [=set/append|Append=] |directive| to |policy|'s [=policy/directive set=].
+        8.  [=set/append|Append=] |directive| to |policy|'s [=policy/directive set=].
 
     3.  Return |policy|.
   </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -464,7 +464,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
             on |directive name|.
 
             Note: Directive names are case-insensitive, that is: `script-SRC 'none'` and
-            `ScRiPt-sRc 'none'` are virtually identical.
+            `ScRiPt-sRc 'none'` are equivalent.
 
         5.  If |policy|'s [=policy/directive set=] contains a [=directive=] whose [=directive/name=]
             is |directive name|, [=iteration/continue=].


### PR DESCRIPTION
Fixes: https://github.com/w3c/webappsec-csp/issues/236

Tests for this will be upstreamed from a Chrome CR that will also fix this behaviour in Chrome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/346.html" title="Last updated on Oct 8, 2018, 12:59 PM GMT (d6115d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/346/8c85e67...andypaicu:d6115d1.html" title="Last updated on Oct 8, 2018, 12:59 PM GMT (d6115d1)">Diff</a>