### PR TITLE
Fixed navigations running on URL instead of current URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 47cb5324cd11789aef12f220cf86d1780f94ab9c" name="generator">
+  <meta content="Bikeshed version 1e757f3ee68e638e030f32dc3e8d2e3234d3aed5" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="7f94bd6fdabe3f3209cd4089eeb9129939ba90a5" name="document-revision">
+  <meta content="5c4813650bc2c4f39262ceedf50a92440eb182c7" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-08">8 October 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-10">10 October 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2767,7 +2767,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -2776,7 +2776,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         </ol>
       </ol>
      <li data-md>
-      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
+      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑧">CSP List</a>:</p>
@@ -2786,7 +2786,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <ol>
            <li data-md>
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <code>null</code>,
-  "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">url</a>,
+  "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>,
   skip to the next <var>directive</var>.</p>
            <li data-md>
             <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
@@ -2795,7 +2795,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
            <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md>
@@ -2832,7 +2832,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   we haven’t processed the navigation to create a Document yet.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑤">resource</a> to <var>navigation
-  response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">URL</a>.</p>
+  response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -4437,7 +4437,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑤">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
@@ -4690,12 +4690,12 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url⑥">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
+  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
@@ -6268,7 +6268,10 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">2.4.2. 
     Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-concept-request-current-url①">6.6.2.3. 
+    <li><a href="#ref-for-concept-request-current-url①">4.2.5. 
+    Should navigation request of type from source in target be blocked
+    by Content Security Policy? </a> <a href="#ref-for-concept-request-current-url②">(2)</a>
+    <li><a href="#ref-for-concept-request-current-url③">6.6.2.3. 
     Does request match source list? </a>
    </ul>
   </aside>
@@ -6677,15 +6680,12 @@ rest of Google’s CSP Cabal.</p>
     Initialize a Document's CSP list </a>
     <li><a href="#ref-for-concept-response-url①">4.2.2. 
     Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-response-url②">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-response-url③">(2)</a>
-    <li><a href="#ref-for-concept-response-url④">4.2.6. 
+    <li><a href="#ref-for-concept-response-url②">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response-url⑤">6.3.2.1. 
+    <li><a href="#ref-for-concept-response-url③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response-url⑥">6.6.2.4. 
+    <li><a href="#ref-for-concept-response-url④">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>

--- a/index.src.html
+++ b/index.src.html
@@ -1364,7 +1364,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                 object</a>, |policy|, and |directive|'s <a for="directive">name</a>.
 
             3.  Set |violation|'s <a for="violation">resource</a> to |navigation
-                request|'s <a for="response">URL</a>.
+                request|'s <a for="request">URL</a>.
 
             4.  Execute [[#report-violation]] on |violation|.
 
@@ -1372,7 +1372,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                 set |result| to "`Blocked`".
 
     3.  If |result| is "`Allowed`", and if |navigation request|'s
-        <a for="request">url</a>'s <a for="url">scheme</a> is `javascript`:
+        <a for="request">current URL</a>'s <a for="url">scheme</a> is `javascript`:
 
         1.  For each |policy| in |source|'s <a>active document</a>'s
             <a for="Document">CSP List</a>:
@@ -1381,7 +1381,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
                 1.  If |directive|'s <a for="directive">inline check</a>
                     returns "`Allowed`" when executed upon `null`,
-                    "`navigation`" and |navigation request|'s <a for="request">url</a>,
+                    "`navigation`" and |navigation request|'s <a for="request">current URL</a>,
                     skip to the next |directive|.
 
                 2.  Let |directive-name| be the result of executing
@@ -1392,7 +1392,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                     object</a>, |policy|, and |directive-name|.
 
                 4.  Set |violation|'s <a for="violation">resource</a> to |navigation
-                    request|'s <a for="response">URL</a>.
+                    request|'s <a for="request">URL</a>.
 
                 5.  Execute [[#report-violation]] on |violation|.
 


### PR DESCRIPTION
Also linking to request/URL instead of response/URL where it was incorrect.

For violation reports  and such, the URL is still used.

Fixes https://github.com/w3c/webappsec-csp/issues/343