### PR TITLE
Inherit source browsing context's CSP instead of parent/opener

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,11 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 3d3d56b4350a4c381fdf2373ffcf534daaa9ba33" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-<<<<<<< HEAD
-  <meta content="03288a3ee8528804d66b63190d60dffd78a787b5" name="document-revision">
-=======
-  <meta content="b042762ebf7c04665da0e421e9c1d7dd7c8405c7" name="document-revision">
->>>>>>> Inherit source browsing context's CSP instead of parent/opener
+  <meta content="c126ebc91a9864ffdc508953d61412f5f27427f3" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1509,11 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-06">6 November 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-24">24 October 2018</time></span></h2>
->>>>>>> Inherit source browsing context's CSP instead of parent/opener
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-07">7 November 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2621,6 +2613,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>:</p>
+        <p class="issue" id="issue-04a9cf28"><a class="self-link" href="#issue-04a9cf28"></a> <var>source</var>’s active document is incorrect here. <a href="https://github.com/w3c/webappsec-csp/issues/360">&lt;https://github.com/w3c/webappsec-csp/issues/360></a></p>
         <ol>
          <li data-md>
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
@@ -5443,11 +5436,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
-<<<<<<< HEAD
-  policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing context</a>. The goal is to ensure that a page can’t
-=======
   policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
->>>>>>> Inherit source browsing context's CSP instead of parent/opener
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5455,15 +5444,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
-<<<<<<< HEAD
-    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> which
-  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document④">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context②">opener browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> or vice-versa.</p>
-=======
-    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a> which
-  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> or vice-versa.</p>
->>>>>>> Inherit source browsing context's CSP instead of parent/opener
+    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
+  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> is a
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -8253,6 +8236,7 @@ rest of Google’s CSP Cabal.</p>
    <div class="issue"> This hook is missing from W3C’s HTML. <a href="https://github.com/w3c/html/issues/547">&lt;https://github.com/w3c/html/issues/547></a><a href="#issue-5faf83e6"> ↵ </a></div>
    <div class="issue"> W3C’s HTML is not based on Fetch, and does not
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a><a href="#issue-ed7a45a9"> ↵ </a></div>
+   <div class="issue"> <var>source</var>’s active document is incorrect here. <a href="https://github.com/w3c/webappsec-csp/issues/360">&lt;https://github.com/w3c/webappsec-csp/issues/360></a><a href="#issue-04a9cf28"> ↵ </a></div>
    <div class="issue"> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
   to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-d5a07bef"> ↵ </a></div>
@@ -9472,13 +9456,8 @@ rest of Google’s CSP Cabal.</p>
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
     <li><a href="#ref-for-global-object-csp-list①⑧">6.2.1.1. 
     Is base allowed for document? </a>
-<<<<<<< HEAD
     <li><a href="#ref-for-global-object-csp-list①⑨">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②⓪">(2)</a> <a href="#ref-for-global-object-csp-list②①">(3)</a> <a href="#ref-for-global-object-csp-list②②">(4)</a> <a href="#ref-for-global-object-csp-list②③">(5)</a>
-=======
-    <li><a href="#ref-for-global-object-csp-list①⑧">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list①⑨">(2)</a> <a href="#ref-for-global-object-csp-list②⓪">(3)</a> <a href="#ref-for-global-object-csp-list②①">(4)</a>
->>>>>>> Inherit source browsing context's CSP instead of parent/opener
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②⓪">(2)</a> <a href="#ref-for-global-object-csp-list②①">(3)</a> <a href="#ref-for-global-object-csp-list②②">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enforced">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,11 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 3d3d56b4350a4c381fdf2373ffcf534daaa9ba33" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
   <meta content="03288a3ee8528804d66b63190d60dffd78a787b5" name="document-revision">
+=======
+  <meta content="b042762ebf7c04665da0e421e9c1d7dd7c8405c7" name="document-revision">
+>>>>>>> Inherit source browsing context's CSP instead of parent/opener
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1509,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-06">6 November 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-24">24 October 2018</time></span></h2>
+>>>>>>> Inherit source browsing context's CSP instead of parent/opener
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2605,31 +2613,21 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a></p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Initialize a Document&apos;s CSP list" data-level="4.2.1" id="initialize-document-csp"><span class="secno">4.2.1. </span><span class="content"> Initialize a <code>Document</code>'s <code>CSP list</code> </span><a class="self-link" href="#initialize-document-csp"></a></h4>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> (<var>document</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), the
-  user agent performs the following steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> (<var>document</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> (<var>source</var>) the user agent performs the following
+  steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md>
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>documents</var> be an empty list.</p>
-       <li data-md>
-        <p>If <var>document</var> has an <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a> (<var>embedding</var>), then add <var>embedding</var> to <var>documents</var>.</p>
-       <li data-md>
-        <p>If <var>document</var> has an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context">opener browsing context</a>, then add its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a> to <var>documents</var>.</p>
-       <li data-md>
-        <p>For each <var>doc</var> in <var>documents</var>:</p>
+        <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>:</p>
         <ol>
          <li data-md>
-          <p>For each <var>policy</var> in <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>:</p>
-          <ol>
-           <li data-md>
-            <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
-          </ol>
+          <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+  therefore copy the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
@@ -2668,7 +2666,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
      <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
@@ -2752,7 +2750,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     by Content Security Policy?" data-level="4.2.5" id="should-block-navigation-request"><span class="secno">4.2.5. </span><span class="content"> Should <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked
     by Content Security Policy? </span><a class="self-link" href="#should-block-navigation-request"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①③">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
-  "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
+  "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
   the navigation, and "<code>Allowed</code>" otherwise:</p>
     <ol class="algorithm">
      <li data-md>
@@ -2814,7 +2812,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     in target be blocked by Content Security Policy?" data-level="4.2.6" id="should-block-navigation-response"><span class="secno">4.2.6. </span><span class="content"> Should <var>navigation response</var> to <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-navigation-response"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①④">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
   "<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> <var>navigation
-  response</var>, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
+  response</var>, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
   returns "<code>Blocked</code>" if the active policy blocks the navigation, and "<code>Allowed</code>"
   otherwise:</p>
     <ol class="algorithm">
@@ -4404,7 +4402,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
   submission violates the <code>form-action</code> directive’s constraints, and "<code>Allowed</code>"
   otherwise. This constitutes the <code>form-action</code> directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4437,7 +4435,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
@@ -4446,7 +4444,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing context</a>.</p>
      <li data-md>
       <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
      <li data-md>
@@ -4498,7 +4496,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing contexts</a> (<var>source</var> and <var>target</var>),
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>),
   and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
@@ -4522,14 +4520,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
       <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①③">browsing context</a>.</p>
      <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md>
@@ -5445,7 +5443,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
+<<<<<<< HEAD
   policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing context</a>. The goal is to ensure that a page can’t
+=======
+  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
+>>>>>>> Inherit source browsing context's CSP instead of parent/opener
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5453,9 +5455,15 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
+<<<<<<< HEAD
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> is a
   snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document④">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context②">opener browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> or vice-versa.</p>
+=======
+    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a> which
+  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> is a
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> or vice-versa.</p>
+>>>>>>> Inherit source browsing context's CSP instead of parent/opener
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -6844,20 +6852,22 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-browsing-context">2.3. Directives</a> <a href="#ref-for-browsing-context①">(2)</a>
     <li><a href="#ref-for-browsing-context②">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-browsing-context③">4.2.5. 
+    <li><a href="#ref-for-browsing-context③">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-browsing-context④">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context④">4.2.6. 
+    <li><a href="#ref-for-browsing-context⑤">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context⑤">6.3.1.1. 
+    <li><a href="#ref-for-browsing-context⑥">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-browsing-context⑥">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-browsing-context⑦">(2)</a> <a href="#ref-for-browsing-context⑧">(3)</a>
-    <li><a href="#ref-for-browsing-context⑨">6.3.3.1. 
+    <li><a href="#ref-for-browsing-context⑦">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-browsing-context⑧">(2)</a> <a href="#ref-for-browsing-context⑨">(3)</a>
+    <li><a href="#ref-for-browsing-context①⓪">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-browsing-context①⓪">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context①①">(2)</a> <a href="#ref-for-browsing-context①②">(3)</a>
+    <li><a href="#ref-for-browsing-context①①">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context①②">(2)</a> <a href="#ref-for-browsing-context①③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-case-sensitive">
@@ -7083,15 +7093,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-object-element⑥">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opener-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-opener-browsing-context">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-opener-browsing-context①">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-opener-browsing-context②">(2)</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
@@ -7271,6 +7272,15 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-settimeout">6.1.11. script-src</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-source-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-source-browsing-context">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-source-browsing-context①">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
@@ -7950,7 +7960,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-browsing-context-nested-through" style="color:initial">nested through</span>
      <li><span class="dfn-paneled" id="term-for-attr-nonce" style="color:initial">nonce</span>
      <li><span class="dfn-paneled" id="term-for-the-object-element" style="color:initial">object</span>
-     <li><span class="dfn-paneled" id="term-for-opener-browsing-context" style="color:initial">opener browsing context</span>
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
      <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
@@ -7974,6 +7983,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-set-the-frozen-base-url" style="color:initial">set the frozen base url</span>
      <li><span class="dfn-paneled" id="term-for-dom-setinterval" style="color:initial">setInterval()</span>
      <li><span class="dfn-paneled" id="term-for-dom-settimeout" style="color:initial">setTimeout()</span>
+     <li><span class="dfn-paneled" id="term-for-source-browsing-context" style="color:initial">source browsing context</span>
      <li><span class="dfn-paneled" id="term-for-the-style-element" style="color:initial">style</span>
      <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
      <li><span class="dfn-paneled" id="term-for-attr-embed-type" style="color:initial">type</span>
@@ -9462,8 +9472,13 @@ rest of Google’s CSP Cabal.</p>
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
     <li><a href="#ref-for-global-object-csp-list①⑧">6.2.1.1. 
     Is base allowed for document? </a>
+<<<<<<< HEAD
     <li><a href="#ref-for-global-object-csp-list①⑨">7.8. 
     CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②⓪">(2)</a> <a href="#ref-for-global-object-csp-list②①">(3)</a> <a href="#ref-for-global-object-csp-list②②">(4)</a> <a href="#ref-for-global-object-csp-list②③">(5)</a>
+=======
+    <li><a href="#ref-for-global-object-csp-list①⑧">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list①⑨">(2)</a> <a href="#ref-for-global-object-csp-list②⓪">(3)</a> <a href="#ref-for-global-object-csp-list②①">(4)</a>
+>>>>>>> Inherit source browsing context's CSP instead of parent/opener
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enforced">
@@ -9485,12 +9500,8 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="embedding-document">
    <b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-embedding-document">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-embedding-document①">(2)</a>
-    <li><a href="#ref-for-embedding-document②">4.2.2. 
+    <li><a href="#ref-for-embedding-document">4.2.2. 
     Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-embedding-document③">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-embedding-document④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-report">

--- a/index.src.html
+++ b/index.src.html
@@ -1193,32 +1193,21 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Initialize a `Document`'s `CSP list`
   </h4>
 
-  Given a {{Document}} (|document|), and a <a>response</a> (|response|), the
-  user agent performs the following steps in order to initialize |document|'s
-  <a for="Document">CSP list</a>:
+  Given a {{Document}} (|document|), a <a>response</a> (|response|), and a
+  <a>browsing context</a> (|source|) the user agent performs the following
+  steps in order to initialize |document|'s <a for="Document">CSP list</a>:
 
   1.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a> is a
       <a>local scheme</a>:
 
-      1.  Let |documents| be an empty list.
+      1.  For each |policy| in |source|'s <a>active document</a>'s
+          <a for="Document">CSP list</a>:
 
-      2.  If |document| has an <a>embedding document</a> (|embedding|), then add
-          |embedding| to |documents|.
-
-      3.  If |document| has an <a>opener browsing context</a>, then add its
-          <a>active document</a> to |documents|.
-
-      4.  For each |doc| in |documents|:
-
-          1.  For each |policy| in |doc|'s <a for="Document">CSP list</a>:
-
-              1.  Insert a copy of |policy| into |document|'s
-                  <a for="Document">CSP list</a>.
-
+          1.  Insert a copy of |policy| into |document|'s
+              <a for="Document">CSP list</a>.
 
       Note: <a>local scheme</a> includes `about:`, and this algorithm will
-      therefore copy the <a>embedding document</a>'s policies for <a>an iframe
-      `srcdoc` `Document`</a>.
+      therefore copy the <a>source browsing context</a>'s policies for <a>an iframe `srcdoc` `Document`</a>.
 
       Note: We do all this to ensure that a page cannot bypass its <a for="/">policy</a>
       by embedding a frame or popping up a new window containing content it
@@ -4771,8 +4760,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   As described in [[#initialize-document-csp]] and [[#initialize-global-object-csp]],
   documents loaded from <a>local schemes</a> will inherit a copy of the
-  policies in the <a for="global object">CSP list</a> of the <a>embedding document</a>
-  or <a>opener browsing context</a>. The goal is to ensure that a page can't
+  policies in the <a>source browsing context</a>. The goal is to ensure that a page can't
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (`srcdoc` documents, `blob:` or `data:`
   URLs, `about:blank` documents that can be manipulated via `document.write()`, etc).
@@ -4790,8 +4778,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   means that the new {{Document}}'s <a for="global object">CSP list</a> is a
   snapshot of the relevant policies at its creation time. Modifications in the
   <a for="global object">CSP list</a> of the new {{Document}} won't affect the
-  <a>embedding document</a> or <a>opener browsing context</a>'s
-  <a for="global object">CSP list</a> or vice-versa.
+  <a>source browsing context</a>'s <a for="global object">CSP list</a> or vice-versa.
 
   <div class="example">
     In the example below the image inside the iframe will not load because it is

--- a/index.src.html
+++ b/index.src.html
@@ -975,7 +975,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       header. If we get a response from a Service Worker (via <a>HTTP fetch</a>,
       we'll process its <a for="response">CSP list</a> before handing the
       response back to our caller.
-      
+
       Note: A fetch request abides by the <a for="/">global object</a>'s
       <a for="global object">CSP list</a> including any redirects it might follow.
       Any <a http-header>Content-Security-Policy</a> headers found in a redirect
@@ -1202,6 +1202,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
       1.  For each |policy| in |source|'s <a>active document</a>'s
           <a for="Document">CSP list</a>:
+
+          ISSUE(w3c/webappsec-csp#360): |source|'s active document is incorrect here.
 
           1.  Insert a copy of |policy| into |document|'s
               <a for="Document">CSP list</a>.


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/209
Fixes https://github.com/w3c/webappsec-csp/issues/211


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/358.html" title="Last updated on Nov 7, 2018, 10:48 AM GMT (1068f9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/358/df35fe4...andypaicu:1068f9a.html" title="Last updated on Nov 7, 2018, 10:48 AM GMT (1068f9a)">Diff</a>