### PR TITLE
Add a `self-origin` member to policy to facilitate opaque origin contexts that inherit their policies

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,19 @@ Possible extra rowspan handling
 		}
 	}
 </style>
+<<<<<<< HEAD
   <meta content="Bikeshed version 0da7328bb90ef81993146377e4e0fed236969c4c" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
   <meta content="5730913006762928a91facf69b31d7b8b99ab167" name="document-revision">
+=======
+  <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
+  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
+  <meta content="c126ebc91a9864ffdc508953d61412f5f27427f3" name="document-revision">
+=======
+  <meta content="df35fe41260ecd426e7f33dfa6bc1e0b432e1424" name="document-revision">
+>>>>>>> Initialize self-origin as part of the response CSP list init process
+>>>>>>> Initialize self-origin as part of the response CSP list init process
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1515,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-23">23 November 2018</time></span></h2>
+=======
+<<<<<<< HEAD
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-07">7 November 2018</time></span></h2>
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-08">8 November 2018</time></span></h2>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
+>>>>>>> Initialize self-origin as part of the response CSP list init process
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2050,6 +2068,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   "<code>enforce</code>" or "<code>report</code>".</p>
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-source">source</dfn>, which is either "<code>header</code>"
   or "<code>meta</code>".</p>
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-self-origin">self-origin</dfn>, which
+  is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> that is used when doing <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> matching. This is
+  needed to facilitate the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①"><code>'self'</code></a> checks of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> documents/workers that have inherited their policy but have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>. <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> describes situations when a policy is inherited.</p>
     <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="csp-list">CSP list</dfn>.</p>
     <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
@@ -2179,7 +2200,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   expression</dfn>:</p>
     <ol>
      <li data-md>
-      <p>Keywords such as <a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none"><code>'none'</code></a> and <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> (which match nothing and the current
+      <p>Keywords such as <a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none"><code>'none'</code></a> and <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②"><code>'self'</code></a> (which match nothing and the current
   URL’s origin, respectively)</p>
      <li data-md>
       <p>Serialized URLs such as <code>https://example.com/path/to/file.js</code> (which matches a specific file) or <code>https://example.com/</code> (which matches everything on that origin)</p>
@@ -2449,6 +2470,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>For each <var>policy</var> in <var>policies</var>:</p>
       <ol>
        <li data-md>
+        <p>Set <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin">self-origin</a> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>.</p>
+       <li data-md>
         <p>Insert <var>policy</var> into <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑤">CSP list</a>.</p>
       </ol>
     </ol>
@@ -2607,7 +2630,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md>
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a>:</p>
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a>:</p>
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
@@ -2616,8 +2639,13 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
+<<<<<<< HEAD
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+=======
+      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a> includes <code>about:</code>, and this algorithm will
+  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
@@ -2638,7 +2666,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
     <ol>
      <li data-md>
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
       <ol>
        <li data-md>
         <p>Let <var>owners</var> be an empty list.</p>
@@ -2655,8 +2683,13 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           </ol>
         </ol>
       </ol>
+<<<<<<< HEAD
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+=======
+      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local scheme</a> includes <code>about:</code>, and this algorithm will
+  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
      <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
@@ -2821,7 +2854,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   we haven’t processed the navigation to create a Document yet.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑤">resource</a> to <var>navigation
-  response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">URL</a>.</p>
+  response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -3345,8 +3378,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3359,8 +3391,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3376,22 +3408,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
     <div class="example" id="example-327c55f5">
      <a class="self-link" href="#example-327c55f5"></a> The following header: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src①">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src①">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src①">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src①">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
@@ -3400,22 +3432,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑧">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑧">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
                          <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -3491,8 +3523,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3505,8 +3536,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3535,8 +3566,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3549,8 +3579,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3581,8 +3611,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3595,8 +3625,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3625,8 +3655,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3639,8 +3669,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3672,8 +3702,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3686,8 +3716,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3716,8 +3746,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>,
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3730,8 +3761,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
-  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3778,8 +3809,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3792,8 +3823,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3846,7 +3877,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var>,
+  this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
@@ -3857,7 +3889,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var>, this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
@@ -3904,7 +3936,8 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var> and this directive.</p>
+      <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var>,
+  this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
@@ -3915,7 +3948,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var> and this directive.</p>
+      <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var>, this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
@@ -4014,8 +4047,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4032,8 +4065,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4075,8 +4108,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4093,8 +4126,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4161,8 +4194,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4175,8 +4208,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4207,7 +4240,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md>
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md>
-        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url" id="ref-for-fallback-base-url">fallback base URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
+        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin①">self-origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
          <li data-md>
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global
@@ -4396,8 +4429,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md>
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, and a <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4412,7 +4444,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③⓪">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①①">meta</a></code> element.</p>
@@ -4425,7 +4457,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
+<<<<<<< HEAD
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
+=======
+      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>,
+  are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
+>>>>>>> Initialize self-origin as part of the response CSP list init process
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
@@ -4444,9 +4481,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>document</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-origin" id="ref-for-dom-document-origin">origin</a></code>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
+<<<<<<< HEAD
   executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return "<code>Blocked</code>".</p>
        <li data-md>
         <p>Set <var>current</var> to <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing context</a>.</p>
+=======
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin②">self-origin</a>, and <code>0</code>, return
+  "<code>Blocked</code>".</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4495,8 +4537,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
   wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4521,8 +4563,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -4576,7 +4618,12 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
+<<<<<<< HEAD
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+=======
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>),
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>):</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
@@ -4626,15 +4673,20 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md>
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
-  "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
+<<<<<<< HEAD
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+=======
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>),
+  a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like②">script-like</a>:</p>
@@ -4648,15 +4700,19 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md>
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
-  "<code>Blocked</code>".</p>
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
+<<<<<<< HEAD
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+=======
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a> (<var>policy</var>), this
+>>>>>>> Initialize self-origin as part of the response CSP list init process
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4693,6 +4749,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
+<<<<<<< HEAD
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
@@ -4701,9 +4758,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
+=======
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect count</a>.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect count</a>.</p>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4729,10 +4794,10 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.2.6" id="match-url-to-source-expression"><span class="secno">6.6.2.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑨">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①⓪">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑨">source expression</a> (<var>expression</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this algorithm
   returns "<code>Matches</code>" if <var>url</var> matches <var>expression</var>, and "<code>Does Not Match</code>"
   otherwise.</p>
-    <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
+    <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
   meaning depending on that bit of context.</p>
     <ol>
      <li data-md>
@@ -4789,7 +4854,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   return "<code>Matches</code>" if one or more of the following conditions is met:</p>
       <ol>
        <li data-md>
-        <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin②">origin</a></p>
+        <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a></p>
        <li data-md>
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
   or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
@@ -5310,7 +5375,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   we are currently checking a worker request), a <code>default-src</code> directive
   should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
-  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
@@ -5332,7 +5397,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧③">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5452,8 +5517,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   secure variant.</p>
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
+<<<<<<< HEAD
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
   policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
+=======
+  documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑥">local schemes</a> will inherit a copy of the
+  policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing context</a>. The goal is to ensure that a page can’t
+>>>>>>> Initialize self-origin as part of the response CSP list init process
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5519,7 +5589,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <ol>
      <li data-md>
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③①"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -5637,7 +5707,7 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧④">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5856,16 +5926,16 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-documenturl">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li>
-    effective directive
-    <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
-     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
-    </ul>
-   <li>
     effectiveDirective
     <ul>
      <li><a href="#dom-securitypolicyviolationevent-effectivedirective">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-effectivedirective">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
+    </ul>
+   <li>
+    effective directive
+    <ul>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
+     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li><a href="#violation-element">element</a><span>, in §2.4</span>
    <li><a href="#embedding-document">embedding document</a><span>, in §4.2</span>
@@ -5966,6 +6036,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent">SecurityPolicyViolationEvent(type)</a><span>, in §5.1</span>
    <li><a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent">SecurityPolicyViolationEvent(type, eventInitDict)</a><span>, in §5.1</span>
    <li><a href="#grammardef-self">'self'</a><span>, in §2.3.1</span>
+   <li><a href="#policy-self-origin">self-origin</a><span>, in §2.2</span>
    <li><a href="#serialized-csp">serialized CSP</a><span>, in §2.2</span>
    <li><a href="#serialized-csp-list">serialized CSP list</a><span>, in §2.2</span>
    <li><a href="#serialized-directive">serialized directive</a><span>, in §2.3</span>
@@ -6398,11 +6469,12 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-scheme">1.3. Changes from Level 2</a>
-    <li><a href="#ref-for-local-scheme①">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-local-scheme②">(2)</a>
-    <li><a href="#ref-for-local-scheme③">4.2.2. 
-    Initialize a global object’s CSP list </a> <a href="#ref-for-local-scheme④">(2)</a>
-    <li><a href="#ref-for-local-scheme⑤">7.8. 
+    <li><a href="#ref-for-local-scheme①">2.2. Policies</a>
+    <li><a href="#ref-for-local-scheme②">4.2.1. 
+    Initialize a Document's CSP list </a> <a href="#ref-for-local-scheme③">(2)</a>
+    <li><a href="#ref-for-local-scheme④">4.2.2. 
+    Initialize a global object’s CSP list </a> <a href="#ref-for-local-scheme⑤">(2)</a>
+    <li><a href="#ref-for-local-scheme⑥">7.8. 
     CSP Inheriting to avoid bypasses </a>
    </ul>
   </aside>
@@ -6447,10 +6519,6 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-request-origin">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request-origin①">6.6.2.3. 
-    Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-origin②">6.6.2.4. 
-    Does response to request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-parser-metadata">
@@ -6707,15 +6775,15 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-response-url">
    <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-url">4.2.1. 
+    <li><a href="#ref-for-concept-response-url">4.1.1. 
+    Set response’s CSP list </a>
+    <li><a href="#ref-for-concept-response-url①">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-response-url①">4.2.2. 
+    <li><a href="#ref-for-concept-response-url②">4.2.2. 
     Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-response-url②">4.2.6. 
+    <li><a href="#ref-for-concept-response-url③">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response-url③">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
     <li><a href="#ref-for-concept-response-url④">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
@@ -6942,13 +7010,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-embed-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fallback-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fallback-base-url">6.2.1.1. 
-    Is base allowed for document? </a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-forced-sandboxing-flag-set">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
@@ -7091,6 +7152,24 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-object-element⑥">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
+<<<<<<< HEAD
+=======
+  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
+   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-origin-opaque">2.2. Policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-opener-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-opener-browsing-context">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-opener-browsing-context①">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-opener-browsing-context②">(2)</a>
+   </ul>
+  </aside>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
   <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
@@ -7688,11 +7767,9 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-origin">
    <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-origin">6.2.1.1. 
-    Is base allowed for document? </a>
-    <li><a href="#ref-for-concept-url-origin①">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-url-origin②">6.6.2.6. 
+    <li><a href="#ref-for-concept-url-origin">4.1.1. 
+    Set response’s CSP list </a>
+    <li><a href="#ref-for-concept-url-origin①">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
@@ -7921,7 +7998,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-document-2" style="color:initial">document</span>
      <li><span class="dfn-paneled" id="term-for-parse-error-duplicate-attribute" style="color:initial">duplicate-attribute</span>
      <li><span class="dfn-paneled" id="term-for-the-embed-element" style="color:initial">embed</span>
-     <li><span class="dfn-paneled" id="term-for-fallback-base-url" style="color:initial">fallback base url</span>
      <li><span class="dfn-paneled" id="term-for-forced-sandboxing-flag-set" style="color:initial">forced sandboxing flag set</span>
      <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
      <li><span class="dfn-paneled" id="term-for-frame" style="color:initial">frame</span>
@@ -7936,6 +8012,11 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-browsing-context-nested-through" style="color:initial">nested through</span>
      <li><span class="dfn-paneled" id="term-for-attr-nonce" style="color:initial">nonce</span>
      <li><span class="dfn-paneled" id="term-for-the-object-element" style="color:initial">object</span>
+<<<<<<< HEAD
+=======
+     <li><span class="dfn-paneled" id="term-for-concept-origin-opaque" style="color:initial">opaque origin</span>
+     <li><span class="dfn-paneled" id="term-for-opener-browsing-context" style="color:initial">opener browsing context</span>
+>>>>>>> Initialize self-origin as part of the response CSP list init process
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
      <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
@@ -8390,12 +8471,20 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Pre-Navigation Check </a>
     <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.1.1. 
+    Script directives pre-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.6.1.2. 
+    Script directives post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑦⑨">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    <li><a href="#ref-for-content-security-policy-object⑧⓪">6.6.2.3. 
+    Does request match source list? </a>
+    <li><a href="#ref-for-content-security-policy-object⑧①">6.6.2.4. 
+    Does response to request match source list? </a>
+    <li><a href="#ref-for-content-security-policy-object⑧②">6.7.4. 
     Should fetch directive execute </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑧③">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑧④">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8462,6 +8551,21 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP list </a> <a href="#ref-for-policy-source④">(2)</a>
     <li><a href="#ref-for-policy-source⑤">4.1.1. 
     Set response’s CSP list </a> <a href="#ref-for-policy-source⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="policy-self-origin">
+   <b><a href="#policy-self-origin">#policy-self-origin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-policy-self-origin">4.1.1. 
+    Set response’s CSP list </a>
+    <li><a href="#ref-for-policy-self-origin①">6.2.1.1. 
+    Is base allowed for document? </a>
+    <li><a href="#ref-for-policy-self-origin②">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a>
+    <li><a href="#ref-for-policy-self-origin③">6.6.2.3. 
+    Does request match source list? </a>
+    <li><a href="#ref-for-policy-self-origin④">6.6.2.4. 
+    Does response to request match source list? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="csp-list">
@@ -9085,10 +9189,11 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="grammardef-self">
    <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-self">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self①">6.1.3. default-src</a> <a href="#ref-for-grammardef-self②">(2)</a> <a href="#ref-for-grammardef-self③">(3)</a> <a href="#ref-for-grammardef-self④">(4)</a> <a href="#ref-for-grammardef-self⑤">(5)</a> <a href="#ref-for-grammardef-self⑥">(6)</a> <a href="#ref-for-grammardef-self⑦">(7)</a> <a href="#ref-for-grammardef-self⑧">(8)</a> <a href="#ref-for-grammardef-self⑨">(9)</a> <a href="#ref-for-grammardef-self①⓪">(10)</a> <a href="#ref-for-grammardef-self①①">(11)</a> <a href="#ref-for-grammardef-self①②">(12)</a> <a href="#ref-for-grammardef-self①③">(13)</a> <a href="#ref-for-grammardef-self①④">(14)</a> <a href="#ref-for-grammardef-self①⑤">(15)</a> <a href="#ref-for-grammardef-self①⑥">(16)</a> <a href="#ref-for-grammardef-self①⑦">(17)</a> <a href="#ref-for-grammardef-self①⑧">(18)</a> <a href="#ref-for-grammardef-self①⑨">(19)</a> <a href="#ref-for-grammardef-self②⓪">(20)</a> <a href="#ref-for-grammardef-self②①">(21)</a> <a href="#ref-for-grammardef-self②②">(22)</a> <a href="#ref-for-grammardef-self②③">(23)</a> <a href="#ref-for-grammardef-self②④">(24)</a> <a href="#ref-for-grammardef-self②⑤">(25)</a> <a href="#ref-for-grammardef-self②⑥">(26)</a> <a href="#ref-for-grammardef-self②⑦">(27)</a>
-    <li><a href="#ref-for-grammardef-self②⑧">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self②⑨">8.2. 
+    <li><a href="#ref-for-grammardef-self">2.2. Policies</a> <a href="#ref-for-grammardef-self①">(2)</a>
+    <li><a href="#ref-for-grammardef-self②">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-grammardef-self③">6.1.3. default-src</a> <a href="#ref-for-grammardef-self④">(2)</a> <a href="#ref-for-grammardef-self⑤">(3)</a> <a href="#ref-for-grammardef-self⑥">(4)</a> <a href="#ref-for-grammardef-self⑦">(5)</a> <a href="#ref-for-grammardef-self⑧">(6)</a> <a href="#ref-for-grammardef-self⑨">(7)</a> <a href="#ref-for-grammardef-self①⓪">(8)</a> <a href="#ref-for-grammardef-self①①">(9)</a> <a href="#ref-for-grammardef-self①②">(10)</a> <a href="#ref-for-grammardef-self①③">(11)</a> <a href="#ref-for-grammardef-self①④">(12)</a> <a href="#ref-for-grammardef-self①⑤">(13)</a> <a href="#ref-for-grammardef-self①⑥">(14)</a> <a href="#ref-for-grammardef-self①⑦">(15)</a> <a href="#ref-for-grammardef-self①⑧">(16)</a> <a href="#ref-for-grammardef-self①⑨">(17)</a> <a href="#ref-for-grammardef-self②⓪">(18)</a> <a href="#ref-for-grammardef-self②①">(19)</a> <a href="#ref-for-grammardef-self②②">(20)</a> <a href="#ref-for-grammardef-self②③">(21)</a> <a href="#ref-for-grammardef-self②④">(22)</a> <a href="#ref-for-grammardef-self②⑤">(23)</a> <a href="#ref-for-grammardef-self②⑥">(24)</a> <a href="#ref-for-grammardef-self②⑦">(25)</a> <a href="#ref-for-grammardef-self②⑧">(26)</a> <a href="#ref-for-grammardef-self②⑨">(27)</a>
+    <li><a href="#ref-for-grammardef-self③⓪">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self③①">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>

--- a/index.html
+++ b/index.html
@@ -1212,23 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-<<<<<<< HEAD
-  <meta content="Bikeshed version 0da7328bb90ef81993146377e4e0fed236969c4c" name="generator">
+  <meta content="Bikeshed version 1aac991e58c33dfe3b8db7962e04b859eef562d3" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="5730913006762928a91facf69b31d7b8b99ab167" name="document-revision">
-=======
-  <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
-  <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-<<<<<<< HEAD
-<<<<<<< HEAD
-  <meta content="c126ebc91a9864ffdc508953d61412f5f27427f3" name="document-revision">
-=======
-  <meta content="df35fe41260ecd426e7f33dfa6bc1e0b432e1424" name="document-revision">
->>>>>>> Initialize self-origin as part of the response CSP list init process
->>>>>>> Initialize self-origin as part of the response CSP list init process
-=======
-  <meta content="9ebc31d25ce899c589a8ba2a8559369f414d0972" name="document-revision">
->>>>>>> Added note and merged
+  <meta content="5ce73dae3c6aac015b0e012482c6746a62983699" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1519,19 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-<<<<<<< HEAD
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-23">23 November 2018</time></span></h2>
-=======
-<<<<<<< HEAD
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-07">7 November 2018</time></span></h2>
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-08">8 November 2018</time></span></h2>
->>>>>>> Initialize self-origin as part of the response CSP list init process
->>>>>>> Initialize self-origin as part of the response CSP list init process
-=======
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-08">8 November 2018</time></span></h2>
->>>>>>> Added note and merged
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-28">28 November 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4462,12 +4436,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
-<<<<<<< HEAD
-      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
-=======
-      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>,
-  are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
->>>>>>> Initialize self-origin as part of the response CSP list init process
+      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, and <var>navigation type</var>, are
+  unused in this algorithm, as <code>frame-ancestors</code> is concerned only
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
@@ -4483,25 +4453,12 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
        <li data-md>
         <p>Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code> that <var>current</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through①">nested through</a>.</p>
        <li data-md>
-<<<<<<< HEAD
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>document</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-origin" id="ref-for-dom-document-origin">origin</a></code>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-<<<<<<< HEAD
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return "<code>Blocked</code>".</p>
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <code>0</code>, return "<code>Blocked</code>".</p>
        <li data-md>
         <p>Set <var>current</var> to <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing context</a>.</p>
-=======
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin②">self-origin</a>, and <code>0</code>, return
-=======
-        <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
-  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a>.</p>
-       <li data-md>
-        <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <code>0</code>, return
->>>>>>> Added note and merged
-  "<code>Blocked</code>".</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4631,12 +4588,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-<<<<<<< HEAD
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
-=======
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>),
   and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>):</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
@@ -4694,12 +4647,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
-<<<<<<< HEAD
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
-=======
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>),
   a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like②">script-like</a>:</p>
@@ -4721,11 +4670,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-<<<<<<< HEAD
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
-=======
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a> (<var>policy</var>), this
->>>>>>> Initialize self-origin as part of the response CSP list init process
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4762,27 +4707,12 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-<<<<<<< HEAD
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
-  count</a>.</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect count</a>.</p>
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
-  this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
-  count</a>.</p>
-=======
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
-    <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
-<<<<<<< HEAD
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect count</a>.</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
-=======
   and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin⑤">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect count</a>.</p>
->>>>>>> Added note and merged
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
@@ -5543,15 +5473,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
-<<<<<<< HEAD
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
-=======
-    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
-  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context③">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> or vice-versa.</p>
->>>>>>> Added note and merged
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context③">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -7190,11 +7114,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-settings-object-origin">2.2. Policies</a>
     <li><a href="#ref-for-concept-settings-object-origin①">5.3. 
     Report a violation </a>
-<<<<<<< HEAD
-=======
-    <li><a href="#ref-for-concept-settings-object-origin②">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
->>>>>>> Added note and merged
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">

--- a/index.html
+++ b/index.html
@@ -1220,11 +1220,15 @@ Possible extra rowspan handling
   <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
 <<<<<<< HEAD
+<<<<<<< HEAD
   <meta content="c126ebc91a9864ffdc508953d61412f5f27427f3" name="document-revision">
 =======
   <meta content="df35fe41260ecd426e7f33dfa6bc1e0b432e1424" name="document-revision">
 >>>>>>> Initialize self-origin as part of the response CSP list init process
 >>>>>>> Initialize self-origin as part of the response CSP list init process
+=======
+  <meta content="9ebc31d25ce899c589a8ba2a8559369f414d0972" name="document-revision">
+>>>>>>> Added note and merged
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1516,6 +1520,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
 <<<<<<< HEAD
+<<<<<<< HEAD
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-23">23 November 2018</time></span></h2>
 =======
 <<<<<<< HEAD
@@ -1524,6 +1529,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-08">8 November 2018</time></span></h2>
 >>>>>>> Initialize self-origin as part of the response CSP list init process
 >>>>>>> Initialize self-origin as part of the response CSP list init process
+=======
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-08">8 November 2018</time></span></h2>
+>>>>>>> Added note and merged
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2069,8 +2077,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-source">source</dfn>, which is either "<code>header</code>"
   or "<code>meta</code>".</p>
     <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-self-origin">self-origin</dfn>, which
-  is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> that is used when doing <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> matching. This is
-  needed to facilitate the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①"><code>'self'</code></a> checks of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> documents/workers that have inherited their policy but have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>. <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> describes situations when a policy is inherited.</p>
+  is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> that is used when matching the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> keyword.</p>
+    <p class="note" role="note"><span>Note:</span> This is needed to facilitate the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①"><code>'self'</code></a> checks of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> documents/workers that have inherited their policy but
+  have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>. Most of the time this will simply be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a>.
+  The <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> algorithm describes situations in which
+  a policy is inherited.</p>
     <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="csp-list">CSP list</dfn>.</p>
     <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
@@ -2639,13 +2650,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
-<<<<<<< HEAD
-      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-=======
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
+  therefore copy the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
+      <p class="note" role="note"><span>Note:</span> Since <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin①">self-origin</a> is also copied, any <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③"><code>'self'</code></a> checks will be using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>’s origin. This is
+  done for the purpose of making <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④"><code>'self'</code></a> make sense in documents
+  with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque①">opaque origins</a>. The <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤"><code>'self'</code></a> keyword is used
+  in the <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> algorithm.</p>
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
@@ -2683,13 +2693,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           </ol>
         </ol>
       </ol>
-<<<<<<< HEAD
-      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-=======
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
->>>>>>> Initialize self-origin as part of the response CSP list init process
+  therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
      <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
@@ -3172,7 +3177,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
              <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑥">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings
-  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a></p>
+  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a></p>
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
              <dd data-md>
               <p>"<code>no-window</code>"</p>
@@ -3408,22 +3413,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
     <div class="example" id="example-327c55f5">
      <a class="self-link" href="#example-327c55f5"></a> The following header: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③">'self'</a>
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src①">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src①">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src①">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src①">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①①">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①②">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①③">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src①">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①④">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem">script-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>
 </pre>
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
@@ -3432,22 +3437,22 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑦">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
 </pre>
      <p>will have the same behavior as the following header:</p>
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑧">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①⑨">'self'</a>;
-                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>;
-                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
-                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
-                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
-                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
-                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑧">Content-Security-Policy</a>: <a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src②">connect-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②①">'self'</a>;
+                         <a data-link-type="dfn" href="#font-src" id="ref-for-font-src②">font-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②②">'self'</a>;
+                         <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src①">frame-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②③">'self'</a>;
+                         <a data-link-type="dfn" href="#img-src" id="ref-for-img-src①">img-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②④">'self'</a>;
+                         <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src①">manifest-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑤">'self'</a>;
+                         <a data-link-type="dfn" href="#media-src" id="ref-for-media-src①">media-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
+                         <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src①">prefetch-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>;
+                         <a data-link-type="dfn" href="#object-src" id="ref-for-object-src②">object-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>;
                          <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem②">script-src-elem</a> https://example.com;
-                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑥">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑦">'self'</a>;
-                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑧">'self'</a>;
-                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨">'self'</a>
+                         <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr①">script-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⑨">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem①">style-src-elem</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③⓪">'self'</a>;
+                         <a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr①">style-src-attr</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③①">'self'</a>;
+                         <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src①">worker-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③②">'self'</a>
 </pre>
      <p>Given this behavior, one good way to build a policy for a site would be to
     begin with a <code>default-src</code> of <code>'none'</code>, and to build up a policy from there
@@ -4240,7 +4245,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md>
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md>
-        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin①">self-origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
+        <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin②">self-origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
          <li data-md>
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global
@@ -4444,7 +4449,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③⓪">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③③">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①①">meta</a></code> element.</p>
@@ -4478,6 +4483,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
        <li data-md>
         <p>Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code> that <var>current</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through①">nested through</a>.</p>
        <li data-md>
+<<<<<<< HEAD
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>document</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-origin" id="ref-for-dom-document-origin">origin</a></code>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
@@ -4487,6 +4493,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
         <p>Set <var>current</var> to <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing context</a>.</p>
 =======
   executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin②">self-origin</a>, and <code>0</code>, return
+=======
+        <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
+  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a>.</p>
+       <li data-md>
+        <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <code>0</code>, return
+>>>>>>> Added note and merged
   "<code>Blocked</code>".</p>
 >>>>>>> Initialize self-origin as part of the response CSP list init process
       </ol>
@@ -4760,12 +4773,16 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   count</a>.</p>
 =======
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect count</a>.</p>
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect count</a>.</p>
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+<<<<<<< HEAD
   and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin④">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect count</a>.</p>
 >>>>>>> Initialize self-origin as part of the response CSP list init process
+=======
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin⑤">self-origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect count</a>.</p>
+>>>>>>> Added note and merged
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
@@ -5517,13 +5534,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   secure variant.</p>
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
-<<<<<<< HEAD
-  documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
-  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
-=======
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑥">local schemes</a> will inherit a copy of the
-  policies in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document③">embedding document</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context" id="ref-for-opener-browsing-context①">opener browsing context</a>. The goal is to ensure that a page can’t
->>>>>>> Initialize self-origin as part of the response CSP list init process
+  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>. The goal is to ensure that a page can’t
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5531,9 +5543,15 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
+<<<<<<< HEAD
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
   snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
+=======
+    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
+  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> is a
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context③">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> or vice-versa.</p>
+>>>>>>> Added note and merged
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -5589,7 +5607,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <ol>
      <li data-md>
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
-  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③①"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
+  and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③④"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
@@ -7010,6 +7028,12 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-embed-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object">2.2. Policies</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-forced-sandboxing-flag-set">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
@@ -7152,29 +7176,25 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-object-element⑥">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-<<<<<<< HEAD
-=======
   <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.2. Policies</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-opener-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-opener-browsing-context">4.2.1. 
+    <li><a href="#ref-for-concept-origin-opaque①">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-opener-browsing-context①">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-opener-browsing-context②">(2)</a>
    </ul>
   </aside>
->>>>>>> Initialize self-origin as part of the response CSP list init process
   <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-settings-object-origin">5.3. 
+    <li><a href="#ref-for-concept-settings-object-origin">2.2. Policies</a>
+    <li><a href="#ref-for-concept-settings-object-origin①">5.3. 
     Report a violation </a>
+<<<<<<< HEAD
+=======
+    <li><a href="#ref-for-concept-settings-object-origin②">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a>
+>>>>>>> Added note and merged
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
@@ -7333,9 +7353,9 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-browsing-context">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-source-browsing-context①">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context②">(2)</a>
+    Initialize a Document's CSP list </a> <a href="#ref-for-source-browsing-context①">(2)</a>
+    <li><a href="#ref-for-source-browsing-context②">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
@@ -7998,6 +8018,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-dom-document-2" style="color:initial">document</span>
      <li><span class="dfn-paneled" id="term-for-parse-error-duplicate-attribute" style="color:initial">duplicate-attribute</span>
      <li><span class="dfn-paneled" id="term-for-the-embed-element" style="color:initial">embed</span>
+     <li><span class="dfn-paneled" id="term-for-environment-settings-object" style="color:initial">environment settings object</span>
      <li><span class="dfn-paneled" id="term-for-forced-sandboxing-flag-set" style="color:initial">forced sandboxing flag set</span>
      <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
      <li><span class="dfn-paneled" id="term-for-frame" style="color:initial">frame</span>
@@ -8012,11 +8033,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-browsing-context-nested-through" style="color:initial">nested through</span>
      <li><span class="dfn-paneled" id="term-for-attr-nonce" style="color:initial">nonce</span>
      <li><span class="dfn-paneled" id="term-for-the-object-element" style="color:initial">object</span>
-<<<<<<< HEAD
-=======
      <li><span class="dfn-paneled" id="term-for-concept-origin-opaque" style="color:initial">opaque origin</span>
-     <li><span class="dfn-paneled" id="term-for-opener-browsing-context" style="color:initial">opener browsing context</span>
->>>>>>> Initialize self-origin as part of the response CSP list init process
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
      <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
@@ -8558,13 +8575,15 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-policy-self-origin">4.1.1. 
     Set response’s CSP list </a>
-    <li><a href="#ref-for-policy-self-origin①">6.2.1.1. 
+    <li><a href="#ref-for-policy-self-origin①">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-policy-self-origin②">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-policy-self-origin②">6.3.2.1. 
+    <li><a href="#ref-for-policy-self-origin③">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-policy-self-origin③">6.6.2.3. 
+    <li><a href="#ref-for-policy-self-origin④">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-policy-self-origin④">6.6.2.4. 
+    <li><a href="#ref-for-policy-self-origin⑤">6.6.2.4. 
     Does response to request match source list? </a>
    </ul>
   </aside>
@@ -9191,9 +9210,11 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.2. Policies</a> <a href="#ref-for-grammardef-self①">(2)</a>
     <li><a href="#ref-for-grammardef-self②">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-grammardef-self③">6.1.3. default-src</a> <a href="#ref-for-grammardef-self④">(2)</a> <a href="#ref-for-grammardef-self⑤">(3)</a> <a href="#ref-for-grammardef-self⑥">(4)</a> <a href="#ref-for-grammardef-self⑦">(5)</a> <a href="#ref-for-grammardef-self⑧">(6)</a> <a href="#ref-for-grammardef-self⑨">(7)</a> <a href="#ref-for-grammardef-self①⓪">(8)</a> <a href="#ref-for-grammardef-self①①">(9)</a> <a href="#ref-for-grammardef-self①②">(10)</a> <a href="#ref-for-grammardef-self①③">(11)</a> <a href="#ref-for-grammardef-self①④">(12)</a> <a href="#ref-for-grammardef-self①⑤">(13)</a> <a href="#ref-for-grammardef-self①⑥">(14)</a> <a href="#ref-for-grammardef-self①⑦">(15)</a> <a href="#ref-for-grammardef-self①⑧">(16)</a> <a href="#ref-for-grammardef-self①⑨">(17)</a> <a href="#ref-for-grammardef-self②⓪">(18)</a> <a href="#ref-for-grammardef-self②①">(19)</a> <a href="#ref-for-grammardef-self②②">(20)</a> <a href="#ref-for-grammardef-self②③">(21)</a> <a href="#ref-for-grammardef-self②④">(22)</a> <a href="#ref-for-grammardef-self②⑤">(23)</a> <a href="#ref-for-grammardef-self②⑥">(24)</a> <a href="#ref-for-grammardef-self②⑦">(25)</a> <a href="#ref-for-grammardef-self②⑧">(26)</a> <a href="#ref-for-grammardef-self②⑨">(27)</a>
-    <li><a href="#ref-for-grammardef-self③⓪">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-grammardef-self③①">8.2. 
+    <li><a href="#ref-for-grammardef-self③">4.2.1. 
+    Initialize a Document's CSP list </a> <a href="#ref-for-grammardef-self④">(2)</a> <a href="#ref-for-grammardef-self⑤">(3)</a>
+    <li><a href="#ref-for-grammardef-self⑥">6.1.3. default-src</a> <a href="#ref-for-grammardef-self⑦">(2)</a> <a href="#ref-for-grammardef-self⑧">(3)</a> <a href="#ref-for-grammardef-self⑨">(4)</a> <a href="#ref-for-grammardef-self①⓪">(5)</a> <a href="#ref-for-grammardef-self①①">(6)</a> <a href="#ref-for-grammardef-self①②">(7)</a> <a href="#ref-for-grammardef-self①③">(8)</a> <a href="#ref-for-grammardef-self①④">(9)</a> <a href="#ref-for-grammardef-self①⑤">(10)</a> <a href="#ref-for-grammardef-self①⑥">(11)</a> <a href="#ref-for-grammardef-self①⑦">(12)</a> <a href="#ref-for-grammardef-self①⑧">(13)</a> <a href="#ref-for-grammardef-self①⑨">(14)</a> <a href="#ref-for-grammardef-self②⓪">(15)</a> <a href="#ref-for-grammardef-self②①">(16)</a> <a href="#ref-for-grammardef-self②②">(17)</a> <a href="#ref-for-grammardef-self②③">(18)</a> <a href="#ref-for-grammardef-self②④">(19)</a> <a href="#ref-for-grammardef-self②⑤">(20)</a> <a href="#ref-for-grammardef-self②⑥">(21)</a> <a href="#ref-for-grammardef-self②⑦">(22)</a> <a href="#ref-for-grammardef-self②⑧">(23)</a> <a href="#ref-for-grammardef-self②⑨">(24)</a> <a href="#ref-for-grammardef-self③⓪">(25)</a> <a href="#ref-for-grammardef-self③①">(26)</a> <a href="#ref-for-grammardef-self③②">(27)</a>
+    <li><a href="#ref-for-grammardef-self③③">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-grammardef-self③④">8.2. 
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>

--- a/index.src.html
+++ b/index.src.html
@@ -411,6 +411,12 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   Each policy has an associated <dfn for="policy" export>source</dfn>, which is either "`header`"
   or "`meta`".
 
+  Each policy has an associated <dfn for="policy" export>self-origin</dfn>, which
+  is an <a>origin</a> that is used when doing <a grammar>`'self'`</a> matching. This is
+  needed to facilitate the <a grammar>`'self'`</a> checks of <a>local scheme</a>
+  documents/workers that have inherited their policy but have an <a>opaque origin</a>.
+  [[#initialize-document-csp]] describes situations when a policy is inherited.
+
   Multiple [=/policies=] can be applied to a single resource, and are collected into a [=list=] of
   [=/policies=] known as a <dfn export>CSP list</dfn>.
 
@@ -1005,7 +1011,10 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
     4.  For each |policy| in |policies|:
 
-        1.  Insert |policy| into |response|'s <a for="response">CSP list</a>.
+        1.  Set |policy|'s [=policy/self-origin=] to |response|'s [=response/url=]'s
+            [=url/origin=].
+
+        2.  Insert |policy| into |response|'s <a for="response">CSP list</a>.
   </ol>
 
   <h4 id="report-for-request" algorithm>
@@ -2027,8 +2036,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `connect-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and
+      |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2048,9 +2057,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `connect-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2242,8 +2250,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `font-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and
+      |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2263,9 +2271,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `font-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2311,8 +2318,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `frame-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and
+      |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2332,9 +2339,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `frame-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2383,8 +2389,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `img-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2404,9 +2410,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `frame-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2451,8 +2456,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2472,9 +2477,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `manifest-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2522,8 +2526,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `media-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2543,9 +2547,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `media-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2590,8 +2593,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   2.  If the result of executing [[#should-directive-execute]] on |name|,
       `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If the result of executing [[#match-request-to-source-list]] on |request| and this
-      directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-request-to-source-list]] on |request|,
+      this directive's [=directive/value=], and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2610,8 +2614,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   2.  If the result of executing [[#should-directive-execute]] on |name|,
       `prefetch-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  If the result of executing [[#match-response-to-source-list]] on |response|, |request|,
-      and this directive's [=directive/value=] is "`Does Not Match`", return "`Blocked`".
+  3.  If the result of executing [[#match-response-to-source-list]] on |response|,
+      |request|, this directive's [=directive/value=], and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2682,8 +2687,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `object-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2703,9 +2708,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `object-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -2772,7 +2776,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   2.  If the result of executing [[#should-directive-execute]] on |name|,
       `script-src` and |policy| is "`No`", return "`Allowed`".
 
-  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
+  3.  Return the result of executing [[#script-pre-request]] on |request|,
+      this directive, and |policy|.
 
   <h5 algorithm id="script-src-post-request">
     `script-src` Post-request check
@@ -2790,7 +2795,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `script-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  Return the result of executing [[#script-post-request]] on |request|,
-      |response| and this directive.
+      |response|, this directive, and |policy|.
 
   <h5 algorithm id="script-src-inline">
     `script-src` Inline Check
@@ -2850,7 +2855,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   2.  If the result of executing [[#should-directive-execute]] on |name|,
       `script-src-elem` and |policy| is "`No`", return "`Allowed`".
 
-  3.  Return the result of executing [[#script-pre-request]] on |request| and this directive.
+  3.  Return the result of executing [[#script-pre-request]] on |request|,
+      this directive, and |policy|.
 
   <h5 algorithm id="script-src-elem-post-request">
     `script-src-elem` Post-request check
@@ -2868,7 +2874,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `script-src-elem` and |policy| is "`No`", return "`Allowed`".
 
   3.  Return the result of executing [[#script-post-request]] on |request|,
-      |response| and this directive.
+      |response|, this directive, and |policy|.
 
   <h5 algorithm id="script-src-elem-inline">
     `script-src-elem` Inline Check
@@ -2994,8 +3000,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       "`Allowed`".
 
   4.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   5.  Return "`Allowed`".
 
@@ -3020,9 +3026,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       "`Allowed`".
 
   4.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   5.  Return "`Allowed`".
 
@@ -3085,8 +3090,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       "`Allowed`".
 
   4.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   5.  Return "`Allowed`".
 
@@ -3111,9 +3116,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       "`Allowed`".
 
   4.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   5.  Return "`Allowed`".
 
@@ -3215,8 +3219,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `worker-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-request-to-source-list]] on
-      |request| and this directive's <a for="directive">value</a> is
-      "`Does Not Match`", return "`Blocked`".
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -3236,9 +3240,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       `worker-src` and |policy| is "`No`", return "`Allowed`".
 
   3.  If the result of executing [[#match-response-to-source-list]] on
-      |response|, |request|, and this directive's
-      <a for="directive">value</a> is "`Does Not Match`", return
-      "`Blocked`".
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 
@@ -3284,8 +3287,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       3.  If |source list| is `null`, skip to the next |policy|.
 
       4.  If the result of executing [[#match-url-to-source-list]] on |base|, |source list|,
-          |document|'s <a>fallback base URL</a>'s <a for="url">origin</a>, and `0` is "`Does
-          Not Match`":
+          |policy|'s [=policy/self-origin=], and `0` is "`Does Not Match`":
 
           1.  Let |violation| be the result of executing
               [[#create-violation-for-global]] on |document|'s <a for="/">global
@@ -3521,8 +3523,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     2.  If |navigation type| is "`form-submission`":
 
         1.  If the result of executing [[#match-request-to-source-list]] on
-            |request| and this directive's <a for="directive">value</a> is
-            "`Does Not Match`", return "`Blocked`".
+            |request|, this directive's <a for="directive">value</a>, and a
+            |policy|, is "`Does Not Match`", return "`Blocked`".
 
     3.  Return "`Allowed`".
   </ol>
@@ -3567,8 +3569,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   `frame-ancestors` directive's <a>navigation response check</a>:
 
   <ol class="algorithm">
-    1.  Assert: |request|, |navigation response|, |navigation type|, and
-        |policy| are unused in this algorithm, as `frame-ancestors` is concerned only
+    1.  Assert: |request|, |navigation response|, and |navigation type|, are
+        unused in this algorithm, as `frame-ancestors` is concerned only
         with |navigation response|'s <a>frame-ancestors</a> <a>directive</a>.
 
     2.  If |check type| is "`source`", return "`Allowed`".
@@ -3591,8 +3593,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
         3.  If [[#match-url-to-source-list]] returns `Does Not Match` when
             executed upon |origin|, this directive's <a for="directive">value</a>,
-            |navigation response|'s <a for="response">url</a>'s
-            <a for="url">origin</a>, and `0`, return "`Blocked`".
+            |policy|'s [=policy/self-origin=], and `0`, return "`Blocked`".
 
         4.  Set |current| to |document|'s <a>browsing context</a>.
 
@@ -3676,8 +3677,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         <a for="response">status</a> in [[#navigate-to-navigation-response]].
 
     3.  If the result of executing [[#match-request-to-source-list]] on
-        |request| and this directive's <a for="directive">value</a> is
-        "`Does Not Match`", return "`Blocked`".
+        |request|, this directive's <a for="directive">value</a>, and |policy|,
+        is "`Does Not Match`", return "`Blocked`".
 
     4.  Return "`Allowed`".
   </ol>
@@ -3717,8 +3718,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         <a>redirect status</a>, return "`Allowed`".
 
     6.  If the result of executing [[#match-request-to-source-list]] on
-        |request| and this directive's <a for="directive">value</a> is
-        "`Does Not Match`", return "`Blocked`".
+        |request|, this directive's <a for="directive">value</a>, and |policy|,
+        is "`Does Not Match`", return "`Blocked`".
 
     7.  Return "`Allowed`".
   </ol>
@@ -3801,7 +3802,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Script directives pre-request check
   </h5>
 
-  Given a <a for="/">request</a> (|request|) and a <a>directive</a> (|directive|):
+  Given a <a for="/">request</a> (|request|), a <a>directive</a> (|directive|),
+  and a <a for="/">policy</a> (|policy|):
 
   1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
 
@@ -3857,8 +3859,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
               in [[#strict-dynamic-usage]].
 
       4.  If the result of executing [[#match-request-to-source-list]] on
-          |request| and |directive|'s <a for="directive">value</a> is
-          "`Does Not Match`", return "`Blocked`".
+          |request|, |directive|'s <a for="directive">value</a>, and |policy|,
+          is "`Does Not Match`", return "`Blocked`".
 
   2.  Return "`Allowed`".
 
@@ -3868,8 +3870,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a>directive</a> (|directive|):
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|),
+  a <a>directive</a> (|directive|), and a <a for="/">policy</a> (|policy|):
 
   1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
 
@@ -3884,9 +3886,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           return "`Allowed`".
 
       3.  If the result of executing [[#match-response-to-source-list]] on
-          |response|, |request|, and |directive|'s
-          <a for="directive">value</a> is "`Does Not Match`", return
-          "`Blocked`".
+          |response|, |request|, |directive|'s <a for="directive">value</a>,
+          and |policy|, is "`Does Not Match`", return "`Blocked`".
 
   2.  Return "`Allowed`".
 
@@ -3936,11 +3937,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Does |request| match |source list|?
   </h5>
 
-  Given a <a for="/">request</a> (|request|), and a <a>source list</a> (|source list|),
-  this algorithm returns the result of executing [[#match-url-to-source-list]]
-  on |request|'s <a for="request">current url</a>, |source list|, |request|'s
-  <a for="request">origin</a>, and |request|'s <a for="request">redirect
-  count</a>.
+  Given a <a for="/">request</a> (|request|), a <a>source list</a> (|source list|),
+  and a <a for="/">policy</a> (|policy|), this algorithm returns the result of executing
+  [[#match-url-to-source-list]] on |request|'s <a for="request">current url</a>,
+  |source list|, |policy|'s [=policy/self-origin=], and |request|'s
+  <a for="request">redirect count</a>.
 
   Note: This is generally used in <a>directives</a>' <a>pre-request check</a>
   algorithms to verify that a given <a for="/">request</a> is reasonable.
@@ -3950,10 +3951,10 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h5>
 
   Given a <a for="/">request</a> (|request|), and a <a>source list</a> (|source list|),
-  this algorithm returns the result of executing [[#match-url-to-source-list]]
-  on |response|'s <a for="response">url</a>, |source list|, |request|'s
-  <a for="request">origin</a>, and |request|'s <a for="request">redirect
-  count</a>.
+  and a <a for="/">policy</a> (|policy|), this algorithm returns the result of executing
+  [[#match-url-to-source-list]] on |response|'s <a for="response">url</a>,
+  |source list|, |policy|'s [=policy/self-origin=], and |request|'s
+  <a for="request">redirect count</a>.
 
   Note: This is generally used in <a>directives</a>' <a>post-request check</a>
   algorithms to verify that a given <a>response</a> is reasonable.

--- a/index.src.html
+++ b/index.src.html
@@ -412,10 +412,14 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   or "`meta`".
 
   Each policy has an associated <dfn for="policy" export>self-origin</dfn>, which
-  is an <a>origin</a> that is used when doing <a grammar>`'self'`</a> matching. This is
-  needed to facilitate the <a grammar>`'self'`</a> checks of <a>local scheme</a>
-  documents/workers that have inherited their policy but have an <a>opaque origin</a>.
-  [[#initialize-document-csp]] describes situations when a policy is inherited.
+  is an <a>origin</a> that is used when matching the <a grammar>`'self'`</a> keyword.
+
+  Note: This is needed to facilitate the <a grammar>`'self'`</a> checks of
+  <a>local scheme</a> documents/workers that have inherited their policy but
+  have an <a>opaque origin</a>. Most of the time this will simply be the
+  <a>environment settings object</a>'s [=environment settings object/origin=].
+  The [[#initialize-document-csp]] algorithm describes situations in which
+  a policy is inherited.
 
   Multiple [=/policies=] can be applied to a single resource, and are collected into a [=list=] of
   [=/policies=] known as a <dfn export>CSP list</dfn>.
@@ -1216,7 +1220,14 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
               <a for="Document">CSP list</a>.
 
       Note: <a>local scheme</a> includes `about:`, and this algorithm will
-      therefore copy the <a>source browsing context</a>'s policies for <a>an iframe `srcdoc` `Document`</a>.
+      therefore copy the <a>source browsing context</a>'s policies for
+      <a>an iframe `srcdoc` `Document`</a>.
+
+      Note: Since [=policy/self-origin=] is also copied, any <a grammar>`'self'`</a>
+      checks will be using the <a>source browsing context</a>'s origin. This is
+      done for the purpose of making <a grammar>`'self'`</a> make sense in documents
+      with <a>opaque origins</a>. The <a grammar>`'self'`</a> keyword is used
+      in the [[#match-url-to-source-expression]] algorithm.
 
       Note: We do all this to ensure that a page cannot bypass its <a for="/">policy</a>
       by embedding a frame or popping up a new window containing content it


### PR DESCRIPTION
* Add a `self-origin` member to policy.
* Use `self-origin` when doing `self` matching.
* Set `self-origin` as part of initializing a response's CSP List


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/362.html" title="Last updated on Nov 28, 2018, 2:33 PM GMT (597af77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/362/d3fcb8c...andypaicu:597af77.html" title="Last updated on Nov 28, 2018, 2:33 PM GMT (597af77)">Diff</a>