### PR TITLE
Specify behavior in case of malformed policies

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="07ba1fff78f39707fec541400794b23c7987f7b2" name="document-revision">
+  <meta content="48b736b9049ec5d8c82375c5a972bd57ad43759a" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1589,6 +1589,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <ol class="toc">
         <li><a href="#parse-serialized-policy"><span class="secno">2.2.1</span> <span class="content"> Parse a serialized CSP </span></a>
         <li><a href="#parse-serialized-policy-list"><span class="secno">2.2.2</span> <span class="content"> Parse a serialized CSP list </span></a>
+        <li><a href="#malformed-default-csp-replacement"><span class="secno">2.2.3</span> <span class="content"> Return a malformed policy placeholder </span></a>
        </ol>
       <li>
        <a href="#framework-directives"><span class="secno">2.3</span> <span class="content">Directives</span></a>
@@ -2105,7 +2106,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source③">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②">disposition</a> (<var>disposition</var>), execute the following
   steps.</p>
     <p>This algorithm returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤">Content Security Policy objects</a>. If <var>list</var> cannot be
-  parsed, the returned list will be empty.</p>
+  parsed, the returned list will contain a <a data-link-type="dfn" href="#malformed-policy-placeholder" id="ref-for-malformed-policy-placeholder">malformed policy placeholder</a> for every <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> in the <var>list</var> that cannot be parsed.</p>
     <ol class="algorithm">
      <li data-md>
       <p>Let <var>policies</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
@@ -2113,7 +2114,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>list</var> on commas</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp">parsing</a> <var>token</var>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source④">source</a> of <var>source</var>, and <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition③">disposition</a> of <var>disposition</var>.</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace" id="ref-for-strip-leading-and-trailing-ascii-whitespace①">Strip leading and trailing ASCII whitespace</a> from <var>token</var>.</p>
+       <li data-md>
+        <p>If <var>token</var> does not match the <a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a> grammar,
+  let <var>policy</var> be the result of executing <a href="#malformed-default-csp-replacement">§2.2.3 Return a malformed policy placeholder</a> on <var>source</var>, and <var>disposition</var>.</p>
+        <p class="note" role="note"><span>Note:</span> In this case the user agent SHOULD notify developers that the
+  policy they are using is invalid. A console warning might be appropriate.</p>
+       <li data-md>
+        <p>Otherwise, let <var>policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp">parsing</a> <var>token</var>, with
+  a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source④">source</a> of <var>source</var>, and <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition③">disposition</a> of <var>disposition</var>.</p>
        <li data-md>
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set④">directive set</a> is empty, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
        <li data-md>
@@ -2122,11 +2131,39 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li data-md>
       <p>Return <var>policies</var>.</p>
     </ol>
+    <h4 class="heading settled algorithm" data-algorithm="Return a malformed policy placeholder" data-level="2.2.3" id="malformed-default-csp-replacement"><span class="secno">2.2.3. </span><span class="content"> Return a malformed policy placeholder </span><a class="self-link" href="#malformed-default-csp-replacement"></a></h4>
+    <p>In the situation where a malformed <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> is used, it will be replaced with
+  the <var>policy</var> returned by this algorithm. This is done to ensure that mistakes
+  in the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> are not silently ignored which would lead to security issues.
+  Instead the following very restrictive policy is used:</p>
+<pre>default-src 'none'; base-uri 'none'; form-action 'none'; navigate-to 'none';
+</pre>
+    <p>To return a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="malformed-policy-placeholder">malformed policy placeholder</dfn> given a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑤">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> (<var>disposition</var>), execute the following
+  steps:</p>
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>policy</var> be a new <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> with an empty <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>,
+  a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑥">source</a> of <var>source</var>, and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑤">disposition</a> of <var>disposition</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①">Append</a> a new <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is <code>"default-src"</code>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is <code>"'none'"</code>,
+  to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑥">directive set</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append②">Append</a> a new <a data-link-type="dfn" href="#directives" id="ref-for-directives④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a> is <code>"base-uri"</code>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> is <code>"'none'"</code>,
+  to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑦">directive set</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append③">Append</a> a new <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a> is <code>"form-action"</code>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">value</a> is <code>"'none'"</code>,
+  to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append④">Append</a> a new <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a> is <code>"navigate-to"</code>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④">value</a> is <code>"'none'"</code>,
+  to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑨">directive set</a>.</p>
+     <li data-md>
+      <p>Return <var>policy</var>.</p>
+    </ol>
     <h3 class="heading settled" data-level="2.3" id="framework-directives"><span class="secno">2.3. </span><span class="content">Directives</span><a class="self-link" href="#framework-directives"></a></h3>
-    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>), each of which controls a specific behavior. The directives
+    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive set</a>), each of which controls a specific behavior. The directives
   defined in this document are described in detail in <a href="#csp-directives">§6 Content Security Policy Directives</a>.</p>
-    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is a
-  non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
+    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives⑦">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a> is a
+  non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
@@ -2139,45 +2176,45 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1④">ALPHA</a>, <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑤">DIGIT</a>, and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑥">VCHAR</a> are defined in Appendix B.1 of RFC 5234.
 </pre>
-    <p><a data-link-type="dfn" href="#directives" id="ref-for-directives④">Directives</a> have a number of associated algorithms:</p>
+    <p><a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">Directives</a> have a number of associated algorithms:</p>
     <ol>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as an argument, and is executed
   during <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
     Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
-  type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a>, and a source string as arguments,
+  type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a>, and a source string as arguments,
   and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a> for <code>javascript:</code> requests. This
   algorithm returns "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing contexts</a>, a check type string ("<code>source</code>"
-  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
+  or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
-    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
+    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑦">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
   executed. Each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> represents one of the following types of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="source expression" id="source-expression">source
   expression</dfn>:</p>
     <ol>
@@ -2249,9 +2286,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="violation">violation</dfn> represents an action or resource which goes against the
-  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
+  set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-global-object">global object</dfn>, which
-  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> has been violated.</p>
+  is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> has been violated.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
@@ -2261,9 +2298,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   which violated the policy.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑥">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose
   enforcement caused the violation.</p>
     <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-source-file">source file</dfn>, which is
   either <code>null</code> or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url③">URL</a></code>.</p>
@@ -2278,7 +2315,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   characters of an inline script, event handler, or style that caused an violation. Violations
   which stem from an external file will not include a sample in the violation report.</p>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
+    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
      <li data-md>
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
@@ -2304,7 +2341,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, and policy." data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, and <var>policy</var>. </span><a class="self-link" href="#create-violation-for-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑨">policy</a> (<var>policy</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> (<var>policy</var>),
   the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
@@ -2322,14 +2359,14 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="policy-delivery"><span class="secno">3. </span><span class="content"> Policy Delivery </span><a class="self-link" href="#policy-delivery"></a></h2>
-    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⓪">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
+    <p>A server MAY declare a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> for a particular <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-3" id="ref-for-section-3">resource
   representation</a> via an HTTP response header field whose value is a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp③">serialized CSP</a>. This mechanism is defined in detail in <a href="#csp-header">§3.1 The Content-Security-Policy HTTP Response Header Field</a> and <a href="#cspro-header">§3.2 The Content-Security-Policy-Report-Only HTTP Response Header Field</a>, and the integration with Fetch
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a>
+<pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
                     ; but it incorporates the modifications specified
                     ; in section 2.1 of this document.
@@ -2350,7 +2387,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h3 class="heading settled" data-level="3.2" id="cspro-header"><span class="secno">3.2. </span><span class="content"> The <code>Content-Security-Policy-Report-Only</code> HTTP Response Header Field </span><a class="self-link" href="#cspro-header"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
+<pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy③">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
                     ; but it incorporates the modifications specified
                     ; in section 2.1 of this document.
@@ -2405,7 +2442,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   documents are the normative references which ought to be consulted for
   detailed information.</p>
     <h3 class="heading settled" data-level="4.1" id="fetch-integration"><span class="secno">4.1. </span><span class="content"> Integration with Fetch </span><a class="self-link" href="#fetch-integration"></a></h3>
-    <p>A number of <a data-link-type="dfn" href="#directives" id="ref-for-directives⑦">directives</a> control resource loading in one way or
+    <p>A number of <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directives</a> control resource loading in one way or
   another. This specification provides algorithms which allow Fetch to make
   decisions about whether or not a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥">request</a> should be blocked
   or allowed, and about whether a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> should be replaced
@@ -2422,7 +2459,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
-    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②②">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
+    <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> is generally enforced upon a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object④">global object</a>, but the
   user agent needs to <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp③">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
@@ -2446,9 +2483,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p>Set <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list④">CSP list</a> to the empty list.</p>
      <li data-md>
-      <p>Let <var>policies</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑤">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑤">disposition</a> of "<code>enforce</code>".</p>
+      <p>Let <var>policies</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑦">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> of "<code>enforce</code>".</p>
      <li data-md>
-      <p>Append to <var>policies</var> the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list①">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values①">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑥">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑥">disposition</a> of "<code>report</code>".</p>
+      <p>Append to <var>policies</var> the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list①">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values①">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑧">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> of "<code>report</code>".</p>
      <li data-md>
       <p>For each <var>policy</var> in <var>policies</var>:</p>
       <ol>
@@ -2466,7 +2503,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
        <li data-md>
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> is "<code>enforce</code>",
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑨">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md>
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
@@ -2485,7 +2522,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
        <li data-md>
-        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> is "<code>report</code>",
+        <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⓪">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
        <li data-md>
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
@@ -2522,7 +2559,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
            <li data-md>
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑨">disposition</a> is "<code>enforce</code>",
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①①">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2543,7 +2580,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
            <li data-md>
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⓪">disposition</a> is "<code>enforce</code>",
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①②">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2556,20 +2593,20 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
      <li data-md>
-      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects which are
+      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> and <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> algorithms.</p>
       <p class="issue" id="issue-a794766b"><a class="self-link" href="#issue-a794766b"></a> This concept is missing from W3C’s Workers. <a href="https://github.com/w3c/html/issues/187">&lt;https://github.com/w3c/html/issues/187></a></p>
      <li data-md>
       <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> as the <code>object</code>.</p>
      <li data-md>
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list④">CSP list</a>.</p>
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list④">CSP list</a>.</p>
      <li data-md>
-      <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> objects associated
+      <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a> objects associated
   with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
      <li data-md>
       <p><a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
-  new <code>Document</code> object</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①④">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>.</p>
+  new <code>Document</code> object</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①④">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>.</p>
      <li data-md>
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
@@ -2578,7 +2615,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
+      <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
      <li data-md>
       <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
      <li data-md>
@@ -2626,7 +2663,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
+      <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
@@ -2714,7 +2751,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a>:</p>
       <ol>
        <li data-md>
-        <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑥">directive set</a>:</p>
+        <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①①">directive set</a>:</p>
         <ol>
          <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check">inline check</a> returns
@@ -2731,13 +2768,13 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element">element</a> to <var>element</var>.</p>
          <li data-md>
-          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> the
+          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑧">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> the
   expression "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample①"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample②">sample</a> to the substring of <var>source</var> containing its first 40
   characters.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①①">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①③">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2763,14 +2800,14 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>source</var>, <var>target</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
+  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①②">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①④">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2798,7 +2835,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md>
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①③">disposition</a> is "<code>enforce</code>", then
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2826,7 +2863,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md>
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
-          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
+          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a>.</p>
           <p class="note" role="note"><span>Note:</span> We use <code>null</code> for the global object, as no global exists:
   we haven’t processed the navigation to create a Document yet.</p>
          <li data-md>
@@ -2835,7 +2872,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①④">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2851,14 +2888,14 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
+  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -2887,10 +2924,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
          <li data-md>
           <p>Let <var>source-list</var> be <code>null</code>.</p>
          <li data-md>
-          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a> is "<code>script-src</code>", then
-  set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
-          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a> is
-  "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
+          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is "<code>script-src</code>", then
+  set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a>.</p>
+          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is
+  "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a>.</p>
          <li data-md>
           <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression②">source expression</a> which is
   an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>",
@@ -2907,7 +2944,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md>
-            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
+            <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
   "<code>Blocked</code>".</p>
           </ol>
         </ol>
@@ -2921,9 +2958,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="violation report" id="violation-report">violation
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="violation report" id="violation-report">violation
   report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a>.</p>
+  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a>.</p>
     <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
 <pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-securitypolicyviolationeventdisposition"><code><c- g>SecurityPolicyViolationEventDisposition</c-></code></dfn> {
   <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-enforce"><code><c- s>"enforce"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-report"><code><c- s>"report"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
@@ -3009,7 +3046,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑦">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy①">policy</a></p>
        <dt data-md>"<code>disposition</code>"
        <dd data-md>
-        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
+        <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
        <dt data-md>"<code>status-code</code>"
        <dd data-md>
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status①">status</a></p>
@@ -3124,15 +3161,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   tree. <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target" id="ref-for-dom-event-target">target</a></code>, et al will be automagically scoped correctly for
   the main tree.</p>
        <li data-md>
-        <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑥">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑦">directive
-  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
+        <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑥">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①②">directive
+  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
   (<var>directive</var>):</p>
         <ol>
          <li data-md>
-          <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> named
+          <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①③">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> named
   "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to①"><code>report-to</code></a>", skip the remaining substeps.</p>
          <li data-md>
-          <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①"> splitting a string on ASCII whitespace</a> with <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑦">value</a> as the <code>input</code>.</p>
+          <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①"> splitting a string on ASCII whitespace</a> with <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> as the <code>input</code>.</p>
           <ol>
            <li data-md>
             <p>Let <var>endpoint</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> with <var>token</var> as the input, and <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url②">url</a> as the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-base-url" id="ref-for-concept-base-url">base URL</a>.</p>
@@ -3193,12 +3230,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   is, the latter overrides the former, allowing for backwards compatibility
   with browsers that don’t support the new mechanism.</p>
        <li data-md>
-        <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑧">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑨">directive
-  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
+        <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑧">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①④">directive
+  set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
   (<var>directive</var>):</p>
         <ol>
          <li data-md>
-          <p>Let <var>group</var> be <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑧">value</a>.</p>
+          <p>Let <var>group</var> be <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a>.</p>
          <li data-md>
           <p>Let <var>settings object</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑧">global
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>.</p>
@@ -3225,7 +3262,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
    </section>
    <section>
     <h2 class="heading settled" data-level="6" id="csp-directives"><span class="secno">6. </span><span class="content"> Content Security Policy Directives </span><a class="self-link" href="#csp-directives"></a></h2>
-    <p>This specification defines a number of types of <a data-link-type="dfn" href="#directives" id="ref-for-directives①④">directives</a> which allow
+    <p>This specification defines a number of types of <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directives</a> which allow
   developers to control certain aspects of their sites' behavior. This document
   defines directives which govern resource fetching (in <a href="#directives-fetch">§6.1 Fetch Directives</a>),
   directives which govern the state of a document (in <a href="#directives-document">§6.2 Document Directives</a>),
@@ -3285,7 +3322,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3293,11 +3330,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3305,7 +3342,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
-  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
+  check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
@@ -3349,28 +3386,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3436,38 +3473,38 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> for the comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
+      <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> for the
   comparison.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Inline Check" data-level="6.1.3.3" id="default-src-inline"><span class="secno">6.1.3.3. </span><span class="content"> <code>default-src</code> Inline Check </span><a class="self-link" href="#default-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
+      <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
@@ -3496,28 +3533,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3540,28 +3577,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3586,28 +3623,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3630,28 +3667,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3677,28 +3714,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3721,7 +3758,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3729,13 +3766,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3743,7 +3780,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>,
-  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+  and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -3775,7 +3812,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
@@ -3783,28 +3820,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3852,7 +3889,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3863,7 +3900,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3874,7 +3911,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
@@ -3883,7 +3920,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3902,7 +3939,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p><code>script-src-elem</code> applies to inline checks whose <code>|type|</code> is "<code>script</code>" and
 "<code>navigation</code>" (and is ignored for inline checks whose <code>|type|</code> is "<code>script attribute</code>").</p>
      <li data-md>
-      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
+      <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is not used for JavaScript
 execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
      <li data-md>
       <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
@@ -3910,7 +3947,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     </ul>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3921,7 +3958,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3932,7 +3969,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
@@ -3941,7 +3978,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code>, and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a>, <var>type</var>,
   and <var>source</var> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -3955,7 +3992,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   it will override the <code>script-src</code> directive for relevant checks.</p>
     <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
@@ -3964,7 +4001,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4017,7 +4054,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4025,17 +4062,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4043,24 +4080,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4078,7 +4115,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   except for styles defined in inline attributes.</p>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4086,17 +4123,17 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4104,24 +4141,24 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4134,14 +4171,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
     <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
-    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
+    <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
+      <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4168,28 +4205,28 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a> is "<code>Does Not Match</code>", return
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4215,9 +4252,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
        <li data-md>
         <p>Let <var>source list</var> be <code>null</code>.</p>
        <li data-md>
-        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is
-  "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
-  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
+        <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑦">name</a> is
+  "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⑤">directive
+  set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a>.</p>
        <li data-md>
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
        <li data-md>
@@ -4231,7 +4268,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
-          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is "<code>enforce</code>",
+          <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is "<code>enforce</code>",
   return "<code>Blocked</code>".</p>
         </ol>
       </ol>
@@ -4285,7 +4322,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4298,7 +4335,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
        <li data-md>
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
-  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
+  in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4314,7 +4351,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①⓪">CSP list</a>:</p>
       <ol>
        <li data-md>
-        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
+        <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
          <li data-md>
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
@@ -4328,7 +4365,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
            <li data-md>
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
-  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
+  item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -4351,12 +4388,12 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md>
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is one of
@@ -4364,7 +4401,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
       <ol>
        <li data-md>
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
-  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
+  using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
   the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a> flags, return
   "<code>Blocked</code>".</p>
@@ -4378,16 +4415,16 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization②">initialization</a> algorithm is
   responsible for adjusting a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑥">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set">forced sandboxing flag set</a> according to the <a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox"><code>sandbox</code></a> values present in its policies, as
   follows:</p>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>response</var> is unused.</p>
      <li data-md>
-      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code>, then abort this algorithm.</p>
+      <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②②">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code>, then abort this algorithm.</p>
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <h3 class="heading settled" data-level="6.3" id="directives-navigation"><span class="secno">6.3. </span><span class="content"> Navigation Directives </span><a class="self-link" href="#directives-navigation"></a></h3>
@@ -4400,7 +4437,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
+  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
   submission violates the <code>form-action</code> directive’s constraints, and "<code>Allowed</code>"
   otherwise. This constitutes the <code>form-action</code> directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4410,7 +4447,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
        <li data-md>
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
@@ -4433,16 +4470,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
-  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
+  with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a>.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing context</a>.</p>
      <li data-md>
       <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
      <li data-md>
@@ -4457,7 +4494,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
@@ -4469,7 +4506,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors②"><code>frame-ancestors</code></a> directive checks against each ancestor. If _any_ ancestor doesn’t
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
-  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
+  _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②③">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
     <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response②">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
@@ -4495,7 +4532,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
   "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
@@ -4503,33 +4540,33 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p class="assertion">Assert: <var>source</var> and <var>target</var> are unused as 'navigate-to'
   is concerned with the details of the request.</p>
      <li data-md>
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
   wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
+  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
       <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①③">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①③">browsing context</a>.</p>
      <li data-md>
-      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
+      <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
+      <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
@@ -4537,7 +4574,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a> is
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4592,17 +4629,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
        <li data-md>
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md>
-        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
+        <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
        <li data-md>
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
@@ -4618,7 +4655,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
            <li data-md>
-            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
+            <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
@@ -4631,7 +4668,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
        <li data-md>
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
@@ -4642,7 +4679,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
        <li data-md>
-        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a> is
+        <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var> and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑥">value</a> is
   "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
@@ -4650,21 +4687,21 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like②">script-like</a>:</p>
       <ol>
        <li data-md>
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
-  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
+  directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑦">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
        <li data-md>
-        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
+        <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑧">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
        <li data-md>
-        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a> is "<code>Does Not Match</code>", return
+        <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑨">value</a> is "<code>Does Not Match</code>", return
   "<code>Blocked</code>".</p>
       </ol>
      <li data-md>
@@ -4672,8 +4709,8 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
-  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧①">policy</a> (<var>policy</var>), this
+  algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
      <li data-md>
@@ -4712,12 +4749,12 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑥">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑦">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does url match source list in origin with redirect count?" data-level="6.6.2.5" id="match-url-to-source-list"><span class="secno">6.6.2.5. </span><span class="content"> Does <var>url</var> match <var>source list</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-list"></a></h5>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑨">URL</a></code> (<var>url</var>), a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑤">source list</a> (<var>source list</var>), an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> (<var>origin</var>), and a number (<var>redirect count</var>), this
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
@@ -5116,7 +5153,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
     <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑧">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
@@ -5192,7 +5229,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
-    <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> of the effective directive.</p>
+    <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑨">name</a> of the effective directive.</p>
     <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
@@ -5229,7 +5266,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get fetch directive fallback list" data-level="6.7.3" id="directive-fallback-list"><span class="secno">6.7.3. </span><span class="content"> Get fetch directive fallback list </span><a class="self-link" href="#directive-fallback-list"></a></h4>
-    <p>Will return an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">ordered set</a> of the fallback <a data-link-type="dfn" href="#directives" id="ref-for-directives③④">directives</a> for a specific <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑤">directive</a>.
+    <p>Will return an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">ordered set</a> of the fallback <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑧">directives</a> for a specific <a data-link-type="dfn" href="#directives" id="ref-for-directives③⑨">directive</a>.
   The returned <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set⑤">ordered set</a> is sorted from most relevant to least relevant
   and it includes the effective directive itself.</p>
     <p>Given a string (<var>directive name</var>):</p>
@@ -5326,7 +5363,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   we are currently checking a worker request), a <code>default-src</code> directive
   should not execute if a <code>worker-src</code> or <code>script-src</code> directive exists.</p>
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
-  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
+  a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
@@ -5336,7 +5373,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
        <li data-md>
         <p>If <var>directive name</var> is <var>fallback directive</var>, Return "<code>Yes</code>".</p>
        <li data-md>
-        <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
+        <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②⓪">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
       </ol>
      <li data-md>
       <p>Return "<code>No</code>".</p>
@@ -5348,7 +5385,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Nonces override the other restrictions present in the directive in which
   they’re delivered. It is critical, then, that they remain unguessable, as
   bypassing a resource’s policy is otherwise trivial.</p>
-    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑨">policy</a>, the server MUST generate a unique value each time it
+    <p>If a server delivers a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑧">nonce-source</a> expression as part of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧③">policy</a>, the server MUST generate a unique value each time it
   transmits a policy. The generated value SHOULD be at least 128 bits long
   (before encoding), and SHOULD be generated via a cryptographically secure
   random number generator in order to ensure that the value is difficult for
@@ -5653,7 +5690,7 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
    <section>
     <h2 class="heading settled" data-level="9" id="implementation-considerations"><span class="secno">9. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
     <h3 class="heading settled" data-level="9.1" id="extensions"><span class="secno">9.1. </span><span class="content">Vendor-specific Extensions and Addons</span><a class="self-link" href="#extensions"></a></h3>
-    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧⓪">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
+    <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧④">Policy</a> enforced on a resource SHOULD NOT interfere with the operation
   of user-agent features like addons, extensions, or bookmarklets. These kinds
   of features generally advance the user’s priority over page authors, as
   espoused in <a data-link-type="biblio" href="#biblio-html-design">[HTML-DESIGN]</a>.</p>
@@ -5872,16 +5909,16 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-documenturl">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li>
-    effective directive
-    <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
-     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
-    </ul>
-   <li>
     effectiveDirective
     <ul>
      <li><a href="#dom-securitypolicyviolationevent-effectivedirective">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-effectivedirective">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
+    </ul>
+   <li>
+    effective directive
+    <ul>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
+     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
     </ul>
    <li><a href="#violation-element">element</a><span>, in §2.4</span>
    <li><a href="#embedding-document">embedding document</a><span>, in §4.2</span>
@@ -5912,6 +5949,7 @@ rest of Google’s CSP Cabal.</p>
     </ul>
    <li><a href="#violation-line-number">line number</a><span>, in §2.4</span>
    <li><a href="#dom-securitypolicyviolationevent-linenumber">lineNumber</a><span>, in §5.1</span>
+   <li><a href="#malformed-policy-placeholder">malformed policy placeholder</a><span>, in §2.2.3</span>
    <li><a href="#manifest-src">manifest-src</a><span>, in §6.1.7</span>
    <li><a href="#media-src">media-src</a><span>, in §6.1.8</span>
    <li><a href="#grammardef-media-type">media-type</a><span>, in §6.2.2</span>
@@ -7512,6 +7550,8 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">2.2.1. 
     Parse a serialized CSP </a>
+    <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace①">2.2.2. 
+    Parse a serialized CSP list </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-valid-mime-type">
@@ -8326,120 +8366,122 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy-object③">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-content-security-policy-object④">(2)</a>
     <li><a href="#ref-for-content-security-policy-object⑤">2.2.2. 
-    Parse a serialized CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object⑥">2.3. Directives</a> <a href="#ref-for-content-security-policy-object⑦">(2)</a> <a href="#ref-for-content-security-policy-object⑧">(3)</a> <a href="#ref-for-content-security-policy-object⑨">(4)</a> <a href="#ref-for-content-security-policy-object①⓪">(5)</a> <a href="#ref-for-content-security-policy-object①①">(6)</a> <a href="#ref-for-content-security-policy-object①②">(7)</a> <a href="#ref-for-content-security-policy-object①③">(8)</a>
-    <li><a href="#ref-for-content-security-policy-object①④">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①⑤">(2)</a> <a href="#ref-for-content-security-policy-object①⑥">(3)</a> <a href="#ref-for-content-security-policy-object①⑦">(4)</a>
-    <li><a href="#ref-for-content-security-policy-object①⑧">2.4.1. 
+    Parse a serialized CSP list </a> <a href="#ref-for-content-security-policy-object⑥">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object⑦">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-content-security-policy-object⑧">(2)</a> <a href="#ref-for-content-security-policy-object⑨">(3)</a>
+    <li><a href="#ref-for-content-security-policy-object①⓪">2.3. Directives</a> <a href="#ref-for-content-security-policy-object①①">(2)</a> <a href="#ref-for-content-security-policy-object①②">(3)</a> <a href="#ref-for-content-security-policy-object①③">(4)</a> <a href="#ref-for-content-security-policy-object①④">(5)</a> <a href="#ref-for-content-security-policy-object①⑤">(6)</a> <a href="#ref-for-content-security-policy-object①⑥">(7)</a> <a href="#ref-for-content-security-policy-object①⑦">(8)</a>
+    <li><a href="#ref-for-content-security-policy-object①⑧">2.4. Violations</a> <a href="#ref-for-content-security-policy-object①⑨">(2)</a> <a href="#ref-for-content-security-policy-object②⓪">(3)</a> <a href="#ref-for-content-security-policy-object②①">(4)</a>
+    <li><a href="#ref-for-content-security-policy-object②②">2.4.1. 
     Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-content-security-policy-object①⑨">2.4.2. 
+    <li><a href="#ref-for-content-security-policy-object②③">2.4.2. 
     Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-content-security-policy-object②⓪">3. 
-    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②①">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object②②">4.1. 
+    <li><a href="#ref-for-content-security-policy-object②④">3. 
+    Policy Delivery </a> <a href="#ref-for-content-security-policy-object②⑤">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object②⑥">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-content-security-policy-object②③">4.2. 
-    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②④">(2)</a> <a href="#ref-for-content-security-policy-object②⑤">(3)</a> <a href="#ref-for-content-security-policy-object②⑥">(4)</a> <a href="#ref-for-content-security-policy-object②⑦">(5)</a>
-    <li><a href="#ref-for-content-security-policy-object②⑧">4.2.1. 
+    <li><a href="#ref-for-content-security-policy-object②⑦">4.2. 
+    Integration with HTML </a> <a href="#ref-for-content-security-policy-object②⑧">(2)</a> <a href="#ref-for-content-security-policy-object②⑨">(3)</a> <a href="#ref-for-content-security-policy-object③⓪">(4)</a> <a href="#ref-for-content-security-policy-object③①">(5)</a>
+    <li><a href="#ref-for-content-security-policy-object③②">4.2.1. 
     Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-content-security-policy-object②⑨">5. 
-    Reporting </a> <a href="#ref-for-content-security-policy-object③⓪">(2)</a>
-    <li><a href="#ref-for-content-security-policy-object③①">6.1.1.1. 
+    <li><a href="#ref-for-content-security-policy-object③③">5. 
+    Reporting </a> <a href="#ref-for-content-security-policy-object③④">(2)</a>
+    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③②">6.1.1.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③③">6.1.2.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③④">6.1.2.2. 
+    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑤">6.1.3.1. 
+    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑥">6.1.3.2. 
+    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑦">6.1.3.3. 
+    <li><a href="#ref-for-content-security-policy-object④①">6.1.3.3. 
     default-src Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑧">6.1.4.1. 
+    <li><a href="#ref-for-content-security-policy-object④②">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object③⑨">6.1.4.2. 
+    <li><a href="#ref-for-content-security-policy-object④③">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⓪">6.1.5.1. 
+    <li><a href="#ref-for-content-security-policy-object④④">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④①">6.1.5.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④②">6.1.6.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④③">6.1.6.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④④">6.1.7.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑤">6.1.7.2. 
+    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑥">6.1.8.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑦">6.1.8.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.9.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.9.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.10. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.10. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤③">6.1.11.1. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑤">6.1.11.3. 
+    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑥">6.1.12.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.12.1. 
     script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑦">6.1.12.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.12.2. 
     script-src-elem Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑧">6.1.12.3. 
+    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.12.3. 
     script-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⑨">6.1.13.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.13.1. 
     script-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⓪">6.1.14.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥①">6.1.14.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥②">6.1.14.3. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥③">6.1.15.1. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.15.1. 
     style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥④">6.1.15.2. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.1.15.2. 
     style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑤">6.1.15.3. 
+    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.1.15.3. 
     style-src-elem Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑥">6.1.16.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.1.16.1. 
     style-src-attr Inline Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑦">6.1.17.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦①">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑧">6.1.17.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦②">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑥⑨">6.2.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦③">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⓪">6.2.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦④">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦①">6.2.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-content-security-policy-object⑦②">6.3.1.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦③">6.3.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦④">6.3.2.2. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑤">6.3.3.1. 
+    <li><a href="#ref-for-content-security-policy-object⑦⑨">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑥">6.3.3.2. 
+    <li><a href="#ref-for-content-security-policy-object⑧⓪">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑦">6.6.2.1. 
+    <li><a href="#ref-for-content-security-policy-object⑧①">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑧">6.7.4. 
+    <li><a href="#ref-for-content-security-policy-object⑧②">6.7.4. 
     Should fetch directive execute </a>
-    <li><a href="#ref-for-content-security-policy-object⑦⑨">7.1. Nonce Reuse</a>
-    <li><a href="#ref-for-content-security-policy-object⑧⓪">9.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-content-security-policy-object⑧③">7.1. Nonce Reuse</a>
+    <li><a href="#ref-for-content-security-policy-object⑧④">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive-set">
@@ -8449,12 +8491,14 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-policy-directive-set①">(2)</a> <a href="#ref-for-policy-directive-set②">(3)</a> <a href="#ref-for-policy-directive-set③">(4)</a>
     <li><a href="#ref-for-policy-directive-set④">2.2.2. 
     Parse a serialized CSP list </a>
-    <li><a href="#ref-for-policy-directive-set⑤">2.3. Directives</a>
-    <li><a href="#ref-for-policy-directive-set⑥">4.2.4. 
+    <li><a href="#ref-for-policy-directive-set⑤">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-policy-directive-set⑥">(2)</a> <a href="#ref-for-policy-directive-set⑦">(3)</a> <a href="#ref-for-policy-directive-set⑧">(4)</a> <a href="#ref-for-policy-directive-set⑨">(5)</a>
+    <li><a href="#ref-for-policy-directive-set①⓪">2.3. Directives</a>
+    <li><a href="#ref-for-policy-directive-set①①">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-directive-set⑦">5.3. 
-    Report a violation </a> <a href="#ref-for-policy-directive-set⑧">(2)</a> <a href="#ref-for-policy-directive-set⑨">(3)</a>
-    <li><a href="#ref-for-policy-directive-set①⓪">6.2.1.1. 
+    <li><a href="#ref-for-policy-directive-set①②">5.3. 
+    Report a violation </a> <a href="#ref-for-policy-directive-set①③">(2)</a> <a href="#ref-for-policy-directive-set①④">(3)</a>
+    <li><a href="#ref-for-policy-directive-set①⑤">6.2.1.1. 
     Is base allowed for document? </a>
    </ul>
   </aside>
@@ -8465,35 +8509,37 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-policy-disposition①">(2)</a>
     <li><a href="#ref-for-policy-disposition②">2.2.2. 
     Parse a serialized CSP list </a> <a href="#ref-for-policy-disposition③">(2)</a>
-    <li><a href="#ref-for-policy-disposition④">2.4. Violations</a>
-    <li><a href="#ref-for-policy-disposition⑤">4.1.1. 
-    Set response’s CSP list </a> <a href="#ref-for-policy-disposition⑥">(2)</a>
-    <li><a href="#ref-for-policy-disposition⑦">4.1.2. 
+    <li><a href="#ref-for-policy-disposition④">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-policy-disposition⑤">(2)</a>
+    <li><a href="#ref-for-policy-disposition⑥">2.4. Violations</a>
+    <li><a href="#ref-for-policy-disposition⑦">4.1.1. 
+    Set response’s CSP list </a> <a href="#ref-for-policy-disposition⑧">(2)</a>
+    <li><a href="#ref-for-policy-disposition⑨">4.1.2. 
     Report Content Security Policy violations for request </a>
-    <li><a href="#ref-for-policy-disposition⑧">4.1.3. 
+    <li><a href="#ref-for-policy-disposition①⓪">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-disposition⑨">4.1.4. 
+    <li><a href="#ref-for-policy-disposition①①">4.1.4. 
     Should response to request be blocked by Content
-    Security Policy? </a> <a href="#ref-for-policy-disposition①⓪">(2)</a>
-    <li><a href="#ref-for-policy-disposition①①">4.2.4. 
+    Security Policy? </a> <a href="#ref-for-policy-disposition①②">(2)</a>
+    <li><a href="#ref-for-policy-disposition①③">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-policy-disposition①②">4.2.5. 
+    <li><a href="#ref-for-policy-disposition①④">4.2.5. 
     Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-policy-disposition①③">(2)</a>
-    <li><a href="#ref-for-policy-disposition①④">4.2.6. 
+    by Content Security Policy? </a> <a href="#ref-for-policy-disposition①⑤">(2)</a>
+    <li><a href="#ref-for-policy-disposition①⑥">4.2.6. 
     Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a> <a href="#ref-for-policy-disposition①⑤">(2)</a>
-    <li><a href="#ref-for-policy-disposition①⑥">4.3.1. 
+    in target be blocked by Content Security Policy? </a> <a href="#ref-for-policy-disposition①⑦">(2)</a>
+    <li><a href="#ref-for-policy-disposition①⑧">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-policy-disposition①⑦">5.2. 
+    <li><a href="#ref-for-policy-disposition①⑨">5.2. 
     Obtain the deprecated serialization of violation </a>
-    <li><a href="#ref-for-policy-disposition①⑧">6.2.1.1. 
+    <li><a href="#ref-for-policy-disposition②⓪">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-policy-disposition①⑨">6.2.3.1. 
+    <li><a href="#ref-for-policy-disposition②①">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-policy-disposition②⓪">6.2.3.2. 
+    <li><a href="#ref-for-policy-disposition②②">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-policy-disposition②①">6.3.2.2. 
+    <li><a href="#ref-for-policy-disposition②③">6.3.2.2. 
 		Relation to X-Frame-Options </a>
    </ul>
   </aside>
@@ -8505,8 +8551,10 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP </a> <a href="#ref-for-policy-source②">(2)</a>
     <li><a href="#ref-for-policy-source③">2.2.2. 
     Parse a serialized CSP list </a> <a href="#ref-for-policy-source④">(2)</a>
-    <li><a href="#ref-for-policy-source⑤">4.1.1. 
-    Set response’s CSP list </a> <a href="#ref-for-policy-source⑥">(2)</a>
+    <li><a href="#ref-for-policy-source⑤">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-policy-source⑥">(2)</a>
+    <li><a href="#ref-for-policy-source⑦">4.1.1. 
+    Set response’s CSP list </a> <a href="#ref-for-policy-source⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="csp-list">
@@ -8540,9 +8588,11 @@ rest of Google’s CSP Cabal.</p>
    <b><a href="#grammardef-serialized-policy">#grammardef-serialized-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-serialized-policy">2.2. Policies</a>
-    <li><a href="#ref-for-grammardef-serialized-policy①">3.1. 
+    <li><a href="#ref-for-grammardef-serialized-policy①">2.2.2. 
+    Parse a serialized CSP list </a>
+    <li><a href="#ref-for-grammardef-serialized-policy②">3.1. 
     The Content-Security-Policy HTTP Response Header Field </a>
-    <li><a href="#ref-for-grammardef-serialized-policy②">3.2. 
+    <li><a href="#ref-for-grammardef-serialized-policy③">3.2. 
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
    </ul>
   </aside>
@@ -8573,58 +8623,67 @@ rest of Google’s CSP Cabal.</p>
     Set response’s CSP list </a> <a href="#ref-for-abstract-opdef-parse-a-serialized-csp-list①">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="malformed-policy-placeholder">
+   <b><a href="#malformed-policy-placeholder">#malformed-policy-placeholder</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-malformed-policy-placeholder">2.2.2. 
+    Parse a serialized CSP list </a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="directives">
    <b><a href="#directives">#directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directives">2.2. Policies</a>
     <li><a href="#ref-for-directives①">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-directives②">(2)</a>
-    <li><a href="#ref-for-directives③">2.3. Directives</a> <a href="#ref-for-directives④">(2)</a>
-    <li><a href="#ref-for-directives⑤">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-directives⑥">2.4. Violations</a>
-    <li><a href="#ref-for-directives⑦">4.1. 
+    <li><a href="#ref-for-directives③">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-directives④">(2)</a> <a href="#ref-for-directives⑤">(3)</a> <a href="#ref-for-directives⑥">(4)</a>
+    <li><a href="#ref-for-directives⑦">2.3. Directives</a> <a href="#ref-for-directives⑧">(2)</a>
+    <li><a href="#ref-for-directives⑨">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-directives①⓪">2.4. Violations</a>
+    <li><a href="#ref-for-directives①①">4.1. 
     Integration with Fetch </a>
-    <li><a href="#ref-for-directives⑧">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directives⑨">(2)</a> <a href="#ref-for-directives①⓪">(3)</a>
-    <li><a href="#ref-for-directives①①">5.3. 
-    Report a violation </a> <a href="#ref-for-directives①②">(2)</a> <a href="#ref-for-directives①③">(3)</a>
-    <li><a href="#ref-for-directives①④">6. 
+    <li><a href="#ref-for-directives①②">4.3.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directives①③">(2)</a> <a href="#ref-for-directives①④">(3)</a>
+    <li><a href="#ref-for-directives①⑤">5.3. 
+    Report a violation </a> <a href="#ref-for-directives①⑥">(2)</a> <a href="#ref-for-directives①⑦">(3)</a>
+    <li><a href="#ref-for-directives①⑧">6. 
     Content Security Policy Directives </a>
-    <li><a href="#ref-for-directives①⑤">6.1.1.1. 
+    <li><a href="#ref-for-directives①⑨">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-directives①⑥">6.1.1.2. 
+    <li><a href="#ref-for-directives②⓪">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-directives①⑦">6.1.3.1. 
+    <li><a href="#ref-for-directives②①">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-directives①⑧">6.1.3.2. 
+    <li><a href="#ref-for-directives②②">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directives①⑨">6.1.3.3. 
+    <li><a href="#ref-for-directives②③">6.1.3.3. 
     default-src Inline Check </a>
-    <li><a href="#ref-for-directives②⓪">6.2.1.1. 
-    Is base allowed for document? </a> <a href="#ref-for-directives②①">(2)</a>
-    <li><a href="#ref-for-directives②②">6.2.2.2. 
+    <li><a href="#ref-for-directives②④">6.2.1.1. 
+    Is base allowed for document? </a> <a href="#ref-for-directives②⑤">(2)</a>
+    <li><a href="#ref-for-directives②⑥">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directives②③">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives②④">(2)</a>
-    <li><a href="#ref-for-directives②⑤">6.3.2.2. 
+    <li><a href="#ref-for-directives②⑦">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-directives②⑧">(2)</a>
+    <li><a href="#ref-for-directives②⑨">6.3.2.2. 
 		Relation to X-Frame-Options </a>
-    <li><a href="#ref-for-directives②⑥">6.3.3.1. 
+    <li><a href="#ref-for-directives③⓪">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-directives②⑦">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directives②⑧">(2)</a>
-    <li><a href="#ref-for-directives②⑨">6.6.1.1. 
+    <li><a href="#ref-for-directives③①">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directives③②">(2)</a>
+    <li><a href="#ref-for-directives③③">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-directives③⓪">6.6.1.2. 
+    <li><a href="#ref-for-directives③④">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-directives③①">6.6.2.1. 
+    <li><a href="#ref-for-directives③⑤">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-directives③②">6.6.2.3. 
+    <li><a href="#ref-for-directives③⑥">6.6.2.3. 
     Does request match source list? </a>
-    <li><a href="#ref-for-directives③③">6.6.2.4. 
+    <li><a href="#ref-for-directives③⑦">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-directives③④">6.7.3. 
-    Get fetch directive fallback list </a> <a href="#ref-for-directives③⑤">(2)</a>
+    <li><a href="#ref-for-directives③⑧">6.7.3. 
+    Get fetch directive fallback list </a> <a href="#ref-for-directives③⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="directive-name">
@@ -8632,32 +8691,34 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-name">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-directive-name①">(2)</a>
-    <li><a href="#ref-for-directive-name②">2.3. Directives</a>
-    <li><a href="#ref-for-directive-name③">4.2.5. 
+    <li><a href="#ref-for-directive-name②">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-directive-name③">(2)</a> <a href="#ref-for-directive-name④">(3)</a> <a href="#ref-for-directive-name⑤">(4)</a>
+    <li><a href="#ref-for-directive-name⑥">2.3. Directives</a>
+    <li><a href="#ref-for-directive-name⑦">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-name④">4.2.6. 
+    <li><a href="#ref-for-directive-name⑧">4.2.6. 
     Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a> <a href="#ref-for-directive-name⑤">(2)</a>
-    <li><a href="#ref-for-directive-name⑥">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name⑦">(2)</a>
-    <li><a href="#ref-for-directive-name⑧">6.1.1.1. 
+    in target be blocked by Content Security Policy? </a> <a href="#ref-for-directive-name⑨">(2)</a>
+    <li><a href="#ref-for-directive-name①⓪">4.3.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-name①①">(2)</a>
+    <li><a href="#ref-for-directive-name①②">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-directive-name⑨">6.1.1.2. 
+    <li><a href="#ref-for-directive-name①③">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-directive-name①⓪">6.1.3.1. 
+    <li><a href="#ref-for-directive-name①④">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-directive-name①①">6.1.3.2. 
+    <li><a href="#ref-for-directive-name①⑤">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directive-name①②">6.1.3.3. 
+    <li><a href="#ref-for-directive-name①⑥">6.1.3.3. 
     default-src Inline Check </a>
-    <li><a href="#ref-for-directive-name①③">6.2.1.1. 
+    <li><a href="#ref-for-directive-name①⑦">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-name①④">6.7.1. 
+    <li><a href="#ref-for-directive-name①⑧">6.7.1. 
     Get the effective directive for request </a>
-    <li><a href="#ref-for-directive-name①⑤">6.7.2. 
+    <li><a href="#ref-for-directive-name①⑨">6.7.2. 
     Get the effective directive for inline checks </a>
-    <li><a href="#ref-for-directive-name①⑥">6.7.4. 
+    <li><a href="#ref-for-directive-name②⓪">6.7.4. 
     Should fetch directive execute </a>
    </ul>
   </aside>
@@ -8666,104 +8727,106 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-directive-value">2.2.1. 
     Parse a serialized CSP </a>
-    <li><a href="#ref-for-directive-value①">2.3. Directives</a> <a href="#ref-for-directive-value②">(2)</a>
-    <li><a href="#ref-for-directive-value③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-directive-value④">4.2.4. 
+    <li><a href="#ref-for-directive-value①">2.2.3. 
+    Return a malformed policy placeholder </a> <a href="#ref-for-directive-value②">(2)</a> <a href="#ref-for-directive-value③">(3)</a> <a href="#ref-for-directive-value④">(4)</a>
+    <li><a href="#ref-for-directive-value⑤">2.3. Directives</a> <a href="#ref-for-directive-value⑥">(2)</a>
+    <li><a href="#ref-for-directive-value⑦">2.3.1. Source Lists</a>
+    <li><a href="#ref-for-directive-value⑧">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-directive-value⑤">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-value⑥">(2)</a>
-    <li><a href="#ref-for-directive-value⑦">5.3. 
-    Report a violation </a> <a href="#ref-for-directive-value⑧">(2)</a>
-    <li><a href="#ref-for-directive-value⑨">6.1.1.1. 
+    <li><a href="#ref-for-directive-value⑨">4.3.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a> <a href="#ref-for-directive-value①⓪">(2)</a>
+    <li><a href="#ref-for-directive-value①①">5.3. 
+    Report a violation </a> <a href="#ref-for-directive-value①②">(2)</a>
+    <li><a href="#ref-for-directive-value①③">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⓪">6.1.1.2. 
+    <li><a href="#ref-for-directive-value①④">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①①">6.1.2.1. 
+    <li><a href="#ref-for-directive-value①⑤">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①②">6.1.2.2. 
+    <li><a href="#ref-for-directive-value①⑥">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①③">6.1.3.1. 
+    <li><a href="#ref-for-directive-value①⑦">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①④">6.1.3.2. 
+    <li><a href="#ref-for-directive-value①⑧">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑤">6.1.3.3. 
+    <li><a href="#ref-for-directive-value①⑨">6.1.3.3. 
     default-src Inline Check </a>
-    <li><a href="#ref-for-directive-value①⑥">6.1.4.1. 
+    <li><a href="#ref-for-directive-value②⓪">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑦">6.1.4.2. 
+    <li><a href="#ref-for-directive-value②①">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-directive-value①⑧">6.1.5.1. 
+    <li><a href="#ref-for-directive-value②②">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value①⑨">6.1.5.2. 
+    <li><a href="#ref-for-directive-value②③">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⓪">6.1.6.1. 
+    <li><a href="#ref-for-directive-value②④">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②①">6.1.6.2. 
+    <li><a href="#ref-for-directive-value②⑤">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②②">6.1.7.1. 
+    <li><a href="#ref-for-directive-value②⑥">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②③">6.1.7.2. 
+    <li><a href="#ref-for-directive-value②⑦">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②④">6.1.8.1. 
+    <li><a href="#ref-for-directive-value②⑧">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑤">6.1.8.2. 
+    <li><a href="#ref-for-directive-value②⑨">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑥">6.1.9.1. 
+    <li><a href="#ref-for-directive-value③⓪">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑦">6.1.9.2. 
+    <li><a href="#ref-for-directive-value③①">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑧">6.1.10.1. 
+    <li><a href="#ref-for-directive-value③②">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑨">6.1.10.2. 
+    <li><a href="#ref-for-directive-value③③">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
+    <li><a href="#ref-for-directive-value③④">6.1.11.3. 
     script-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
-    <li><a href="#ref-for-directive-value③②">6.1.12.3. 
+    <li><a href="#ref-for-directive-value③⑤">6.1.12. script-src-elem</a>
+    <li><a href="#ref-for-directive-value③⑥">6.1.12.3. 
     script-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value③③">6.1.13.1. 
+    <li><a href="#ref-for-directive-value③⑦">6.1.13.1. 
     script-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value③④">6.1.14.1. 
-    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑤">(2)</a>
-    <li><a href="#ref-for-directive-value③⑥">6.1.14.2. 
-    style-src Post-request Check </a> <a href="#ref-for-directive-value③⑦">(2)</a>
-    <li><a href="#ref-for-directive-value③⑧">6.1.14.3. 
+    <li><a href="#ref-for-directive-value③⑧">6.1.14.1. 
+    style-src Pre-request Check </a> <a href="#ref-for-directive-value③⑨">(2)</a>
+    <li><a href="#ref-for-directive-value④⓪">6.1.14.2. 
+    style-src Post-request Check </a> <a href="#ref-for-directive-value④①">(2)</a>
+    <li><a href="#ref-for-directive-value④②">6.1.14.3. 
     style-src Inline Check </a>
-    <li><a href="#ref-for-directive-value③⑨">6.1.15.1. 
-    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④⓪">(2)</a>
-    <li><a href="#ref-for-directive-value④①">6.1.15.2. 
-    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④②">(2)</a>
-    <li><a href="#ref-for-directive-value④③">6.1.15.3. 
+    <li><a href="#ref-for-directive-value④③">6.1.15.1. 
+    style-src-elem Pre-request Check </a> <a href="#ref-for-directive-value④④">(2)</a>
+    <li><a href="#ref-for-directive-value④⑤">6.1.15.2. 
+    style-src-elem Post-request Check </a> <a href="#ref-for-directive-value④⑥">(2)</a>
+    <li><a href="#ref-for-directive-value④⑦">6.1.15.3. 
     style-src-elem Inline Check </a>
-    <li><a href="#ref-for-directive-value④④">6.1.16.1. 
+    <li><a href="#ref-for-directive-value④⑧">6.1.16.1. 
     style-src-attr Inline Check </a>
-    <li><a href="#ref-for-directive-value④⑤">6.1.17.1. 
+    <li><a href="#ref-for-directive-value④⑨">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-directive-value④⑥">6.1.17.2. 
+    <li><a href="#ref-for-directive-value⑤⓪">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-directive-value④⑦">6.2.1.1. 
+    <li><a href="#ref-for-directive-value⑤①">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-directive-value④⑧">6.2.2.1. 
+    <li><a href="#ref-for-directive-value⑤②">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-directive-value④⑨">6.2.2.2. 
+    <li><a href="#ref-for-directive-value⑤③">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
-    <li><a href="#ref-for-directive-value⑤⓪">6.2.3.1. 
+    <li><a href="#ref-for-directive-value⑤④">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-directive-value⑤①">6.2.3.2. 
+    <li><a href="#ref-for-directive-value⑤⑤">6.2.3.2. 
     sandbox Initialization </a>
-    <li><a href="#ref-for-directive-value⑤②">6.3.1.1. 
+    <li><a href="#ref-for-directive-value⑤⑥">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-directive-value⑤③">6.3.2.1. 
+    <li><a href="#ref-for-directive-value⑤⑦">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-directive-value⑤④">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑤">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑥">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑤⑦">(2)</a>
-    <li><a href="#ref-for-directive-value⑤⑧">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a> <a href="#ref-for-directive-value⑥⓪">(3)</a> <a href="#ref-for-directive-value⑥①">(4)</a> <a href="#ref-for-directive-value⑥②">(5)</a>
-    <li><a href="#ref-for-directive-value⑥③">6.6.1.2. 
-    Script directives post-request check </a> <a href="#ref-for-directive-value⑥④">(2)</a> <a href="#ref-for-directive-value⑥⑤">(3)</a>
+    <li><a href="#ref-for-directive-value⑤⑧">6.3.3.1. 
+    navigate-to Pre-Navigation Check </a> <a href="#ref-for-directive-value⑤⑨">(2)</a>
+    <li><a href="#ref-for-directive-value⑥⓪">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-directive-value⑥①">(2)</a>
+    <li><a href="#ref-for-directive-value⑥②">6.6.1.1. 
+    Script directives pre-request check </a> <a href="#ref-for-directive-value⑥③">(2)</a> <a href="#ref-for-directive-value⑥④">(3)</a> <a href="#ref-for-directive-value⑥⑤">(4)</a> <a href="#ref-for-directive-value⑥⑥">(5)</a>
+    <li><a href="#ref-for-directive-value⑥⑦">6.6.1.2. 
+    Script directives post-request check </a> <a href="#ref-for-directive-value⑥⑧">(2)</a> <a href="#ref-for-directive-value⑥⑨">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serialized-directive">

--- a/index.src.html
+++ b/index.src.html
@@ -493,22 +493,72 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   steps.
 
   This algorithm returns a [=list=] of [=Content Security Policy objects=]. If |list| cannot be
-  parsed, the returned list will be empty.
+  parsed, the returned list will contain a <a>malformed policy placeholder</a>
+  for every [=/policy=] in the |list| that cannot be parsed.
 
   <ol class="algorithm">
     1.  Let |policies| be an empty [=list=].
 
     2.  For each |token| returned by <a lt="split a string on commas">splitting |list| on commas</a>:
 
-        1.  Let |policy| be the result of <a abstract-op lt="parse a serialized CSP">parsing</a>
-            |token|, with a [=policy/source=] of |source|, and [=policy/disposition=] of
-            |disposition|.
+        1.  [=Strip leading and trailing ASCII whitespace=] from |token|.
 
-        2.  If |policy|'s [=policy/directive set=] is empty, [=iteration/continue=].
+        2.  If |token| does not match the <a grammar>serialized-policy</a> grammar,
+            let |policy| be the result of executing [[#malformed-default-csp-replacement]]
+            on |source|, and |disposition|.
 
-        3.  [=list/append|Append=] |policy| to |policies|.
+            Note: In this case the user agent SHOULD notify developers that the
+            policy they are using is invalid. A console warning might be appropriate.
+
+        3.  Otherwise, let |policy| be the result of
+            <a abstract-op lt="parse a serialized CSP">parsing</a> |token|, with
+            a [=policy/source=] of |source|, and [=policy/disposition=] of |disposition|.
+
+        4.  If |policy|'s [=policy/directive set=] is empty, [=iteration/continue=].
+
+        5.  [=list/append|Append=] |policy| to |policies|.
 
     3.  Return |policies|.
+  </ol>
+
+  <h4 id="malformed-default-csp-replacement" algorithm>
+    Return a malformed policy placeholder
+  </h4>
+
+  In the situation where a malformed [=/policy=] is used, it will be replaced with
+  the |policy| returned by this algorithm. This is done to ensure that mistakes
+  in the [=/policy=] are not silently ignored which would lead to security issues.
+  Instead the following very restrictive policy is used:
+
+  <pre>
+    default-src 'none'; base-uri 'none'; form-action 'none'; navigate-to 'none';
+  </pre>
+
+  To return a <dfn>malformed policy placeholder</dfn> given a [=policy/source=]
+  (|source|), and a [=policy/disposition=] (|disposition|), execute the following
+  steps:
+
+  <ol class="algorithm">
+    1.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=],
+        a [=policy/source=] of |source|, and a [=policy/disposition=] of |disposition|.
+
+    2.  [=list/append|Append=] a new [=directive=] whose [=directive/name=] is
+        `"default-src"`, and [=directive/value=] is `"'none'"`,
+        to |policy|'s [=policy/directive set=].
+
+    3.  [=list/append|Append=] a new [=directive=] whose [=directive/name=] is
+        `"base-uri"`, and [=directive/value=] is `"'none'"`,
+        to |policy|'s [=policy/directive set=].
+
+    4.  [=list/append|Append=] a new [=directive=] whose [=directive/name=] is
+        `"form-action"`, and [=directive/value=] is `"'none'"`,
+        to |policy|'s [=policy/directive set=].
+
+    5.  [=list/append|Append=] a new [=directive=] whose [=directive/name=] is
+        `"navigate-to"`, and [=directive/value=] is `"'none'"`,
+        to |policy|'s [=policy/directive set=].
+
+    6.  Return |policy|.
   </ol>
 
   <h3 id="framework-directives">Directives</h3>


### PR DESCRIPTION
This PR specifies the behavior when a malformed policy is encountered.
Fixes: https://github.com/w3c/webappsec-csp/issues/6

I believe there is little risk in breaking a significant number of existing sites that have malformed policy because judging by the metrics in the chrome dev channel, about 0.00015% percent of sites have a malformed policy.

In contrast, I have recently helped investigate an issue where a malformed policy was left undetected and it was only evident because of divergent browser behavior (https://github.com/webcompat/web-bugs/issues/18902).

ccing @shekyan @metromoxie @michaelficarra as people that participated in the discussion in the issue, for any thoughts or feedback.