### PR TITLE
Use request's client instead of the source browsing context to get a navigation initiator's CSP list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
+  <meta content="Bikeshed version 36c8e210b03bee5c4f253cec43379cce76c8dd3f" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="07ba1fff78f39707fec541400794b23c7987f7b2" name="document-revision">
+  <meta content="48b736b9049ec5d8c82375c5a972bd57ad43759a" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-09">9 November 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-11-12">12 November 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1618,8 +1618,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         <li><a href="#set-response-csp-list"><span class="secno">4.1.1</span> <span class="content"> Set <var>response</var>’s <code>CSP list</code> </span></a>
         <li><a href="#report-for-request"><span class="secno">4.1.2</span> <span class="content"> Report Content Security Policy violations for <var>request</var> </span></a>
         <li><a href="#should-block-request"><span class="secno">4.1.3</span> <span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span></a>
-        <li><a href="#should-block-response"><span class="secno">4.1.4</span> <span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content
-    Security Policy? </span></a>
+        <li><a href="#should-block-response"><span class="secno">4.1.4</span> <span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span></a>
        </ol>
       <li>
        <a href="#html-integration"><span class="secno">4.2</span> <span class="content"> Integration with HTML </span></a>
@@ -2147,13 +2146,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
-  and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a>. This algorithm returns
+  and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
-  and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a>. This algorithm returns
+  and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
@@ -2165,14 +2162,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>"
+  or "<code>other</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing contexts</a>, a check type string ("<code>source</code>"
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>, a check type string ("<code>source</code>"
   or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
@@ -2417,8 +2414,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   and against each redirect that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑧">request</a> might go through on its
   way to reaching a resource.</p>
      <li data-md>
-      <p><a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a> is called as part of step #13 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
+      <p><a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> is called as part of step #13 of its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
@@ -2501,9 +2497,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Should response to request be blocked by Content
-    Security Policy?" data-level="4.1.4" id="should-block-response"><span class="secno">4.1.4. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content
-    Security Policy? </span><a class="self-link" href="#should-block-response"></a></h4>
+    <h4 class="heading settled algorithm" data-algorithm="Should response to request be blocked by Content Security Policy?" data-level="4.1.4" id="should-block-response"><span class="secno">4.1.4. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-response"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①②">response</a> (<var>response</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①①">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code>, and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>’s Content Security Policy.</p>
     <ol>
      <li data-md>
@@ -2580,7 +2574,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
      <li data-md>
-      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> is nested.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> is nested.</p>
      <li data-md>
       <p>HTML populates each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata">cryptographic nonce
   metadata</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata">parser metadata</a> with relevant data from the
@@ -2596,8 +2590,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy" id="ref-for-should-plugin-element-be-blocked-a-priori-by-content-security-policy">§6.2.2.2 Should plugin element be blocked a priori by Content
     Security Policy?:</a> is called during the processing of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element">embed</a></code>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet"><code>applet</code></a> elements to determine whether they may trigger a fetch.</p>
-      <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a>.</p>
+      <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
       <p class="issue" id="issue-5faf83e6"><a class="self-link" href="#issue-5faf83e6"></a> This hook is missing from W3C’s HTML. <a href="https://github.com/w3c/html/issues/547">&lt;https://github.com/w3c/html/issues/547></a></p>
      <li data-md>
       <p><a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
@@ -2610,18 +2603,17 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a></p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Initialize a Document&apos;s CSP list" data-level="4.2.1" id="initialize-document-csp"><span class="secno">4.2.1. </span><span class="content"> Initialize a <code>Document</code>'s <code>CSP list</code> </span><a class="self-link" href="#initialize-document-csp"></a></h4>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> (<var>document</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> (<var>source</var>) the user agent performs the following
+    <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> (<var>document</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①③">request</a> (<var>request</var>) the user agent performs the following
   steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md>
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a>:</p>
       <ol>
        <li data-md>
-        <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>:</p>
-        <p class="issue" id="issue-04a9cf28"><a class="self-link" href="#issue-04a9cf28"></a> <var>source</var>’s active document is incorrect here. <a href="https://github.com/w3c/webappsec-csp/issues/360">&lt;https://github.com/w3c/webappsec-csp/issues/360></a></p>
+        <p>For each <var>policy</var> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
         <ol>
          <li data-md>
-          <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
+          <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
@@ -2629,9 +2621,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
-      <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
+      <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a>.</p>
      <li data-md>
-      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP list</a>:</p>
+      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>:</p>
       <ol>
        <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
@@ -2643,7 +2635,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Initialize a global object’s CSP list" data-level="4.2.2" id="initialize-global-object-csp"><span class="secno">4.2.2. </span><span class="content"> Initialize a global object’s <code>CSP list</code> </span><a class="self-link" href="#initialize-global-object-csp"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①①">global object</a> (<var>global</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑥">response</a> (<var>response</var>), the user agent performs the following steps in order
-  to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
+  to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
     <ol>
      <li data-md>
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
@@ -2656,10 +2648,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>For each <var>owner</var> in <var>owners</var>:</p>
         <ol>
          <li data-md>
-          <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
+          <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑦">CSP list</a>:</p>
           <ol>
            <li data-md>
-            <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑦">CSP list</a>.</p>
+            <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑧">CSP list</a>.</p>
           </ol>
         </ol>
       </ol>
@@ -2669,7 +2661,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
        <li data-md>
-        <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑧">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑧">CSP list</a>.</p>
+        <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑧">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑨">CSP list</a>.</p>
       </ol>
      <li data-md>
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope③">WorkletGlobalScope</a></code>:</p>
@@ -2677,24 +2669,24 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
        <li data-md>
         <p>Let <var>owner</var> be <var>global</var>’s <a data-link-type="dfn" href="https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document" id="ref-for-workletglobalscope-owner-document">owner document</a>.</p>
        <li data-md>
-        <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑨">CSP list</a>:</p>
+        <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⓪">CSP list</a>:</p>
         <ol>
          <li data-md>
-          <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⓪">CSP list</a>.</p>
+          <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①①">CSP list</a>.</p>
         </ol>
       </ol>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Retrieve the CSP list of an object" data-level="4.2.3" id="get-csp-of-object"><span class="secno">4.2.3. </span><span class="content"> Retrieve the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①①">CSP list</a> of an <var>object</var> </span><a class="self-link" href="#get-csp-of-object"></a></h4>
-    <p>To obtain <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①②">CSP list</a>:</p>
+    <h4 class="heading settled algorithm" data-algorithm="Retrieve the CSP list of an object" data-level="4.2.3" id="get-csp-of-object"><span class="secno">4.2.3. </span><span class="content"> Retrieve the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①②">CSP list</a> of an <var>object</var> </span><a class="self-link" href="#get-csp-of-object"></a></h4>
+    <p>To obtain <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①③">CSP list</a>:</p>
     <ol>
      <li data-md>
-      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑤">CSP list</a>.</p>
+      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP list</a>.</p>
      <li data-md>
-      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①">Window</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated <code>Document</code></a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑥">CSP list</a>.</p>
+      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①">Window</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated <code>Document</code></a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑤">CSP list</a>.</p>
      <li data-md>
-      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①③">CSP list</a>.</p>
+      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①④">CSP list</a>.</p>
      <li data-md>
-      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope④">WorkletGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①④">CSP list</a>.</p>
+      <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope④">WorkletGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a>.</p>
      <li data-md>
       <p>Return <code>null</code>.</p>
     </ol>
@@ -2711,7 +2703,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
      <li data-md>
-      <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a>:</p>
+      <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a>:</p>
       <ol>
        <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑥">directive set</a>:</p>
@@ -2724,7 +2716,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
          <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
-  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>, <var>policy</var>,
+  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑤">global object</a>, <var>policy</var>,
   and <var>directive-name</var>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource②">resource</a> to "<code>inline</code>".</p>
@@ -2747,23 +2739,22 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h4 class="heading settled algorithm" data-algorithm="Should navigation request of type from source in target be blocked
     by Content Security Policy?" data-level="4.2.5" id="should-block-navigation-request"><span class="secno">4.2.5. </span><span class="content"> Should <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked
     by Content Security Policy? </span><a class="self-link" href="#should-block-navigation-request"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①③">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
-  "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①④">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
+  "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
   the navigation, and "<code>Allowed</code>" otherwise:</p>
     <ol class="algorithm">
      <li data-md>
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
      <li data-md>
-      <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑦">CSP list</a>:</p>
+      <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑧">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑥">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">CSP list</a>:</p>
       <ol>
        <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
          <li data-md>
-          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>source</var>, <var>target</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
+          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
-          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
+          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑦">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
@@ -2778,20 +2769,19 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
       <ol>
        <li data-md>
-        <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑧">CSP List</a>:</p>
+        <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⓪">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑧">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a>:</p>
         <ol>
          <li data-md>
           <p>For each <var>directive</var> in <var>policy</var>:</p>
           <ol>
            <li data-md>
+            <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
+           <li data-md>
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <code>null</code>,
   "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>,
   skip to the next <var>directive</var>.</p>
            <li data-md>
-            <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-           <li data-md>
-            <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global
-  object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
+            <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①①">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑨">global object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
            <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
@@ -2808,9 +2798,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?" data-level="4.2.6" id="should-block-navigation-response"><span class="secno">4.2.6. </span><span class="content"> Should <var>navigation response</var> to <var>navigation request</var> of <var>type</var> from <var>source</var> in <var>target</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-navigation-response"></a></h4>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①④">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑤">request</a> (<var>navigation request</var>), a string (<var>type</var>, either
   "<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑦">response</a> <var>navigation
-  response</var>, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
+  response</var>, and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm
   returns "<code>Blocked</code>" if the active policy blocks the navigation, and "<code>Allowed</code>"
   otherwise:</p>
     <ol class="algorithm">
@@ -2824,7 +2814,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
          <li data-md>
-          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
+          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
           <p class="note" role="note"><span>Note:</span> We use <code>null</code> for the global object, as no global exists:
@@ -2840,18 +2830,17 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         </ol>
       </ol>
      <li data-md>
-      <p>For each <var>policy</var> in <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document③">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑨">CSP List</a>:</p>
-      <p class="note" role="note"><span>Note:</span> Some directives in the <var>source</var> context (like <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to①">navigate-to</a>)
+      <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①②">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a>:</p>
+      <p class="note" role="note"><span>Note:</span> Some directives in the <var>navigation request</var>’s context (like <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to①">navigate-to</a>)
   need the <var>response</var> before acting on the navigation.</p>
       <ol>
        <li data-md>
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
          <li data-md>
-          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>source</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
+          <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
          <li data-md>
-          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>source</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global
-  object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
+          <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①③">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①①">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
@@ -2869,7 +2858,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>ECMAScript defines a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> abstract operation
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
-  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a> to determine whether such compilation ought to be blocked.</p>
+  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> to determine whether such compilation ought to be blocked.</p>
     <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm" id="ref-for-realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a string (<var>source</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>" if not:</p>
@@ -2882,7 +2871,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
        <li data-md>
         <p>Let <var>result</var> be "<code>Allowed</code>".</p>
        <li data-md>
-        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">CSP list</a>:</p>
+        <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a>:</p>
         <ol>
          <li data-md>
           <p>Let <var>source-list</var> be <code>null</code>.</p>
@@ -3139,7 +3128,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
            <li data-md>
             <p>If <var>endpoint</var> is not a valid URL, skip the remaining substeps.</p>
            <li data-md>
-            <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑤">request</a>, initialized as follows:</p>
+            <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑥">request</a>, initialized as follows:</p>
             <dl>
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
              <dd data-md>
@@ -3154,7 +3143,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
              <dd data-md>
               <p>"<code>no-window</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①④">client</a>
              <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑦">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant
   settings object</a></p>
@@ -3259,8 +3248,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
 <pre>directive-name  = "child-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list">serialized-source-list</a>
 </pre>
-    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑥">requests</a> which will populate a frame or a
-  worker. More formally, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑦">requests</a> falling into one of the
+    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑦">requests</a> which will populate a frame or a
+  worker. More formally, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">requests</a> falling into one of the
   following categories:</p>
     <ul>
      <li data-md>
@@ -3285,7 +3274,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3297,7 +3286,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="child-src Post-request check" data-level="6.1.1.2" id="child-src-post-request"><span class="secno">6.1.1.2. </span><span class="content"> <code>child-src</code> Post-request check </span><a class="self-link" href="#child-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3314,7 +3303,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "connect-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①">serialized-source-list</a>
 </pre>
-    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⓪">requests</a> which transmit or receive data from
+    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">requests</a> which transmit or receive data from
   other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping" id="ref-for-dom-a-ping">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
@@ -3349,7 +3338,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3363,7 +3352,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3384,8 +3373,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>If a <a data-link-type="dfn" href="#default-src" id="ref-for-default-src①">default-src</a> directive is present in a policy, its value will be
   used as the policy’s default source list. That is, given <code>default-src 'none'; script-src 'self'</code>, script requests will use <code>'self'</code> as the <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②">source
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
-  out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a> algorithms.</p>
+  out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
     <div class="example" id="example-327c55f5">
      <a class="self-link" href="#example-327c55f5"></a> The following header: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①">'self'</a>
@@ -3436,7 +3424,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="default-src Pre-request check" data-level="6.1.3.1" id="default-src-pre-request"><span class="secno">6.1.3.1. </span><span class="content"> <code>default-src</code> Pre-request check </span><a class="self-link" href="#default-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3448,7 +3436,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="default-src Post-request check" data-level="6.1.3.2" id="default-src-post-request"><span class="secno">6.1.3.2. </span><span class="content"> <code>default-src</code> Post-request check </span><a class="self-link" href="#default-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3496,7 +3484,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3510,7 +3498,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3540,7 +3528,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3554,7 +3542,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3573,8 +3561,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "img-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑤">serialized-source-list</a>
 </pre>
-    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">requests</a> which load images. More formally, this
-  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
+    <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> which load images. More formally, this
+  includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
     <div class="example" id="example-ad572c5c">
      <a class="self-link" href="#example-ad572c5c"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src②">img-src</a> https://example.com/
@@ -3586,7 +3574,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3600,7 +3588,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3630,7 +3618,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3644,7 +3632,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3677,7 +3665,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3691,7 +3679,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3721,7 +3709,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3735,7 +3723,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3783,7 +3771,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
     <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3797,7 +3785,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3822,10 +3810,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <code>script-src</code> directive governs five things:</p>
     <ol>
      <li data-md>
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a>.</p>
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑤">script</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. Their
   behavior will be blocked unless every policy allows inline script, either
@@ -3852,7 +3839,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3863,7 +3850,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Post-request check" data-level="6.1.11.2" id="script-src-post-request"><span class="secno">6.1.11.2. </span><span class="content"> <code>script-src</code> Post-request check </span><a class="self-link" href="#script-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3910,7 +3897,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     </ul>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Pre-request check" data-level="6.1.12.1" id="script-src-elem-pre-request"><span class="secno">6.1.12.1. </span><span class="content"> <code>script-src-elem</code> Pre-request check </span><a class="self-link" href="#script-src-elem-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3921,7 +3908,7 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Post-request check" data-level="6.1.12.2" id="script-src-elem-post-request"><span class="secno">6.1.12.2. </span><span class="content"> <code>script-src-elem</code> Post-request check </span><a class="self-link" href="#script-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -3979,7 +3966,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md>
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md>
@@ -3991,8 +3978,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content
-    Security Policy?</a>.</p>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
@@ -4017,7 +4003,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Pre-request Check" data-level="6.1.14.1" id="style-src-pre-request"><span class="secno">6.1.14.1. </span><span class="content"> <code>style-src</code> Pre-request Check </span><a class="self-link" href="#style-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4035,7 +4021,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4078,7 +4064,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   except for styles defined in inline attributes.</p>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4096,7 +4082,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4168,7 +4154,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4182,7 +4168,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
@@ -4210,7 +4196,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   returns "<code>Allowed</code>" if <var>base</var> may be used as the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element②">base</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href①">href</a></code> attribute, and "<code>Blocked</code>" otherwise:</p>
     <ol>
      <li data-md>
-      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">csp list</a>:</p>
+      <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">csp list</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>source list</var> be <code>null</code>.</p>
@@ -4285,7 +4271,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
     <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
@@ -4311,7 +4297,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
   its document:</p>
     <ol class="algorithm">
      <li data-md>
-      <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①⓪">CSP list</a>:</p>
+      <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑥">CSP list</a>:</p>
       <ol>
        <li data-md>
         <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
@@ -4351,7 +4337,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
     <h5 class="heading settled algorithm" data-algorithm="sandbox Response Check" data-level="6.2.3.1" id="sandbox-response"><span class="secno">6.2.3.1. </span><span class="content"> <code>sandbox</code> Response Check </span><a class="self-link" href="#sandbox-response"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check②">response check</a> algorithm is as
   follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p class="assertion">Assert: <var>response</var> is unused.</p>
@@ -4399,13 +4385,13 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑧">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="form-action Pre-Navigation Check" data-level="6.3.1.1" id="form-action-pre-navigate"><span class="secno">6.3.1.1. </span><span class="content"> <code>form-action</code> Pre-Navigation Check </span><a class="self-link" href="#form-action-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦②">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if a form
   submission violates the <code>form-action</code> directive’s constraints, and "<code>Allowed</code>"
   otherwise. This constitutes the <code>form-action</code> directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
      <li data-md>
-      <p class="assertion">Assert: <var>source</var>, <var>target</var>, and <var>policy</var> are unused in this algorithm, as <code>form-action</code> is concerned only with details of the outgoing request.</p>
+      <p class="assertion">Assert: <var>policy</var> is unused in this algorithm.</p>
      <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
@@ -4433,32 +4419,34 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
     <p class="note" role="note"><span>Note:</span> The <code>frame-ancestors</code> directive’s syntax is similar to a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①①">source
   list</a>, but <code>frame-ancestors</code> will not fall back to the <code>default-src</code> directive’s value if one is specified. That is, a policy that declares <code>default-src 'none'</code> will still allow the resource to be embedded by anyone.</p>
     <h5 class="heading settled algorithm" data-algorithm="frame-ancestors Navigation Response Check" data-level="6.3.2.1" id="frame-ancestors-navigation-response"><span class="secno">6.3.2.1. </span><span class="content"> <code>frame-ancestors</code> Navigation Response Check </span><a class="self-link" href="#frame-ancestors-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑥">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑧">response</a> (<var>navigation response</var>) a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> (<var>target</var>),
+  a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦③">policy</a> (<var>policy</var>) this algorithm returns "<code>Blocked</code>" if one or
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
-      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, <var>source</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
+      <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, <var>navigation type</var>, and <var>policy</var> are unused in this algorithm, as <code>frame-ancestors</code> is concerned only
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a> and it has no impact on the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑨">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing context</a> and it has no impact on the <var>request</var>’s
+  context.</p>
      <li data-md>
       <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
      <li data-md>
       <p>Let <var>current</var> be <var>target</var>.</p>
      <li data-md>
-      <p>While <var>current</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context">parent browsing context</a> (<var>parent</var>):</p>
+      <p>While <var>current</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>:</p>
       <ol>
        <li data-md>
-        <p>Set <var>current</var> to <var>parent</var>.</p>
+        <p>Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code> that <var>current</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through①">nested through</a>.</p>
        <li data-md>
-        <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document④">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object③">relevant settings
-  object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
+        <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>document</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-origin" id="ref-for-dom-document-origin">origin</a></code>.</p>
        <li data-md>
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
-  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return
-  "<code>Blocked</code>".</p>
+  executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>, and <code>0</code>, return "<code>Blocked</code>".</p>
+       <li data-md>
+        <p>Set <var>current</var> to <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing context</a>.</p>
       </ol>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
@@ -4493,15 +4481,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑨">serialized-source-list</a>
 </pre>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Pre-Navigation Check" data-level="6.3.3.1" id="navigate-to-pre-navigate"><span class="secno">6.3.3.1. </span><span class="content"> <code>navigate-to</code> Pre-Navigation Check </span><a class="self-link" href="#navigate-to-pre-navigate"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑦">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
-  "<code>other</code>"), two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①⓪">browsing contexts</a> (<var>source</var> and <var>target</var>),
-  and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or
+  "<code>other</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑤">policy</a> (<var>policy</var>), this algorithm returns "<code>Blocked</code>"
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
-     <li data-md>
-      <p class="assertion">Assert: <var>source</var> and <var>target</var> are unused as 'navigate-to'
-  is concerned with the details of the request.</p>
      <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md>
@@ -4517,15 +4501,15 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑧">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"),  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
-  two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①①">browsing contexts</a> (<var>source</var> and <var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>), a string <var>navigation type</var> ("<code>form-submission</code>" or "<code>other</code>"), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④①">response</a> (<var>navigation response</var>)
+  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> (<var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
      <li data-md>
-      <p class="assertion">Assert: <var>source</var>, and <var>target</var> are unused.</p>
+      <p class="assertion">Assert: <var>target</var> is unused.</p>
      <li data-md>
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
-      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>source</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①②">browsing context</a> and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①③">browsing context</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>request</var>’s context and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
      <li data-md>
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
      <li data-md>
@@ -4592,7 +4576,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <h3 class="heading settled" data-level="6.6" id="matching-algorithms"><span class="secno">6.6. </span><span class="content">Matching Algorithms</span><a class="self-link" href="#matching-algorithms"></a></h3>
     <h4 class="heading settled" data-level="6.6.1" id="script-checks"><span class="secno">6.6.1. </span><span class="content">Script directive checks</span><a class="self-link" href="#script-checks"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Script directives pre-request check" data-level="6.6.1.1" id="script-pre-request"><span class="secno">6.6.1.1. </span><span class="content"> Script directives pre-request check </span><a class="self-link" href="#script-pre-request"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
@@ -4650,7 +4634,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②①">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>):</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like②">script-like</a>:</p>
@@ -4672,7 +4656,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
     <h5 class="heading settled algorithm" data-algorithm="Does request violate policy?" data-level="6.6.2.1" id="does-request-violate-policy"><span class="secno">6.6.2.1. </span><span class="content"> Does <var>request</var> violate <var>policy</var>? </span><a class="self-link" href="#does-request-violate-policy"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>), this
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
@@ -4690,7 +4674,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑦">cryptographic nonce metadata</a> (<var>nonce</var>) and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①②">source list</a> (<var>source list</var>), this algorithm returns
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
@@ -4709,12 +4693,12 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥③">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①③">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url③">current url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin①">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count">redirect
   count</a>.</p>
-    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥④">request</a> is reasonable.</p>
+    <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③②">directives</a>' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②⓪">pre-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> is reasonable.</p>
     <h5 class="heading settled algorithm" data-algorithm="Does response to request match source list?" data-level="6.6.2.4" id="match-response-to-source-list"><span class="secno">6.6.2.4. </span><span class="content"> Does <var>response</var> to <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-response-to-source-list"></a></h5>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑤">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a> (<var>request</var>), and a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①④">source list</a> (<var>source list</var>),
   this algorithm returns the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url④">url</a>, <var>source list</var>, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin②">origin</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-count" id="ref-for-concept-request-redirect-count①">redirect
   count</a>.</p>
     <p class="note" role="note"><span>Note:</span> This is generally used in <a data-link-type="dfn" href="#directives" id="ref-for-directives③③">directives</a>' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②②">post-request check</a> algorithms to verify that a given <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④③">response</a> is reasonable.</p>
@@ -5115,8 +5099,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
-    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑥">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
+    <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a>. Given
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
      <li data-md>
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
@@ -5144,7 +5128,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
        <dd data-md>
         <ol>
          <li data-md>
-          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>, return <code>frame-src</code>.</p>
+          <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑦">nested browsing context</a>, return <code>frame-src</code>.</p>
         </ol>
        <dt data-md>"<code>audio</code>"
        <dt data-md>"<code>track</code>"
@@ -5193,7 +5177,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
     <p>Given a string (<var>type</var>), this algorithm returns the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑤">name</a> of the effective directive.</p>
-    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">requests</a>, in this algorithm it is used similarly to mean
+    <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑨">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
      <li data-md>
@@ -5477,9 +5461,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
 <pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
 </pre>
     </div>
-    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a> which
-  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">CSP list</a> or vice-versa.</p>
+    <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
+  means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -6078,8 +6062,10 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
     <li><a href="#ref-for-document①⑥">6.2.3.2. 
     sandbox Initialization </a> <a href="#ref-for-document①⑦">(2)</a> <a href="#ref-for-document①⑧">(3)</a>
-    <li><a href="#ref-for-document①⑨">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-document②⓪">(2)</a>
+    <li><a href="#ref-for-document①⑨">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a>
+    <li><a href="#ref-for-document②⓪">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-document②①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-element">
@@ -6167,6 +6153,13 @@ rest of Google’s CSP Cabal.</p>
     Security Policy?: </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-document-origin">
+   <a href="https://dom.spec.whatwg.org/#dom-document-origin">https://dom.spec.whatwg.org/#dom-document-origin</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-origin">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-shadow-including-root">
    <a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
    <ul>
@@ -6242,9 +6235,16 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-request-client③">4.1.3. 
     Should request be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client④">(2)</a>
     <li><a href="#ref-for-concept-request-client⑤">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a> <a href="#ref-for-concept-request-client⑥">(2)</a>
-    <li><a href="#ref-for-concept-request-client⑦">5.3. 
+    Should response to request be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client⑥">(2)</a>
+    <li><a href="#ref-for-concept-request-client⑦">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-concept-request-client⑧">4.2.5. 
+    Should navigation request of type from source in target be blocked
+    by Content Security Policy? </a> <a href="#ref-for-concept-request-client⑨">(2)</a> <a href="#ref-for-concept-request-client①⓪">(3)</a> <a href="#ref-for-concept-request-client①①">(4)</a>
+    <li><a href="#ref-for-concept-request-client①②">4.2.6. 
+    Should navigation response to navigation request of type from source
+    in target be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client①③">(2)</a>
+    <li><a href="#ref-for-concept-request-client①④">5.3. 
     Report a violation </a>
    </ul>
   </aside>
@@ -6284,8 +6284,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response-csp-list③">4.1.1. 
     Set response’s CSP list </a> <a href="#ref-for-concept-response-csp-list④">(2)</a> <a href="#ref-for-concept-response-csp-list⑤">(3)</a>
     <li><a href="#ref-for-concept-response-csp-list⑥">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-response-csp-list⑦">4.2.1. 
     Initialize a Document's CSP list </a>
     <li><a href="#ref-for-concept-response-csp-list⑧">4.2.2. 
@@ -6501,110 +6500,111 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-request①⓪">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-request①①">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-request①②">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-concept-request①③">4.2.5. 
+    <li><a href="#ref-for-concept-request①③">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-concept-request①④">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①④">4.2.6. 
+    <li><a href="#ref-for-concept-request①⑤">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①⑤">5.3. 
+    <li><a href="#ref-for-concept-request①⑥">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-request①⑥">6.1.1. child-src</a> <a href="#ref-for-concept-request①⑦">(2)</a>
-    <li><a href="#ref-for-concept-request①⑧">6.1.1.1. 
+    <li><a href="#ref-for-concept-request①⑦">6.1.1. child-src</a> <a href="#ref-for-concept-request①⑧">(2)</a>
+    <li><a href="#ref-for-concept-request①⑨">6.1.1.1. 
     child-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request①⑨">6.1.1.2. 
+    <li><a href="#ref-for-concept-request②⓪">6.1.1.2. 
     child-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⓪">6.1.2. connect-src</a>
-    <li><a href="#ref-for-concept-request②①">6.1.2.1. 
+    <li><a href="#ref-for-concept-request②①">6.1.2. connect-src</a>
+    <li><a href="#ref-for-concept-request②②">6.1.2.1. 
     connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②②">6.1.2.2. 
+    <li><a href="#ref-for-concept-request②③">6.1.2.2. 
     connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②③">6.1.3.1. 
+    <li><a href="#ref-for-concept-request②④">6.1.3.1. 
     default-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②④">6.1.3.2. 
+    <li><a href="#ref-for-concept-request②⑤">6.1.3.2. 
     default-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⑤">6.1.4.1. 
+    <li><a href="#ref-for-concept-request②⑥">6.1.4.1. 
     font-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⑥">6.1.4.2. 
+    <li><a href="#ref-for-concept-request②⑦">6.1.4.2. 
     font-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⑦">6.1.5.1. 
+    <li><a href="#ref-for-concept-request②⑧">6.1.5.1. 
     frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⑧">6.1.5.2. 
+    <li><a href="#ref-for-concept-request②⑨">6.1.5.2. 
     frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⑨">6.1.6. img-src</a> <a href="#ref-for-concept-request③⓪">(2)</a>
-    <li><a href="#ref-for-concept-request③①">6.1.6.1. 
+    <li><a href="#ref-for-concept-request③⓪">6.1.6. img-src</a> <a href="#ref-for-concept-request③①">(2)</a>
+    <li><a href="#ref-for-concept-request③②">6.1.6.1. 
     img-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③②">6.1.6.2. 
+    <li><a href="#ref-for-concept-request③③">6.1.6.2. 
     img-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③③">6.1.7.1. 
+    <li><a href="#ref-for-concept-request③④">6.1.7.1. 
     manifest-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③④">6.1.7.2. 
+    <li><a href="#ref-for-concept-request③⑤">6.1.7.2. 
     manifest-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⑤">6.1.8.1. 
+    <li><a href="#ref-for-concept-request③⑥">6.1.8.1. 
     media-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑥">6.1.8.2. 
+    <li><a href="#ref-for-concept-request③⑦">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⑦">6.1.9.1. 
+    <li><a href="#ref-for-concept-request③⑧">6.1.9.1. 
     prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑧">6.1.9.2. 
+    <li><a href="#ref-for-concept-request③⑨">6.1.9.2. 
     prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⑨">6.1.10.1. 
+    <li><a href="#ref-for-concept-request④⓪">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request④⓪">6.1.10.2. 
+    <li><a href="#ref-for-concept-request④①">6.1.10.2. 
     object-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④①">6.1.11. script-src</a>
-    <li><a href="#ref-for-concept-request④②">6.1.11.1. 
+    <li><a href="#ref-for-concept-request④②">6.1.11. script-src</a>
+    <li><a href="#ref-for-concept-request④③">6.1.11.1. 
     script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request④③">6.1.11.2. 
+    <li><a href="#ref-for-concept-request④④">6.1.11.2. 
     script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.12.1. 
+    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
     script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.2. 
+    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
     script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.14.1. 
+    <li><a href="#ref-for-concept-request④⑦">6.1.14. style-src</a>
+    <li><a href="#ref-for-concept-request④⑧">6.1.14.1. 
     style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.14.2. 
+    <li><a href="#ref-for-concept-request④⑨">6.1.14.2. 
     style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.1.15.1. 
+    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.1. 
     style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.2. 
+    <li><a href="#ref-for-concept-request⑤①">6.1.15.2. 
     style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.1.17.1. 
+    <li><a href="#ref-for-concept-request⑤②">6.1.17.1. 
     worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.1.17.2. 
+    <li><a href="#ref-for-concept-request⑤③">6.1.17.2. 
     worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.2.2.1. 
+    <li><a href="#ref-for-concept-request⑤④">6.2.2.1. 
     plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.2.3.1. 
+    <li><a href="#ref-for-concept-request⑤⑤">6.2.3.1. 
     sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.3.1.1. 
+    <li><a href="#ref-for-concept-request⑤⑥">6.3.1.1. 
     form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.3.2.1. 
+    <li><a href="#ref-for-concept-request⑤⑦">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.3.3.1. 
+    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.2. 
+    <li><a href="#ref-for-concept-request⑤⑨">6.3.3.2. 
     navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.6.1.1. 
+    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.1. 
     Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.2. 
+    <li><a href="#ref-for-concept-request⑥①">6.6.1.2. 
     Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request⑥①">6.6.2.1. 
+    <li><a href="#ref-for-concept-request⑥②">6.6.2.1. 
     Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑥②">6.6.2.2. 
+    <li><a href="#ref-for-concept-request⑥③">6.6.2.2. 
     Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑥③">6.6.2.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑥④">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑤">6.6.2.4. 
+    <li><a href="#ref-for-concept-request⑥④">6.6.2.3. 
+    Does request match source list? </a> <a href="#ref-for-concept-request⑥⑤">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑥">6.6.2.4. 
     Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⑥">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑦">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑧">6.7.2. 
+    <li><a href="#ref-for-concept-request⑥⑦">6.7.1. 
+    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑧">(2)</a>
+    <li><a href="#ref-for-concept-request⑥⑨">6.7.2. 
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
@@ -6617,8 +6617,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response①①">4.1.1. 
     Set response’s CSP list </a>
     <li><a href="#ref-for-concept-response①②">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-response①③">4.2. 
     Integration with HTML </a> <a href="#ref-for-concept-response①④">(2)</a>
     <li><a href="#ref-for-concept-response①⑤">4.2.1. 
@@ -6797,21 +6796,6 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-a-element①">6.3.3. navigate-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-active-document">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-active-document①">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-active-document②">(2)</a>
-    <li><a href="#ref-for-active-document③">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-active-document④">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-an-iframe-srcdoc-document">
    <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document</a><b>Referenced in:</b>
    <ul>
@@ -6865,25 +6849,19 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-browsing-context">2.3. Directives</a> <a href="#ref-for-browsing-context①">(2)</a>
-    <li><a href="#ref-for-browsing-context②">4.2. 
+    <li><a href="#ref-for-browsing-context">2.3. Directives</a>
+    <li><a href="#ref-for-browsing-context①">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-browsing-context③">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-browsing-context④">4.2.5. 
+    <li><a href="#ref-for-browsing-context②">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context⑤">4.2.6. 
+    <li><a href="#ref-for-browsing-context③">4.2.6. 
     Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context⑥">6.3.1.1. 
-    form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-browsing-context⑦">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-browsing-context⑧">(2)</a> <a href="#ref-for-browsing-context⑨">(3)</a>
-    <li><a href="#ref-for-browsing-context①⓪">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-browsing-context①①">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context①②">(2)</a> <a href="#ref-for-browsing-context①③">(3)</a>
+    <li><a href="#ref-for-browsing-context④">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-browsing-context⑤">(2)</a> <a href="#ref-for-browsing-context⑥">(3)</a>
+    <li><a href="#ref-for-browsing-context⑦">6.3.3.2. 
+    navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-case-sensitive">
@@ -6919,16 +6897,10 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-csp-list">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-concept-document-csp-list①">(2)</a> <a href="#ref-for-concept-document-csp-list②">(3)</a> <a href="#ref-for-concept-document-csp-list③">(4)</a> <a href="#ref-for-concept-document-csp-list④">(5)</a>
-    <li><a href="#ref-for-concept-document-csp-list⑤">4.2.3. 
-    Retrieve the CSP list of an object </a> <a href="#ref-for-concept-document-csp-list⑥">(2)</a>
-    <li><a href="#ref-for-concept-document-csp-list⑦">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-document-csp-list⑧">(2)</a>
-    <li><a href="#ref-for-concept-document-csp-list⑨">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-document-csp-list①⓪">6.2.2.2. 
+    Initialize a Document's CSP list </a> <a href="#ref-for-concept-document-csp-list①">(2)</a> <a href="#ref-for-concept-document-csp-list②">(3)</a> <a href="#ref-for-concept-document-csp-list③">(4)</a>
+    <li><a href="#ref-for-concept-document-csp-list④">4.2.3. 
+    Retrieve the CSP list of an object </a> <a href="#ref-for-concept-document-csp-list⑤">(2)</a>
+    <li><a href="#ref-for-concept-document-csp-list⑥">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
    </ul>
@@ -7007,10 +6979,17 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-settings-object-global②">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-concept-settings-object-global③">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
-    <li><a href="#ref-for-concept-settings-object-global④">4.2.4. 
+    Should response to request be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-concept-settings-object-global④">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-concept-settings-object-global⑤">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-concept-settings-object-global⑥">4.2.5. 
+    Should navigation request of type from source in target be blocked
+    by Content Security Policy? </a> <a href="#ref-for-concept-settings-object-global⑦">(2)</a> <a href="#ref-for-concept-settings-object-global⑧">(3)</a> <a href="#ref-for-concept-settings-object-global⑨">(4)</a>
+    <li><a href="#ref-for-concept-settings-object-global①⓪">4.2.6. 
+    Should navigation response to navigation request of type from source
+    in target be blocked by Content Security Policy? </a> <a href="#ref-for-concept-settings-object-global①①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-attr-base-href">
@@ -7078,8 +7057,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-nested-browsing-context②">6.1.5. frame-src</a>
     <li><a href="#ref-for-nested-browsing-context③">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
     <li><a href="#ref-for-nested-browsing-context⑤">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-nested-browsing-context⑥">6.7.1. 
+    frame-ancestors Navigation Response Check </a> <a href="#ref-for-nested-browsing-context⑥">(2)</a>
+    <li><a href="#ref-for-nested-browsing-context⑦">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
@@ -7088,6 +7067,8 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-browsing-context-nested-through">4.2. 
     Integration with HTML </a>
+    <li><a href="#ref-for-browsing-context-nested-through①">6.3.2.1. 
+    frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-attr-nonce">
@@ -7115,8 +7096,6 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">5.3. 
     Report a violation </a>
-    <li><a href="#ref-for-concept-settings-object-origin①">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
@@ -7124,13 +7103,6 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">4.2.2. 
     Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parent-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parent-browsing-context">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive">
@@ -7198,24 +7170,11 @@ rest of Google’s CSP Cabal.</p>
     Create a violation object for global, policy, and directive </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-relevant-global">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-relevant-global①">(2)</a>
-    <li><a href="#ref-for-concept-relevant-global②">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.3. 
     Report a violation </a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
-    <li><a href="#ref-for-relevant-settings-object③">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-run-a-worker">
@@ -7880,6 +7839,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
      <li><span class="dfn-paneled" id="term-for-concept-event-fire" style="color:initial">fire an event</span>
      <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
+     <li><span class="dfn-paneled" id="term-for-dom-document-origin" style="color:initial">origin</span>
      <li><span class="dfn-paneled" id="term-for-concept-shadow-including-root" style="color:initial">shadow-including root</span>
      <li><span class="dfn-paneled" id="term-for-dom-event-target" style="color:initial">target</span>
     </ul>
@@ -7946,7 +7906,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-worker" style="color:initial">Worker</span>
      <li><span class="dfn-paneled" id="term-for-workerglobalscope" style="color:initial">WorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-the-a-element" style="color:initial">a</span>
-     <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
      <li><span class="dfn-paneled" id="term-for-an-iframe-srcdoc-document" style="color:initial">an iframe srcdoc document</span>
      <li><span class="dfn-paneled" id="term-for-applet" style="color:initial">applet</span>
      <li><span class="dfn-paneled" id="term-for-ascii-serialisation-of-an-origin" style="color:initial">ascii serialization of an origin</span>
@@ -7979,7 +7938,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-the-object-element" style="color:initial">object</span>
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
-     <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
      <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
      <li><span class="dfn-paneled" id="term-for-concept-script-parse-error" style="color:initial">parse error</span>
      <li><span class="dfn-paneled" id="term-for-dom-a-ping" style="color:initial">ping</span>
@@ -7989,7 +7947,6 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-process-a-navigate-response" style="color:initial">process a navigate response</span>
      <li><span class="dfn-paneled" id="term-for-queue-a-task" style="color:initial">queue a task</span>
      <li><span class="dfn-paneled" id="term-for-dom-document-referrer" style="color:initial">referrer</span>
-     <li><span class="dfn-paneled" id="term-for-concept-relevant-global" style="color:initial">relevant global object</span>
      <li><span class="dfn-paneled" id="term-for-relevant-settings-object" style="color:initial">relevant settings object</span>
      <li><span class="dfn-paneled" id="term-for-run-a-worker" style="color:initial">run a worker</span>
      <li><span class="dfn-paneled" id="term-for-attr-iframe-sandbox" style="color:initial">sandbox</span>
@@ -8185,7 +8142,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 6 September 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 12 November 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -8270,7 +8227,6 @@ rest of Google’s CSP Cabal.</p>
    <div class="issue"> This hook is missing from W3C’s HTML. <a href="https://github.com/w3c/html/issues/547">&lt;https://github.com/w3c/html/issues/547></a><a href="#issue-5faf83e6"> ↵ </a></div>
    <div class="issue"> W3C’s HTML is not based on Fetch, and does not
   have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm into which to hook. <a href="https://github.com/w3c/html/issues/548">&lt;https://github.com/w3c/html/issues/548></a><a href="#issue-ed7a45a9"> ↵ </a></div>
-   <div class="issue"> <var>source</var>’s active document is incorrect here. <a href="https://github.com/w3c/webappsec-csp/issues/360">&lt;https://github.com/w3c/webappsec-csp/issues/360></a><a href="#issue-04a9cf28"> ↵ </a></div>
    <div class="issue"> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
   to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-d5a07bef"> ↵ </a></div>
@@ -8473,8 +8429,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-policy-disposition⑧">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-policy-disposition⑨">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a> <a href="#ref-for-policy-disposition①⓪">(2)</a>
+    Should response to request be blocked by Content Security Policy? </a> <a href="#ref-for-policy-disposition①⓪">(2)</a>
     <li><a href="#ref-for-policy-disposition①①">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-policy-disposition①②">4.2.5. 
@@ -8839,8 +8794,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check">4.1. 
     Integration with Fetch </a>
     <li><a href="#ref-for-directive-post-request-check①">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-directive-post-request-check②">6.1.1.2. 
     child-src Post-request check </a> <a href="#ref-for-directive-post-request-check③">(2)</a>
     <li><a href="#ref-for-directive-post-request-check④">6.1.2.2. 
@@ -8887,8 +8841,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-response-check">4.1. 
     Integration with Fetch </a>
     <li><a href="#ref-for-directive-response-check①">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-directive-response-check②">6.2.3.1. 
     sandbox Response Check </a>
     <li><a href="#ref-for-directive-response-check③">6.5. 
@@ -9478,23 +9431,30 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-global-object-csp-list②">4.1.3. 
     Should request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-global-object-csp-list③">4.1.4. 
-    Should response to request be blocked by Content
-    Security Policy? </a>
+    Should response to request be blocked by Content Security Policy? </a>
     <li><a href="#ref-for-global-object-csp-list④">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-global-object-csp-list⑤">4.2.2. 
-    Initialize a global object’s CSP list </a> <a href="#ref-for-global-object-csp-list⑥">(2)</a> <a href="#ref-for-global-object-csp-list⑦">(3)</a> <a href="#ref-for-global-object-csp-list⑧">(4)</a> <a href="#ref-for-global-object-csp-list⑨">(5)</a> <a href="#ref-for-global-object-csp-list①⓪">(6)</a>
-    <li><a href="#ref-for-global-object-csp-list①①">4.2.3. 
-    Retrieve the CSP list of an object </a> <a href="#ref-for-global-object-csp-list①②">(2)</a> <a href="#ref-for-global-object-csp-list①③">(3)</a> <a href="#ref-for-global-object-csp-list①④">(4)</a>
-    <li><a href="#ref-for-global-object-csp-list①⑤">4.2.4. 
+    <li><a href="#ref-for-global-object-csp-list⑤">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-global-object-csp-list⑥">4.2.2. 
+    Initialize a global object’s CSP list </a> <a href="#ref-for-global-object-csp-list⑦">(2)</a> <a href="#ref-for-global-object-csp-list⑧">(3)</a> <a href="#ref-for-global-object-csp-list⑨">(4)</a> <a href="#ref-for-global-object-csp-list①⓪">(5)</a> <a href="#ref-for-global-object-csp-list①①">(6)</a>
+    <li><a href="#ref-for-global-object-csp-list①②">4.2.3. 
+    Retrieve the CSP list of an object </a> <a href="#ref-for-global-object-csp-list①③">(2)</a> <a href="#ref-for-global-object-csp-list①④">(3)</a> <a href="#ref-for-global-object-csp-list①⑤">(4)</a>
+    <li><a href="#ref-for-global-object-csp-list①⑥">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-global-object-csp-list①⑥">4.3. Integration with ECMAScript</a>
-    <li><a href="#ref-for-global-object-csp-list①⑦">4.3.1. 
+    <li><a href="#ref-for-global-object-csp-list①⑦">4.2.5. 
+    Should navigation request of type from source in target be blocked
+    by Content Security Policy? </a> <a href="#ref-for-global-object-csp-list①⑧">(2)</a>
+    <li><a href="#ref-for-global-object-csp-list①⑨">4.2.6. 
+    Should navigation response to navigation request of type from source
+    in target be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-global-object-csp-list②⓪">4.3. Integration with ECMAScript</a>
+    <li><a href="#ref-for-global-object-csp-list②①">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-global-object-csp-list①⑧">6.2.1.1. 
+    <li><a href="#ref-for-global-object-csp-list②②">6.2.1.1. 
     Is base allowed for document? </a>
-    <li><a href="#ref-for-global-object-csp-list①⑨">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②⓪">(2)</a> <a href="#ref-for-global-object-csp-list②①">(3)</a> <a href="#ref-for-global-object-csp-list②②">(4)</a>
+    <li><a href="#ref-for-global-object-csp-list②③">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②④">(2)</a> <a href="#ref-for-global-object-csp-list②⑤">(3)</a> <a href="#ref-for-global-object-csp-list②⑥">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enforced">

--- a/index.src.html
+++ b/index.src.html
@@ -566,14 +566,14 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       and has no effect unless otherwise specified.
 
   6.  A <dfn for="directive" export>pre-navigation check</dfn>, which takes a
-      <a for="/">request</a>, a navigation type string ("`form-submission`" or "`other`"),
-      two <a>browsing contexts</a>, and a <a for="/">policy</a> as arguments, and
+      <a for="/">request</a>, a navigation type string ("`form-submission`"
+      or "`other`"), and a <a for="/">policy</a> as arguments, and
       is executed during [[#should-block-navigation-request]]. It returns
       "`Allowed`" unless otherwise specified.
 
   7.  A <dfn for="directive" export>navigation response check</dfn>, which takes a
       <a for="/">request</a>, a navigation type string ("`form-submission`" or "`other`"),
-      a <a>response</a>, two <a>browsing contexts</a>, a check type string ("`source`"
+      a <a>response</a>, a <a>browsing context</a>, a check type string ("`source`"
       or "`response`"), and a <a for="/">policy</a> as arguments, and is executed during
       [[#should-block-navigation-response]]. It returns "`Allowed`" unless otherwise specified.
 
@@ -1063,8 +1063,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   4.  Return |result|.
 
   <h4 id="should-block-response" algorithm>
-    Should |response| to |request| be blocked by Content
-    Security Policy?
+    Should |response| to |request| be blocked by Content Security Policy?
   </h4>
 
   Given a <a>response</a> (|response|) and a <a for="/">request</a>
@@ -1194,16 +1193,15 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h4>
 
   Given a {{Document}} (|document|), a <a>response</a> (|response|), and a
-  <a>browsing context</a> (|source|) the user agent performs the following
+  <a for="/">request</a> (|request|) the user agent performs the following
   steps in order to initialize |document|'s <a for="Document">CSP list</a>:
 
   1.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a> is a
       <a>local scheme</a>:
 
-      1.  For each |policy| in |source|'s <a>active document</a>'s
-          <a for="Document">CSP list</a>:
-
-          ISSUE(w3c/webappsec-csp#360): |source|'s active document is incorrect here.
+      1.  For each |policy| in |request|'s <a for="request">client</a>'s
+          <a for="environment settings object">global object</a>'s
+          <a for="global object">CSP list</a>:
 
           1.  Insert a copy of |policy| into |document|'s
               <a for="Document">CSP list</a>.
@@ -1346,18 +1344,20 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |source|'s <a>active document</a>'s
-        <a for="Document">CSP list</a>:
+    2.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
+        <a for="environment settings object">global object</a>'s
+        <a for="global object">CSP list</a>:
 
         1.  For each |directive| in |policy|:
 
             1.  If |directive|'s <a for="directive">pre-navigation check</a>
                 returns "`Allowed`" when executed upon |navigation request|,
-                |type|, |source|, |target|, and |policy| skip to the next |directive|.
+                |type|, and |policy| skip to the next |directive|.
 
             2.  Otherwise, let |violation| be the result of executing
-                [[#create-violation-for-global]] on |source|'s <a>relevant global
-                object</a>, |policy|, and |directive|'s <a for="directive">name</a>.
+                [[#create-violation-for-global]] on |navigation request|'s
+                <a for="request">client</a>'s <a for="environment settings object">global object</a>,
+                |policy|, and |directive|'s <a for="directive">name</a>.
 
             3.  Set |violation|'s <a for="violation">resource</a> to |navigation
                 request|'s <a for="request">URL</a>.
@@ -1370,22 +1370,24 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     3.  If |result| is "`Allowed`", and if |navigation request|'s
         <a for="request">current URL</a>'s <a for="url">scheme</a> is `javascript`:
 
-        1.  For each |policy| in |source|'s <a>active document</a>'s
-            <a for="Document">CSP List</a>:
+        1.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
+            <a for="environment settings object">global object</a>'s
+            <a for="global object">CSP list</a>:
 
             1.  For each |directive| in |policy|:
 
-                1.  If |directive|'s <a for="directive">inline check</a>
+                1.  Let |directive-name| be the result of executing
+                    [[#effective-directive-for-inline-check]] on |type|.
+
+                2.  If |directive|'s <a for="directive">inline check</a>
                     returns "`Allowed`" when executed upon `null`,
                     "`navigation`" and |navigation request|'s <a for="request">current URL</a>,
                     skip to the next |directive|.
 
-                2.  Let |directive-name| be the result of executing
-                    [[#effective-directive-for-inline-check]] on |type|.
-
                 3.  Otherwise, let |violation| be the result of executing
-                    [[#create-violation-for-global]] on |source|'s <a>relevant global
-                    object</a>, |policy|, and |directive-name|.
+                    [[#create-violation-for-global]] on |navigation request|'s
+                    <a for="request">client</a>'s <a for="environment settings object">global object</a>,
+                    |policy|, and |directive-name|.
 
                 4.  Set |violation|'s <a for="violation">resource</a> to |navigation
                     request|'s <a for="request">URL</a>.
@@ -1422,7 +1424,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
             1.  If |directive|'s <a for="directive">navigation response check</a>
                 returns "`Allowed`" when executed upon |navigation request|, |type|,
-                |navigation response|, |source|, |target|, "`response`", and |policy|
+                |navigation response|, |target|, "`response`", and |policy|
                 skip to the next |directive|.
 
             2.  Otherwise, let |violation| be the result of executing
@@ -1440,21 +1442,24 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
             5.  If |policy|'s <a for="policy">disposition</a> is "`enforce`", then
                 set |result| to "`Blocked`".
 
-    3.  For each |policy| in |source|'s <a>active document</a>'s <a for="Document">CSP List</a>:
+    3.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
+        <a for="environment settings object">global object</a>'s
+        <a for="global object">CSP list</a>:
 
-        Note: Some directives in the |source| context (like <a>navigate-to</a>)
+        Note: Some directives in the |navigation request|'s context (like <a>navigate-to</a>)
         need the |response| before acting on the navigation.
 
         1.  For each |directive| in |policy|:
 
             1.  If |directive|'s <a for="directive">navigation response check</a>
                 returns "`Allowed`" when executed upon |navigation request|, |type|,
-                |navigation response|, |source|, |target|, "`source`", and |policy|
+                |navigation response|, |target|, "`source`", and |policy|
                 skip to the next |directive|.
 
             2.  Otherwise, let |violation| be the result of executing
-                [[#create-violation-for-global]] on |source|'s <a>relevant global
-                object</a>, |policy|, and |directive|'s <a for="directive">name</a>.
+                [[#create-violation-for-global]] on |navigation request|'s
+                <a for="request">client</a>'s <a for="environment settings object">global object</a>,
+                |policy|, and |directive|'s <a for="directive">name</a>.
 
             3.  Set |violation|'s <a for="violation">resource</a> to |navigation
                 request|'s <a for="request">URL</a>.
@@ -3506,14 +3511,12 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h5>
 
   Given a <a for="/">request</a> (|request|), a string |navigation type| ("`form-submission`" or
-  "`other`"), two <a>browsing contexts</a> (|source| and |target|), and a
-  <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if a form
+  "`other`"), and a <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if a form
   submission violates the `form-action` directive's constraints, and "`Allowed`"
   otherwise. This constitutes the `form-action` directive's <a>pre-navigation check</a>:
 
   <ol class="algorithm">
-    1.  Assert: |source|, |target|, and |policy| are unused in this algorithm, as
-        `form-action` is concerned only with details of the outgoing request.
+    1.  Assert: |policy| is unused in this algorithm.
 
     2.  If |navigation type| is "`form-submission`":
 
@@ -3556,42 +3559,42 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   Given a <a for="/">request</a> (|request|), a string |navigation type|
   ("`form-submission`" or "`other`"), a
-  <a>response</a> (|navigation response|) two <a>browsing contexts</a> (|source|
-  and |target|), a string |check type| ("`source`" or "`response`"), and a
+  <a>response</a> (|navigation response|) a <a>browsing context</a> (|target|),
+  a string |check type| ("`source`" or "`response`"), and a
   <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if one or
   more of the ancestors of |target| violate the `frame-ancestors` directive
   delivered with the response, and "`Allowed`" otherwise. This constitutes the
   `frame-ancestors` directive's <a>navigation response check</a>:
 
   <ol class="algorithm">
-    1.  Assert: |request|, |navigation response|, |navigation type|, |source|, and
+    1.  Assert: |request|, |navigation response|, |navigation type|, and
         |policy| are unused in this algorithm, as `frame-ancestors` is concerned only
         with |navigation response|'s <a>frame-ancestors</a> <a>directive</a>.
 
     2.  If |check type| is "`source`", return "`Allowed`".
 
         Note: The 'frame-ancestors' <a>directive</a> is relevant only to the
-        |target| <a>browsing context</a> and it has no impact on the |source|
-        <a>browsing context</a>.
+        |target| <a>browsing context</a> and it has no impact on the |request|'s
+        context.
 
     2.  If |target| is not a <a>nested browsing context</a>, return "`Allowed`".
 
     3.  Let |current| be |target|.
 
-    4.  While |current| has a <a>parent browsing context</a> (|parent|):
+    4.  While |current| is a <a>nested browsing context</a>:
 
-        1.  Set |current| to |parent|.
+        1.  Let |document| be the {{Document}} that |current| is <a>nested through</a>.
 
         2.  Let |origin| be the result of executing the <a>URL parser</a> on the
             <a lt="ASCII serialization of an origin">ASCII serialization</a>
-            of |parent|'s <a>active document</a>'s <a>relevant settings
-            object</a>'s <a for="environment settings object">origin</a>.
+            of |document|'s {{Document/origin}}.
 
         3.  If [[#match-url-to-source-list]] returns `Does Not Match` when
-            executed upon |origin|, this directive's
-            <a for="directive">value</a>, |navigation response|'s
-            <a for="response">url</a>'s <a for="url">origin</a>, and `0`, return
-            "`Blocked`".
+            executed upon |origin|, this directive's <a for="directive">value</a>,
+            |navigation response|'s <a for="response">url</a>'s
+            <a for="url">origin</a>, and `0`, return "`Blocked`".
+
+        4.  Set |current| to |document|'s <a>browsing context</a>.
 
     5.  Return "`Allowed`".
   </ol>
@@ -3655,19 +3658,15 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h5>
 
   Given a <a for="/">request</a> (|request|), a string |navigation type| ("`form-submission`" or
-  "`other`"), two <a>browsing contexts</a> (|source| and |target|),
-  and a <a for="/">policy</a> (|policy|), this algorithm returns "`Blocked`"
+  "`other`"), and a <a for="/">policy</a> (|policy|), this algorithm returns "`Blocked`"
   if the navigation violates the `navigate-to` directive's constraints, and
   "`Allowed`" otherwise. This constitutes the `navigate-to`' directive's <a>pre-navigation check</a>:
 
   <ol class="algorithm">
-    1.  Assert: |source| and |target| are unused as 'navigate-to'
-        is concerned with the details of the request.
-
-    2.  If |navigation type| is "`form-submission`" and |policy| contains a
+    1.  If |navigation type| is "`form-submission`" and |policy| contains a
         <a>directive</a> named "`form-action`", return "`Allowed`".
 
-    3.  If this directive's <a for="directive">value</a> contains a <a>source
+    2.  If this directive's <a for="directive">value</a> contains a <a>source
         expression</a> that is an <a>ASCII case-insensitive</a> match for
         the "<a grammar>`'unsafe-allow-redirects'`</a>"
         <a grammar>keyword-source</a>, return "`Allowed`".
@@ -3676,11 +3675,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         wait for the <a>response</a> and take into account the <a>response</a>'s
         <a for="response">status</a> in [[#navigate-to-navigation-response]].
 
-    4.  If the result of executing [[#match-request-to-source-list]] on
+    3.  If the result of executing [[#match-request-to-source-list]] on
         |request| and this directive's <a for="directive">value</a> is
         "`Does Not Match`", return "`Blocked`".
 
-    5.  Return "`Allowed`".
+    4.  Return "`Allowed`".
   </ol>
 
   <h5 algorithm id="navigate-to-navigation-response">
@@ -3688,21 +3687,20 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h5>
 
   Given a <a for="/">request</a> (|request|), a string |navigation type|
-  ("`form-submission`" or "`other`"),  a <a>response</a> (|navigation response|)
-  two <a>browsing contexts</a> (|source| and |target|), a string |check type|
+  ("`form-submission`" or "`other`"), a <a>response</a> (|navigation response|)
+  a <a>browsing context</a> (|target|), a string |check type|
   ("`source`" or "`response`"), and a <a for="/">policy</a> (|policy|), this
   algorithm returns "`Blocked`" if the navigation violates the `navigate-to`
   directive's constraints, and "`Allowed`" otherwise. This constitutes the
   `navigate-to` directive's <a>navigation response check</a>:
 
   <ol class="algorithm">
-    1.  Assert: |source|, and |target| are unused.
+    1.  Assert: |target| is unused.
 
     2.  If |check type| is "`response`", return "`Allowed`".
 
         Note: The 'navigate-to' <a>directive</a> is relevant only to the
-        |source| <a>browsing context</a> and it has no impact on the |target|
-        <a>browsing context</a>.
+        |request|'s context and it has no impact on the |target| <a>browsing context</a>.
 
     3.  If |navigation type| is "`form-submission`" and |policy| contains a
         <a>directive</a> named "`form-action`", return "`Allowed`".


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/360
Also unblocks: https://github.com/w3c/webappsec-csp/issues/364

@bzbarsky: does this approach seem reasonable?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/365.html" title="Last updated on Nov 12, 2018, 2:22 PM GMT (8b9b3bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/365/48b736b...andypaicu:8b9b3bc.html" title="Last updated on Nov 12, 2018, 2:22 PM GMT (8b9b3bc)">Diff</a>