### PR TITLE
Added javascript: scheme specifically and fixed a small comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,11 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f9fa604b61e5fc96edf5cdebd2c04e0e69b33a7b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+<<<<<<< HEAD
   <meta content="2708de1d1287056257f29e827cc436205f91dc2a" name="document-revision">
+=======
+  <meta content="d0ccab1e883d4644b982b3b23fbedda2dbd7e258" name="document-revision">
+>>>>>>> Added javascript: scheme specifically and fixed a small comment
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2609,7 +2613,11 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md>
+<<<<<<< HEAD
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> and <var>request</var> is not <code>null</code>:</p>
+=======
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> or <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is <code>javascript</code>:</p>
+>>>>>>> Added javascript: scheme specifically and fixed a small comment
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
@@ -2618,12 +2626,17 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
+<<<<<<< HEAD
       <p class="note" role="note"><span>Note:</span> For <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">iframe srcdoc Documents</a>, <var>request</var> will be <code>null</code>, but <var>response</var> will contain a copy of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a> in its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, as specified in <a data-link-type="dfn" href="https://html.spec.whatwg.org/#process-the-iframe-attributes" id="ref-for-process-the-iframe-attributes">process the iframe attributes</a>.
   As such <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">iframe srcdoc Documents</a> inherit their <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
       <p class="note" role="note"><span>Note:</span> Since <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin①">self-origin</a> is also copied, any <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③"><code>'self'</code></a> checks will be using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s origin. This is
   done for the purpose of making <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④"><code>'self'</code></a> make sense in documents
   with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque①">opaque origins</a>. The <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤"><code>'self'</code></a> keyword is used
   in the <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> algorithm.</p>
+=======
+      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
+  therefore apply to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">iframe srcdoc Documents</a>.</p>
+>>>>>>> Added javascript: scheme specifically and fixed a small comment
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
@@ -2644,7 +2657,11 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
     <ol>
      <li data-md>
+<<<<<<< HEAD
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
+=======
+      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
+>>>>>>> Added javascript: scheme specifically and fixed a small comment
       <ol>
        <li data-md>
         <p>Let <var>owners</var> be an empty list.</p>
@@ -2763,7 +2780,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑦">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -2772,7 +2789,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         </ol>
       </ol>
      <li data-md>
-      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
+      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is <code>javascript</code>:</p>
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⓪">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑧">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a>:</p>
@@ -2790,7 +2807,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
             <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①①">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑨">global object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
            <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md>
@@ -2849,7 +2866,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①③">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①①">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -3139,7 +3156,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
              <dd data-md>
               <p>"<code>POST</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑥">url</a>
              <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url③">url</a></p>
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
@@ -4746,9 +4763,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   the following conditions is met:</p>
       <ol>
        <li data-md>
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
        <li data-md>
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> This logic means that in order to allow a resource from a non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme③">network scheme</a>,
   it has to be either explicitly specified (e.g. <code>default-src * data: custom-scheme-1: custom-scheme-2:</code>),
@@ -4757,7 +4774,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source②"><code>scheme-source</code></a> or <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source②"><code>host-source</code></a> grammar:</p>
       <ol>
        <li data-md>
-        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md>
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source③"><code>scheme-source</code></a> grammar,
   return "<code>Matches</code>".</p>
@@ -4768,7 +4785,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md>
         <p>If <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> is <code>null</code>, return "<code>Does Not Match</code>".</p>
        <li data-md>
-        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>,
+        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>,
   return "<code>Does Not Match</code>".</p>
         <p class="note" role="note"><span>Note:</span> As with <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part④"><code>scheme-part</code></a> above, we allow schemeless <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source④"><code>host-source</code></a> expressions to be upgraded from insecure
   schemes to secure schemes.</p>
@@ -4777,7 +4794,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md>
         <p>Let <var>port-part</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part①"><code>port-part</code></a> if present, and <code>null</code> otherwise.</p>
        <li data-md>
-        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md>
         <p>If <var>expression</var> contains a non-empty <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part①"><code>path-part</code></a>, and <var>redirect count</var> is 0, then:</p>
         <ol>
@@ -4798,13 +4815,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a></p>
        <li data-md>
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
-  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
+  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a>s, and
   one or more of the following conditions is met:</p>
         <ol>
          <li data-md>
-          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
+          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
          <li data-md>
-          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>http</code>" and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a> is "<code>http</code>" or "<code>ws</code>"</p>
+          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a> is "<code>http</code>" and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a> is "<code>http</code>" or "<code>ws</code>"</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Like the <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑤"><code>scheme-part</code></a> logic above, the "<code>'self'</code>"
@@ -4817,7 +4834,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
   to <code>script-src http: https:</code>, <code>script-src http://example.com</code> to <code>script-src http://example.com https://example.com</code>, and <code>connect-src ws:</code> to <code>connect-src ws: wss:</code>.</p>
@@ -4878,7 +4895,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
-  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
+  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①④">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
      <li data-md>
       <p>If <var>port A</var> is empty:</p>
@@ -5459,7 +5476,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
-  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
+  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>. The goal is to ensure that a page can’t
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5469,7 +5486,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </div>
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -7272,10 +7289,8 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-source-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-source-browsing-context">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-source-browsing-context①">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context②">(2)</a>
+    <li><a href="#ref-for-source-browsing-context">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
@@ -7742,17 +7757,17 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-url-scheme①">4.2.2. 
+    Initialize a Document's CSP list </a> <a href="#ref-for-concept-url-scheme①">(2)</a>
+    <li><a href="#ref-for-concept-url-scheme②">4.2.2. 
     Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-url-scheme②">4.2.5. 
+    <li><a href="#ref-for-concept-url-scheme③">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-url-scheme③">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a> <a href="#ref-for-concept-url-scheme⑨">(7)</a> <a href="#ref-for-concept-url-scheme①⓪">(8)</a> <a href="#ref-for-concept-url-scheme①①">(9)</a>
-    <li><a href="#ref-for-concept-url-scheme①②">6.6.2.7. 
+    <li><a href="#ref-for-concept-url-scheme④">6.6.2.6. 
+    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme⑤">(2)</a> <a href="#ref-for-concept-url-scheme⑥">(3)</a> <a href="#ref-for-concept-url-scheme⑦">(4)</a> <a href="#ref-for-concept-url-scheme⑧">(5)</a> <a href="#ref-for-concept-url-scheme⑨">(6)</a> <a href="#ref-for-concept-url-scheme①⓪">(7)</a> <a href="#ref-for-concept-url-scheme①①">(8)</a> <a href="#ref-for-concept-url-scheme①②">(9)</a>
+    <li><a href="#ref-for-concept-url-scheme①③">6.6.2.7. 
     scheme-part matching </a>
-    <li><a href="#ref-for-concept-url-scheme①③">6.6.2.9. 
+    <li><a href="#ref-for-concept-url-scheme①④">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>

--- a/index.html
+++ b/index.html
@@ -1214,11 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f9fa604b61e5fc96edf5cdebd2c04e0e69b33a7b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-<<<<<<< HEAD
-  <meta content="2708de1d1287056257f29e827cc436205f91dc2a" name="document-revision">
-=======
-  <meta content="d0ccab1e883d4644b982b3b23fbedda2dbd7e258" name="document-revision">
->>>>>>> Added javascript: scheme specifically and fixed a small comment
+  <meta content="d5b8ca523d1c680c5e8c5f8825d3d853a4d005d9" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2613,11 +2609,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
      <li data-md>
-<<<<<<< HEAD
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> and <var>request</var> is not <code>null</code>:</p>
-=======
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> or <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is <code>javascript</code>:</p>
->>>>>>> Added javascript: scheme specifically and fixed a small comment
+      <p>If <var>request</var> is not <code>null</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is either a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> or <code>javascript</code>:</p>
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
@@ -2626,17 +2618,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
-<<<<<<< HEAD
       <p class="note" role="note"><span>Note:</span> For <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">iframe srcdoc Documents</a>, <var>request</var> will be <code>null</code>, but <var>response</var> will contain a copy of the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document">embedding document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list②">CSP list</a> in its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑦">CSP list</a>, as specified in <a data-link-type="dfn" href="https://html.spec.whatwg.org/#process-the-iframe-attributes" id="ref-for-process-the-iframe-attributes">process the iframe attributes</a>.
   As such <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document①">iframe srcdoc Documents</a> inherit their <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document①">embedding document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a>.</p>
       <p class="note" role="note"><span>Note:</span> Since <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin①">self-origin</a> is also copied, any <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③"><code>'self'</code></a> checks will be using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>’s origin. This is
   done for the purpose of making <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self④"><code>'self'</code></a> make sense in documents
   with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque①">opaque origins</a>. The <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑤"><code>'self'</code></a> keyword is used
   in the <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> algorithm.</p>
-=======
-      <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> includes <code>about:</code>, and this algorithm will
-  therefore apply to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document">iframe srcdoc Documents</a>.</p>
->>>>>>> Added javascript: scheme specifically and fixed a small comment
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
      <li data-md>
@@ -2657,11 +2644,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
     <ol>
      <li data-md>
-<<<<<<< HEAD
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
-=======
-      <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
->>>>>>> Added javascript: scheme specifically and fixed a small comment
       <ol>
        <li data-md>
         <p>Let <var>owners</var> be an empty list.</p>
@@ -2780,7 +2763,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑦">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -2789,7 +2772,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         </ol>
       </ol>
      <li data-md>
-      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is <code>javascript</code>:</p>
+      <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
       <ol>
        <li data-md>
         <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⓪">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑧">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a>:</p>
@@ -2807,7 +2790,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
             <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①①">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑨">global object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
            <li data-md>
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
            <li data-md>
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
            <li data-md>
@@ -2866,7 +2849,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①③">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①①">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
          <li data-md>
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
-  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">URL</a>.</p>
+  request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
          <li data-md>
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
          <li data-md>
@@ -3156,7 +3139,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
              <dd data-md>
               <p>"<code>POST</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑥">url</a>
+             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
              <dd data-md>
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url③">url</a></p>
              <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
@@ -4763,9 +4746,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   the following conditions is met:</p>
       <ol>
        <li data-md>
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
        <li data-md>
-        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
+        <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> This logic means that in order to allow a resource from a non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme③">network scheme</a>,
   it has to be either explicitly specified (e.g. <code>default-src * data: custom-scheme-1: custom-scheme-2:</code>),
@@ -4774,7 +4757,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source②"><code>scheme-source</code></a> or <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source②"><code>host-source</code></a> grammar:</p>
       <ol>
        <li data-md>
-        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md>
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source③"><code>scheme-source</code></a> grammar,
   return "<code>Matches</code>".</p>
@@ -4785,7 +4768,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md>
         <p>If <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> is <code>null</code>, return "<code>Does Not Match</code>".</p>
        <li data-md>
-        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>,
+        <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>,
   return "<code>Does Not Match</code>".</p>
         <p class="note" role="note"><span>Note:</span> As with <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part④"><code>scheme-part</code></a> above, we allow schemeless <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source④"><code>host-source</code></a> expressions to be upgraded from insecure
   schemes to secure schemes.</p>
@@ -4794,7 +4777,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md>
         <p>Let <var>port-part</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part①"><code>port-part</code></a> if present, and <code>null</code> otherwise.</p>
        <li data-md>
-        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>, return "<code>Does Not Match</code>".</p>
+        <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>, return "<code>Does Not Match</code>".</p>
        <li data-md>
         <p>If <var>expression</var> contains a non-empty <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part①"><code>path-part</code></a>, and <var>redirect count</var> is 0, then:</p>
         <ol>
@@ -4815,13 +4798,13 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
         <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a></p>
        <li data-md>
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
-  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a>s, and
+  or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
   one or more of the following conditions is met:</p>
         <ol>
          <li data-md>
-          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
+          <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
          <li data-md>
-          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a> is "<code>http</code>" and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a> is "<code>http</code>" or "<code>ws</code>"</p>
+          <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>http</code>" and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a> is "<code>http</code>" or "<code>ws</code>"</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Like the <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑤"><code>scheme-part</code></a> logic above, the "<code>'self'</code>"
@@ -4834,7 +4817,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
   to <code>script-src http: https:</code>, <code>script-src http://example.com</code> to <code>script-src http://example.com https://example.com</code>, and <code>connect-src ws:</code> to <code>connect-src ws: wss:</code>.</p>
@@ -4895,7 +4878,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
     <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
-  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①④">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
+  strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
      <li data-md>
       <p>If <var>port A</var> is empty:</p>
@@ -5476,7 +5459,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h3 class="heading settled" data-level="7.8" id="security-inherit-csp"><span class="secno">7.8. </span><span class="content"> CSP Inheriting to avoid bypasses </span><a class="self-link" href="#security-inherit-csp"></a></h3>
     <p>As described in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> and <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a>,
   documents loaded from <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme⑤">local schemes</a> will inherit a copy of the
-  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context">source browsing context</a>. The goal is to ensure that a page can’t
+  policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
     <div class="example" id="example-d8547a52">
@@ -5486,7 +5469,7 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     </div>
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
-  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
+  snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
     <div class="example" id="example-46761516">
      <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
@@ -7289,8 +7272,10 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-source-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-source-browsing-context">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context①">(2)</a>
+    <li><a href="#ref-for-source-browsing-context">4.2.1. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-source-browsing-context①">7.8. 
+    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-style-element">
@@ -7757,17 +7742,17 @@ rest of Google’s CSP Cabal.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-concept-url-scheme①">(2)</a>
-    <li><a href="#ref-for-concept-url-scheme②">4.2.2. 
+    Initialize a Document's CSP list </a>
+    <li><a href="#ref-for-concept-url-scheme①">4.2.2. 
     Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-url-scheme③">4.2.5. 
+    <li><a href="#ref-for-concept-url-scheme②">4.2.5. 
     Should navigation request of type from source in target be blocked
     by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-url-scheme④">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme⑤">(2)</a> <a href="#ref-for-concept-url-scheme⑥">(3)</a> <a href="#ref-for-concept-url-scheme⑦">(4)</a> <a href="#ref-for-concept-url-scheme⑧">(5)</a> <a href="#ref-for-concept-url-scheme⑨">(6)</a> <a href="#ref-for-concept-url-scheme①⓪">(7)</a> <a href="#ref-for-concept-url-scheme①①">(8)</a> <a href="#ref-for-concept-url-scheme①②">(9)</a>
-    <li><a href="#ref-for-concept-url-scheme①③">6.6.2.7. 
+    <li><a href="#ref-for-concept-url-scheme③">6.6.2.6. 
+    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a> <a href="#ref-for-concept-url-scheme⑨">(7)</a> <a href="#ref-for-concept-url-scheme①⓪">(8)</a> <a href="#ref-for-concept-url-scheme①①">(9)</a>
+    <li><a href="#ref-for-concept-url-scheme①②">6.6.2.7. 
     scheme-part matching </a>
-    <li><a href="#ref-for-concept-url-scheme①④">6.6.2.9. 
+    <li><a href="#ref-for-concept-url-scheme①③">6.6.2.9. 
     port-part matching </a>
    </ul>
   </aside>

--- a/index.src.html
+++ b/index.src.html
@@ -1200,8 +1200,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <a for="/">request</a> or `null` (|request|) the user agent performs the following
   steps in order to initialize |document|'s <a for="Document">CSP list</a>:
 
-  1.  If |response|'s <a for="response">url</a>'s <a for="url">scheme</a> is a
-      <a>local scheme</a> and |request| is not `null`:
+  1.  If |request| is not `null` and |response|'s <a for="response">url</a>'s
+      <a for="url">scheme</a> is either a <a>local scheme</a> or `javascript`:
 
       1.  For each |policy| in |request|'s <a for="request">client</a>'s
           <a for="environment settings object">global object</a>'s


### PR DESCRIPTION
The change seems very small and uncontroversial to me but since there's a bunch of discussion on the issue I will let people have time to review it if they wish.

Fixes https://github.com/w3c/webappsec-csp/issues/368


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/370.html" title="Last updated on Dec 1, 2018, 12:54 PM GMT (8b3fcda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/370/b294bec...andypaicu:8b3fcda.html" title="Last updated on Dec 1, 2018, 12:54 PM GMT (8b3fcda)">Diff</a>