### PR TITLE
image-src => img-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -5293,11 +5293,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
          <li data-md>
           <p>Return <code>&lt;&lt; "font-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>image-src</code>"
+       <dt data-md>"<code>img-src</code>"
        <dd data-md>
         <ol>
          <li data-md>
-          <p>Return <code>&lt;&lt; "image-src", "default-src" >></code>.</p>
+          <p>Return <code>&lt;&lt; "img-src", "default-src" >></code>.</p>
         </ol>
       </dl>
      <li data-md>

--- a/index.src.html
+++ b/index.src.html
@@ -4574,9 +4574,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       ::
         1.  Return `<< "font-src", "default-src" >>`.
 
-      : "`image-src`"
+      : "`img-src`"
       ::
-        1.  Return `<< "image-src", "default-src" >>`.
+        1.  Return `<< "img-src", "default-src" >>`.
 
   2.  Return `<< >>`.
 


### PR DESCRIPTION
"[6.7.3. Get fetch directive fallback list](https://www.w3.org/TR/CSP/#directive-fallback-list)" has the incorrect directive name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gapple/webappsec-csp/pull/371.html" title="Last updated on Nov 26, 2018, 6:30 AM GMT (08f3ae5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/371/d0ccab1...gapple:08f3ae5.html" title="Last updated on Nov 26, 2018, 6:30 AM GMT (08f3ae5)">Diff</a>