### PR TITLE
Allow plugin-types to be empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f9fa604b61e5fc96edf5cdebd2c04e0e69b33a7b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="d5b8ca523d1c680c5e8c5f8825d3d853a4d005d9" name="document-revision">
+  <meta content="0ab98b910f2953161ad4208042694705b0faddde" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-01">1 December 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-03">3 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4238,7 +4238,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = "" / <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f9fa604b61e5fc96edf5cdebd2c04e0e69b33a7b" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="0ab98b910f2953161ad4208042694705b0faddde" name="document-revision">
+  <meta content="c9b3a0160993beef5604d7ee07c4ae6d33f57266" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-03">3 December 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-04">4 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4252,6 +4252,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list"
      <li data-md>
       <p>The fetched resource does not match the declared type.</p>
     </ol>
+    <p class="note" role="note"><span>Note:</span> The <code>plugin-types</code> grammar allows for an empty directive value in which
+  case all instantions of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element④">embed</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑥">object</a></code> will fail.</p>
     <div class="example" id="example-5240cbd4">
      <a class="self-link" href="#example-5240cbd4"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types">plugin-types</a> application/pdf
@@ -4409,7 +4411,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     </ol>
     <h4 class="heading settled" data-level="6.3.2" id="directive-frame-ancestors"><span class="secno">6.3.2. </span><span class="content"><code>frame-ancestors</code></span><a class="self-link" href="#directive-frame-ancestors"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="frame-ancestors">frame-ancestors</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑦">URL</a></code>s which can
-  embed the resource using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame②">frame</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑥">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element④">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet④"><code>applet</code></a> element. Resources can use this directive to avoid many UI
+  embed the resource using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame②">frame</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑦">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element⑤">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet④"><code>applet</code></a> element. Resources can use this directive to avoid many UI
   Redressing <a data-link-type="biblio" href="#biblio-uisecurity">[UISECURITY]</a> attacks, by avoiding the risk of being embedded into
   potentially hostile contexts.</p>
     <p>The directive’s syntax is described by the following ABNF grammar:</p>
@@ -6942,8 +6944,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-embed-element">4.2. 
     Integration with HTML </a>
     <li><a href="#ref-for-the-embed-element①">6.1.10. object-src</a> <a href="#ref-for-the-embed-element②">(2)</a>
-    <li><a href="#ref-for-the-embed-element③">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-the-embed-element④">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-the-embed-element③">6.2.2. plugin-types</a> <a href="#ref-for-the-embed-element④">(2)</a>
+    <li><a href="#ref-for-the-embed-element⑤">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-environment-settings-object">
@@ -7090,8 +7092,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-object-element">4.2. 
     Integration with HTML </a>
     <li><a href="#ref-for-the-object-element①">6.1.10. object-src</a> <a href="#ref-for-the-object-element②">(2)</a> <a href="#ref-for-the-object-element③">(3)</a> <a href="#ref-for-the-object-element④">(4)</a>
-    <li><a href="#ref-for-the-object-element⑤">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-the-object-element⑥">6.3.2. frame-ancestors</a>
+    <li><a href="#ref-for-the-object-element⑤">6.2.2. plugin-types</a> <a href="#ref-for-the-object-element⑥">(2)</a>
+    <li><a href="#ref-for-the-object-element⑦">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">

--- a/index.src.html
+++ b/index.src.html
@@ -3336,6 +3336,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   3.  The fetched resource does not match the declared type.
 
+  Note: The `plugin-types` grammar allows for an empty directive value in which
+  case all instantions of <{embed}> and <{object}> will fail.
+
   <div class="example">
     Given a page with the following Content Security Policy:
 

--- a/index.src.html
+++ b/index.src.html
@@ -3320,7 +3320,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     directive-name  = "plugin-types"
     directive-value = <a>media-type-list</a>
 
-    <dfn>media-type-list</dfn> = <a>media-type</a> *( <a>required-ascii-whitespace</a> <a>media-type</a> )
+    <dfn>media-type-list</dfn> = "" / <a>media-type</a> *( <a>required-ascii-whitespace</a> <a>media-type</a> )
     <dfn>media-type</dfn> = <a>type</a> "/" <a>subtype</a>
     ; <a>type</a> and <a>subtype</a> are defined in RFC 2045
   </pre>


### PR DESCRIPTION
This effectively is similar to the fetch directives' `'none'` keyword.

Fixes https://github.com/w3c/webappsec-csp/issues/366


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andypaicu/webappsec-csp/pull/374.html" title="Last updated on Dec 4, 2018, 9:19 AM GMT (9d484aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/374/0ab98b9...andypaicu:9d484aa.html" title="Last updated on Dec 4, 2018, 9:19 AM GMT (9d484aa)">Diff</a>