### PR TITLE
Move prefetch-src after object-src in the fetch directives.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version f9fa604b61e5fc96edf5cdebd2c04e0e69b33a7b" name="generator">
+  <meta content="Bikeshed version 6dcb46ba8cae3704b42c05bcd8578c92d239786a" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="c9b3a0160993beef5604d7ee07c4ae6d33f57266" name="document-revision">
+  <meta content="0ca85b6d105c77a885427ddb4ee750af3a455955" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1505,7 +1505,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-04">4 December 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-27">27 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1700,16 +1700,16 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
           <li><a href="#media-src-post-request"><span class="secno">6.1.8.2</span> <span class="content"> <code>media-src</code> Post-request check </span></a>
          </ol>
         <li>
-         <a href="#directive-prefetch-src"><span class="secno">6.1.9</span> <span class="content"><code>prefetch-src</code></span></a>
+         <a href="#directive-object-src"><span class="secno">6.1.9</span> <span class="content"><code>object-src</code></span></a>
          <ol class="toc">
-          <li><a href="#prefetch-src-pre-request"><span class="secno">6.1.9.1</span> <span class="content"> <code>prefetch-src</code> Pre-request check </span></a>
-          <li><a href="#prefetch-src-post-request"><span class="secno">6.1.9.2</span> <span class="content"> <code>prefetch-src</code> Post-request check </span></a>
+          <li><a href="#object-src-pre-request"><span class="secno">6.1.9.1</span> <span class="content"> <code>object-src</code> Pre-request check </span></a>
+          <li><a href="#object-src-post-request"><span class="secno">6.1.9.2</span> <span class="content"> <code>object-src</code> Post-request check </span></a>
          </ol>
         <li>
-         <a href="#directive-object-src"><span class="secno">6.1.10</span> <span class="content"><code>object-src</code></span></a>
+         <a href="#directive-prefetch-src"><span class="secno">6.1.10</span> <span class="content"><code>prefetch-src</code></span></a>
          <ol class="toc">
-          <li><a href="#object-src-pre-request"><span class="secno">6.1.10.1</span> <span class="content"> <code>object-src</code> Pre-request check </span></a>
-          <li><a href="#object-src-post-request"><span class="secno">6.1.10.2</span> <span class="content"> <code>object-src</code> Post-request check </span></a>
+          <li><a href="#prefetch-src-pre-request"><span class="secno">6.1.10.1</span> <span class="content"> <code>prefetch-src</code> Pre-request check </span></a>
+          <li><a href="#prefetch-src-post-request"><span class="secno">6.1.10.2</span> <span class="content"> <code>prefetch-src</code> Post-request check </span></a>
          </ol>
         <li>
          <a href="#directive-script-src"><span class="secno">6.1.11</span> <span class="content"><code>script-src</code></span></a>
@@ -3694,64 +3694,19 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h4 class="heading settled" data-level="6.1.9" id="directive-prefetch-src"><span class="secno">6.1.9. </span><span class="content"><code>prefetch-src</code></span><a class="self-link" href="#directive-prefetch-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
-  prefetched or prerendered. The syntax for the directive’s name and value is described by the
-  following ABNF:</p>
-<pre>directive-name  = "prefetch-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑧">serialized-source-list</a>
-</pre>
-    <div class="example" id="example-f7e7e15d">
-     <a class="self-link" href="#example-f7e7e15d"></a> Given a page with the following Content Security Policy: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src②">prefetch-src</a> https://example.com/
-</pre>
-     <p>Fetches for the following code will return network errors, as the URLs provided do not match <code>prefetch-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prefetch"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prerender"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
-</pre>
-    </div>
-    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.9.1" id="prefetch-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md>
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>,
-  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a>, and <var>policy</var>,
-  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.9.2" id="prefetch-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
-    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
-    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
-    <ol>
-     <li data-md>
-      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a>, and <var>policy</var>,
-  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
-      <p>Return "<code>Allowed</code>".</p>
-    </ol>
-    <h4 class="heading settled" data-level="6.1.10" id="directive-object-src"><span class="secno">6.1.10. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
+    <h4 class="heading settled" data-level="6.1.9" id="directive-object-src"><span class="secno">6.1.9. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="object-src">object-src</dfn> directive restricts the URLs from which plugin
   content may be loaded. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "object-src"
-directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑨">serialized-source-list</a>
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑧">serialized-source-list</a>
 </pre>
     <div class="example" id="example-e9e8c49e">
      <a class="self-link" href="#example-e9e8c49e"></a> Given a page with the following Content Security Policy: 
-<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#object-src" id="ref-for-object-src③">object-src</a> https://example.com/
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#object-src" id="ref-for-object-src③">object-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
-    provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
+    provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
 <pre class="highlight"><c- p>&lt;</c-><c- f>embed</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>embed</c-><c- p>></c->
 <c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
 <c- p>&lt;</c-><c- f>applet</c-> <c- e>archive</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>applet</c-><c- p>></c->
@@ -3767,37 +3722,82 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   another directive, such as an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element③">object</a></code> element with a <code>text/html</code> MIME
   type.</p>
     <p class="note" role="note"><span>Note:</span> When a plugin resource is navigated to directly (that is, as a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document">plugin document</a> in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a> or a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context④">nested browsing context</a>, and not as an embedded
-  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> delivered along
+  subresource via <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element②">embed</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element④">object</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet②"><code>applet</code></a>), any <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑧">policy</a> delivered along
   with that resource will be applied to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document" id="ref-for-plugin-document①">plugin document</a>. This means, for instance, that
   developers can prevent the execution of arbitrary resources as plugin content by delivering the
   policy <code>object-src 'none'</code> along with a response. Given plugins' power (and the
   sometimes-interesting security model presented by Flash and others), this could mitigate the risk
   of attack vectors like <a href="https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/">Rosetta Flash</a>.</p>
-    <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.10.1" id="object-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="object-src Pre-request check" data-level="6.1.9.1" id="object-src-pre-request"><span class="secno">6.1.9.1. </span><span class="content"> <code>object-src</code> Pre-request check </span><a class="self-link" href="#object-src-pre-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md>
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md>
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
+    <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
+    <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
+     <li data-md>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+     <li data-md>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a>,
+  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+     <li data-md>
+      <p>Return "<code>Allowed</code>".</p>
+    </ol>
+    <h4 class="heading settled" data-level="6.1.10" id="directive-prefetch-src"><span class="secno">6.1.10. </span><span class="content"><code>prefetch-src</code></span><a class="self-link" href="#directive-prefetch-src"></a></h4>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
+  prefetched or prerendered. The syntax for the directive’s name and value is described by the
+  following ABNF:</p>
+<pre>directive-name  = "prefetch-src"
+directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑨">serialized-source-list</a>
+</pre>
+    <div class="example" id="example-f7e7e15d">
+     <a class="self-link" href="#example-f7e7e15d"></a> Given a page with the following Content Security Policy: 
+<pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src②">prefetch-src</a> https://example.com/
+</pre>
+     <p>Fetches for the following code will return network errors, as the URLs provided do not match <code>prefetch-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
+<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prefetch"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
+<c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prerender"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
+</pre>
+    </div>
+    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.10.1" id="prefetch-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a>, and <var>policy</var>,
+      <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>,
+  this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
-    <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.10.2" id="object-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.10.2" id="prefetch-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
      <li data-md>
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
      <li data-md>
-      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
+      <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
      <li data-md>
-      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a>,
-  and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
+      <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a>, and <var>policy</var>,
+  is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
      <li data-md>
       <p>Return "<code>Allowed</code>".</p>
     </ol>
@@ -5697,7 +5697,7 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
       <p>This document (see <a href="#directive-media-src">§6.1.8 media-src</a>)</p>
      <dt data-md><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
      <dd data-md>
-      <p>This document (see <a href="#directive-object-src">§6.1.10 object-src</a>)</p>
+      <p>This document (see <a href="#directive-object-src">§6.1.9 object-src</a>)</p>
      <dt data-md><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
      <dd data-md>
       <p>This document (see <a href="#directive-plugin-types">§6.2.2 plugin-types</a>)</p>
@@ -5914,7 +5914,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#directive-navigation-response-check">navigation response check</a><span>, in §2.3</span>
    <li><a href="#grammardef-nonce-source">nonce-source</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-none">'none'</a><span>, in §2.3.1</span>
-   <li><a href="#object-src">object-src</a><span>, in §6.1.10</span>
+   <li><a href="#object-src">object-src</a><span>, in §6.1.9</span>
    <li><a href="#grammardef-optional-ascii-whitespace">optional-ascii-whitespace</a><span>, in §2.1</span>
    <li>
     originalPolicy
@@ -5937,7 +5937,7 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-port-part">port-part</a><span>, in §2.3.1</span>
    <li><a href="#port-part-matches">port-part matches</a><span>, in §6.6.2.9</span>
    <li><a href="#directive-post-request-check">post-request check</a><span>, in §2.3</span>
-   <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.9</span>
+   <li><a href="#prefetch-src">prefetch-src</a><span>, in §6.1.10</span>
    <li><a href="#directive-pre-navigation-check">pre-navigation check</a><span>, in §2.3</span>
    <li><a href="#directive-pre-request-check">pre-request check</a><span>, in §2.3</span>
    <li>
@@ -6555,13 +6555,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-request③⑦">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-concept-request③⑧">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑨">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④⓪">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request④①">6.1.10.2. 
+    <li><a href="#ref-for-concept-request③⑨">6.1.9.2. 
     object-src Post-request check </a>
+    <li><a href="#ref-for-concept-request④⓪">6.1.10.1. 
+    prefetch-src Pre-request check </a>
+    <li><a href="#ref-for-concept-request④①">6.1.10.2. 
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-concept-request④②">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-request④③">6.1.11.1. 
     script-src Pre-request check </a>
@@ -6650,9 +6650,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-concept-response②⑤">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-concept-response②⑥">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑦">6.1.10.2. 
     object-src Post-request check </a>
+    <li><a href="#ref-for-concept-response②⑦">6.1.10.2. 
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-concept-response②⑧">6.1.11. script-src</a>
     <li><a href="#ref-for-concept-response②⑨">6.1.11.2. 
     script-src Post-request check </a>
@@ -6818,7 +6818,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-applet">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-applet①">6.1.10. object-src</a> <a href="#ref-for-applet②">(2)</a>
+    <li><a href="#ref-for-applet①">6.1.9. object-src</a> <a href="#ref-for-applet②">(2)</a>
     <li><a href="#ref-for-applet③">6.2.2.2. 
     Should plugin element be blocked a priori by Content
     Security Policy?: </a>
@@ -6921,7 +6921,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-attr-object-data">
    <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-attr-object-data">6.1.10. object-src</a>
+    <li><a href="#ref-for-attr-object-data">6.1.9. object-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-document-2">
@@ -6943,7 +6943,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-embed-element">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-the-embed-element①">6.1.10. object-src</a> <a href="#ref-for-the-embed-element②">(2)</a>
+    <li><a href="#ref-for-the-embed-element①">6.1.9. object-src</a> <a href="#ref-for-the-embed-element②">(2)</a>
     <li><a href="#ref-for-the-embed-element③">6.2.2. plugin-types</a> <a href="#ref-for-the-embed-element④">(2)</a>
     <li><a href="#ref-for-the-embed-element⑤">6.3.2. frame-ancestors</a>
    </ul>
@@ -7060,7 +7060,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">6.1.1. child-src</a> <a href="#ref-for-nested-browsing-context①">(2)</a>
     <li><a href="#ref-for-nested-browsing-context②">6.1.5. frame-src</a>
-    <li><a href="#ref-for-nested-browsing-context③">6.1.10. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
+    <li><a href="#ref-for-nested-browsing-context③">6.1.9. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
     <li><a href="#ref-for-nested-browsing-context⑤">6.3.2.1. 
     frame-ancestors Navigation Response Check </a> <a href="#ref-for-nested-browsing-context⑥">(2)</a>
     <li><a href="#ref-for-nested-browsing-context⑦">6.7.1. 
@@ -7091,7 +7091,7 @@ rest of Google’s CSP Cabal.</p>
    <ul>
     <li><a href="#ref-for-the-object-element">4.2. 
     Integration with HTML </a>
-    <li><a href="#ref-for-the-object-element①">6.1.10. object-src</a> <a href="#ref-for-the-object-element②">(2)</a> <a href="#ref-for-the-object-element③">(3)</a> <a href="#ref-for-the-object-element④">(4)</a>
+    <li><a href="#ref-for-the-object-element①">6.1.9. object-src</a> <a href="#ref-for-the-object-element②">(2)</a> <a href="#ref-for-the-object-element③">(3)</a> <a href="#ref-for-the-object-element④">(4)</a>
     <li><a href="#ref-for-the-object-element⑤">6.2.2. plugin-types</a> <a href="#ref-for-the-object-element⑥">(2)</a>
     <li><a href="#ref-for-the-object-element⑦">6.3.2. frame-ancestors</a>
    </ul>
@@ -7144,7 +7144,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-plugin-document">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-plugin-document">6.1.10. object-src</a> <a href="#ref-for-plugin-document①">(2)</a>
+    <li><a href="#ref-for-plugin-document">6.1.9. object-src</a> <a href="#ref-for-plugin-document①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-prepare-a-script">
@@ -7292,7 +7292,7 @@ rest of Google’s CSP Cabal.</p>
   <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-top-level-browsing-context">6.1.10. object-src</a>
+    <li><a href="#ref-for-top-level-browsing-context">6.1.9. object-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-attr-embed-type">
@@ -8163,7 +8163,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 13 November 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 6 September 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -8348,15 +8348,15 @@ rest of Google’s CSP Cabal.</p>
     media-src Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object④⑦">6.1.8.2. 
     media-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.10. object-src</a>
-    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.10.1. 
+    <li><a href="#ref-for-content-security-policy-object④⑧">6.1.9. object-src</a>
+    <li><a href="#ref-for-content-security-policy-object④⑨">6.1.9.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.10.2. 
+    <li><a href="#ref-for-content-security-policy-object⑤⓪">6.1.9.2. 
     object-src Post-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤①">6.1.10.1. 
+    prefetch-src Pre-request check </a>
+    <li><a href="#ref-for-content-security-policy-object⑤②">6.1.10.2. 
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-content-security-policy-object⑤③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-content-security-policy-object⑤④">6.1.11.2. 
@@ -8704,13 +8704,13 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-value②⑤">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-directive-value②⑥">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑦">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-value②⑧">6.1.10.1. 
     object-src Pre-request check </a>
-    <li><a href="#ref-for-directive-value②⑨">6.1.10.2. 
+    <li><a href="#ref-for-directive-value②⑦">6.1.9.2. 
     object-src Post-request check </a>
+    <li><a href="#ref-for-directive-value②⑧">6.1.10.1. 
+    prefetch-src Pre-request check </a>
+    <li><a href="#ref-for-directive-value②⑨">6.1.10.2. 
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-directive-value③⓪">6.1.11.3. 
     script-src Inline Check </a>
     <li><a href="#ref-for-directive-value③①">6.1.12. script-src-elem</a>
@@ -8807,9 +8807,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-pre-request-check①⓪">6.1.8.1. 
     media-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①①">6.1.9.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-directive-pre-request-check①②">6.1.10.1. 
     object-src Pre-request check </a>
+    <li><a href="#ref-for-directive-pre-request-check①②">6.1.10.1. 
+    prefetch-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①③">6.1.11.1. 
     script-src Pre-request check </a>
     <li><a href="#ref-for-directive-pre-request-check①④">6.1.12.1. 
@@ -8852,9 +8852,9 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-directive-post-request-check①①">6.1.8.2. 
     media-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①②">6.1.9.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-directive-post-request-check①③">6.1.10.2. 
     object-src Post-request check </a>
+    <li><a href="#ref-for-directive-post-request-check①③">6.1.10.2. 
+    prefetch-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①④">6.1.11.2. 
     script-src Post-request check </a>
     <li><a href="#ref-for-directive-post-request-check①⑤">6.1.12.2. 
@@ -8960,8 +8960,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-source-lists⑤">6.1.6. img-src</a>
     <li><a href="#ref-for-source-lists⑥">6.1.7. manifest-src</a>
     <li><a href="#ref-for-source-lists⑦">6.1.8. media-src</a>
-    <li><a href="#ref-for-source-lists⑧">6.1.9. prefetch-src</a>
-    <li><a href="#ref-for-source-lists⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-source-lists⑧">6.1.9. object-src</a>
+    <li><a href="#ref-for-source-lists⑨">6.1.10. prefetch-src</a>
     <li><a href="#ref-for-source-lists①⓪">6.1.17. worker-src</a>
     <li><a href="#ref-for-source-lists①①">6.3.2. frame-ancestors</a>
     <li><a href="#ref-for-source-lists①②">6.6.2.2. 
@@ -9008,8 +9008,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list⑤">6.1.6. img-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑥">6.1.7. manifest-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list⑦">6.1.8. media-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. prefetch-src</a>
-    <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. object-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list⑧">6.1.9. object-src</a>
+    <li><a href="#ref-for-grammardef-serialized-source-list⑨">6.1.10. prefetch-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①⓪">6.1.11. script-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①①">6.1.12. script-src-elem</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①②">6.1.13. script-src-attr</a>
@@ -9438,8 +9438,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy①①">6.1.6. img-src</a>
     <li><a href="#ref-for-header-content-security-policy①②">6.1.7. manifest-src</a>
     <li><a href="#ref-for-header-content-security-policy①③">6.1.8. media-src</a>
-    <li><a href="#ref-for-header-content-security-policy①④">6.1.9. prefetch-src</a>
-    <li><a href="#ref-for-header-content-security-policy①⑤">6.1.10. object-src</a>
+    <li><a href="#ref-for-header-content-security-policy①④">6.1.9. object-src</a>
+    <li><a href="#ref-for-header-content-security-policy①⑤">6.1.10. prefetch-src</a>
     <li><a href="#ref-for-header-content-security-policy①⑥">6.1.17. worker-src</a>
     <li><a href="#ref-for-header-content-security-policy①⑦">6.2.2. plugin-types</a> <a href="#ref-for-header-content-security-policy①⑧">(2)</a>
     <li><a href="#ref-for-header-content-security-policy①⑨">6.3.3. navigate-to</a> <a href="#ref-for-header-content-security-policy②⓪">(2)</a>
@@ -9767,22 +9767,22 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="prefetch-src">
-   <b><a href="#prefetch-src">#prefetch-src</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-prefetch-src">6.1.3. default-src</a> <a href="#ref-for-prefetch-src①">(2)</a>
-    <li><a href="#ref-for-prefetch-src②">6.1.9. prefetch-src</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="object-src">
    <b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">6. 
     Content Security Policy Directives </a>
     <li><a href="#ref-for-object-src①">6.1.3. default-src</a> <a href="#ref-for-object-src②">(2)</a>
-    <li><a href="#ref-for-object-src③">6.1.10. object-src</a>
+    <li><a href="#ref-for-object-src③">6.1.9. object-src</a>
     <li><a href="#ref-for-object-src④">10.1. 
     Directive Registry </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="prefetch-src">
+   <b><a href="#prefetch-src">#prefetch-src</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-prefetch-src">6.1.3. default-src</a> <a href="#ref-for-prefetch-src①">(2)</a>
+    <li><a href="#ref-for-prefetch-src②">6.1.10. prefetch-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="script-src">

--- a/index.src.html
+++ b/index.src.html
@@ -2557,76 +2557,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   4.  Return "`Allowed`".
 
-  <h4 id="directive-prefetch-src">`prefetch-src`</h4>
-
-  The <dfn export>prefetch-src</dfn> directive restricts the URLs from which resources may be
-  prefetched or prerendered. The syntax for the directive's name and value is described by the
-  following ABNF:
-
-  <pre>
-    directive-name  = "prefetch-src"
-    directive-value = <a grammar>serialized-source-list</a>
-  </pre>
-
-  <div class="example">
-    Given a page with the following Content Security Policy:
-
-    <pre>
-      <a http-header>Content-Security-Policy</a>: <a>prefetch-src</a> https://example.com/
-    </pre>
-
-    Fetches for the following code will return network errors, as the URLs provided do not match
-    `prefetch-src`'s <a>source list</a>:
-
-    <pre highlight="html">
-      &lt;link rel="prefetch" src="https://example.org/"&gt;&lt;/link&gt;
-      &lt;link rel="prerender" src="https://example.org/"&gt;&lt;/link&gt;
-    </pre>
-  </div>
-
-  <h5 algorithm id="prefetch-src-pre-request">
-    `prefetch-src` Pre-request check
-  </h5>
-
-  This directive's <a for="directive">pre-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-request-to-source-list]] on |request|,
-      this directive's [=directive/value=], and |policy|,
-      is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
-
-  <h5 algorithm id="prefetch-src-post-request">
-    `prefetch-src` Post-request check
-  </h5>
-
-  This directive's <a for="directive">post-request check</a> is as follows:
-
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
-
-  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
-      on |request|.
-
-  2.  If the result of executing [[#should-directive-execute]] on |name|,
-      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
-
-  3.  If the result of executing [[#match-response-to-source-list]] on |response|,
-      |request|, this directive's [=directive/value=], and |policy|,
-      is "`Does Not Match`", return "`Blocked`".
-
-  4.  Return "`Allowed`".
-
-
-  <h4 id="directive-object-src">`object-src`</h4>
+<h4 id="directive-object-src">`object-src`</h4>
 
   The <dfn export>object-src</dfn> directive restricts the URLs from which plugin
   content may be loaded. The syntax for the directive's name and value is
@@ -2715,6 +2646,74 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   3.  If the result of executing [[#match-response-to-source-list]] on
       |response|, |request|, this directive's <a for="directive">value</a>,
       and |policy|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h4 id="directive-prefetch-src">`prefetch-src`</h4>
+
+  The <dfn export>prefetch-src</dfn> directive restricts the URLs from which resources may be
+  prefetched or prerendered. The syntax for the directive's name and value is described by the
+  following ABNF:
+
+  <pre>
+    directive-name  = "prefetch-src"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  <div class="example">
+    Given a page with the following Content Security Policy:
+
+    <pre>
+      <a http-header>Content-Security-Policy</a>: <a>prefetch-src</a> https://example.com/
+    </pre>
+
+    Fetches for the following code will return network errors, as the URLs provided do not match
+    `prefetch-src`'s <a>source list</a>:
+
+    <pre highlight="html">
+      &lt;link rel="prefetch" src="https://example.org/"&gt;&lt;/link&gt;
+      &lt;link rel="prerender" src="https://example.org/"&gt;&lt;/link&gt;
+    </pre>
+  </div>
+
+  <h5 algorithm id="prefetch-src-pre-request">
+    `prefetch-src` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-request-to-source-list]] on |request|,
+      this directive's [=directive/value=], and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h5 algorithm id="prefetch-src-post-request">
+    `prefetch-src` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
+  <a for="/">policy</a> (|policy|):
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `prefetch-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-response-to-source-list]] on |response|,
+      |request|, this directive's [=directive/value=], and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
 
   4.  Return "`Allowed`".
 


### PR DESCRIPTION
The other fetch directives are largely in alphabetical order, except this one.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/april/webappsec-csp/pull/379.html" title="Last updated on Dec 27, 2018, 10:45 PM UTC (a6f1b91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/379/0ca85b6...april:a6f1b91.html" title="Last updated on Dec 27, 2018, 10:45 PM UTC (a6f1b91)">Diff</a>