### PR TITLE
Fixes a typo in strict-dynamic-usage

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4919,7 +4919,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   The first change allows you to deploy "<a grammar>`'strict-dynamic'`</a> in a
   backwards compatible way, without requiring user-agent sniffing: the policy
-  `'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'` will act like
+  `'unsafe-inline' https: 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' 'strict-dynamic'` will act like
   `'unsafe-inline' https:` in browsers that support CSP1, `https:
   'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV'` in browsers that support CSP2, and
   `'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV' 'strict-dynamic'` in browsers that


### PR DESCRIPTION
In the section about `strict-dynamic-usage` the documentation explains the impact of adding `'unsafe-inline' https: 'nonce-abcdefg' 'strict-dynamic'`, but in the following example of how this is interpreted in CSP1, 2 and 3 `nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguVV` is used as the example value


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morten-olsen/webappsec-csp/pull/380.html" title="Last updated on Jan 7, 2019, 3:05 PM UTC (778b81f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/380/4b402fd...morten-olsen:778b81f.html" title="Last updated on Jan 7, 2019, 3:05 PM UTC (778b81f)">Diff</a>