### PR TITLE
typo: s/thich/which/

### DIFF
--- a/index.html
+++ b/index.html
@@ -3279,7 +3279,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
     <p>ECMAScript defines a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings" id="ref-for-sec-hostensurecancompilestrings">HostEnsureCanCompileStrings()</a></code> abstract operation
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
-  operation thich examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> to determine whether such compilation ought to be blocked.</p>
+  operation which examines the relevant <a data-link-type="dfn" href="#global-object-csp-list" id="ref-for-global-object-csp-list②⓪">CSP list</a> to determine whether such compilation ought to be blocked.</p>
     <h4 class="heading settled dfn-paneled algorithm" data-algorithm="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" data-dfn-type="dfn" data-export data-level="4.3.1" data-lt="EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)" id="can-compile-strings"><span class="secno">4.3.1. </span><span class="content"> EnsureCSPDoesNotBlockStringCompilation(<var>callerRealm</var>, <var>calleeRealm</var>, <var>source</var>) </span><a class="self-link" href="#can-compile-strings" id="ref-for-can-compile-strings"></a></h4>
     <p>Given two <a data-link-type="dfn" href="https://tc39.github.io/ecma262#realm" id="ref-for-realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a string (<var>source</var>), this algorithm
   returns normally if string compilation is allowed, and throws an "<code>EvalError</code>" if not:</p>

--- a/index.src.html
+++ b/index.src.html
@@ -1491,7 +1491,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   ECMAScript defines a {{HostEnsureCanCompileStrings()}} abstract operation
   which allows the host environment to block the compilation of strings into
   ECMAScript code. This document defines an implementation of that abstract
-  operation thich examines the relevant <a for="global object">CSP list</a>
+  operation which examines the relevant <a for="global object">CSP list</a>
   to determine whether such compilation ought to be blocked.
 
   <h4 id="can-compile-strings" algorithm dfn export>


### PR DESCRIPTION
My locally installed bikeshed created a lot of diff spam when I ran
`make all` so this just changes the one word in both of
`index{,.src}.html`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mikesamuel/webappsec-csp/pull/393.html" title="Last updated on Nov 5, 2020, 8:05 AM UTC (bb30d47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/393/82e32ce...mikesamuel:bb30d47.html" title="Last updated on Nov 5, 2020, 8:05 AM UTC (bb30d47)">Diff</a>