### PR TITLE
Drop mention of obsolete require-sri-for directive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="2d9b52594894cdcf9eb9a4f11c2d2ff60e91a1fc" name="document-revision">
+  <meta content="a0114dd211fa3e3ad11742aca80993a75d18225a" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -5044,8 +5044,6 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
       <p><a data-link-type="biblio" href="#biblio-mix">[MIX]</a> defines <code>block-all-mixed-content</code></p>
      <li data-md>
       <p><a data-link-type="biblio" href="#biblio-upgrade-insecure-requests">[UPGRADE-INSECURE-REQUESTS]</a> defines <code>upgrade-insecure-requests</code></p>
-     <li data-md>
-      <p><a data-link-type="biblio" href="#biblio-sri">[SRI]</a> defines <code>require-sri-for</code></p>
     </ul>
     <p>Extensions to CSP MUST register themselves via the process outlined in <a data-link-type="biblio" href="#biblio-rfc7762">[RFC7762]</a>. In particular, note the criteria discussed in Section 4.2 of
   that document.</p>

--- a/index.src.html
+++ b/index.src.html
@@ -3859,7 +3859,6 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   * [[MIX]] defines `block-all-mixed-content`
   * [[UPGRADE-INSECURE-REQUESTS]] defines `upgrade-insecure-requests`
-  * [[SRI]] defines `require-sri-for`
 
   Extensions to CSP MUST register themselves via the process outlined in
   [[!RFC7762]]. In particular, note the criteria discussed in Section 4.2 of


### PR DESCRIPTION
https://github.com/w3c/webappsec-subresource-integrity/pull/82 removed `require-sri-for` from the SRI spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/417.html" title="Last updated on Dec 25, 2019, 4:27 AM UTC (439095d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/417/faa6120...439095d.html" title="Last updated on Dec 25, 2019, 4:27 AM UTC (439095d)">Diff</a>