### PR TITLE
Use correct set of source expressions in script directives pre-request check

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3910,7 +3910,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
           4.  For each |source| in |integrity sources|:
 
-              1.  If |directive|'s <a for="directive">value</a> does not
+              1.  If |integrity expressions| does not
                   contain a <a>source expression</a> whose
                   <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
                   for |source|'s `hash-algo` component, and whose


### PR DESCRIPTION
The [script directives pre-request check](https://w3c.github.io/webappsec-csp/#script-pre-request) has a part where it talks about the `hash-algorithm` of an arbitrary source expression. That doesn't make sense. But there's already a variable in scope holding just the hash-source subset of source expressions, which isn't used for anything else except a non-emptiness check. Presumably it should be used instead.

For IPR I would consider this to be non-substantive.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bakkot/webappsec-csp/pull/424.html" title="Last updated on Feb 18, 2021, 7:03 AM UTC (7dea64e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/424/1bacede...bakkot:7dea64e.html" title="Last updated on Feb 18, 2021, 7:03 AM UTC (7dea64e)">Diff</a>