### PR TITLE
Fix match-ports to handle a null input port

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4153,16 +4153,19 @@ Content-Type: application/reports+json
     `port-part` matching
   </h5>
 
-  An <a>ASCII string</a> |input| <dfn export>`port-part` matches</dfn> [=/URL=] |url| if a CSP source expression that
-  contained the first as a <a grammar>`port-part`</a> could potentially match a URL containing the latter's [=url/port=]
-  and [=url/scheme=]. For example, "80" <a>`port-part` matches</a> matches http://example.com.
+  An <a>ASCII string</a> or null |input| <dfn export>`port-part` matches</dfn>
+  [=/URL=] |url| if a CSP source expression that contained the first as a <a
+  grammar>`port-part`</a> could potentially match a URL containing the latter's
+  [=url/port=] and [=url/scheme=]. For example, "80" <a>`port-part` matches</a>
+  matches http://example.com.
 
   <ol class="algorithm">
-    1.  Assert: |input| is the empty string, "*", or a sequence of <a>ASCII digits</a>.
+    1.  Assert: |input| is null, "*", or a sequence of one or more <a>ASCII digits</a>.
 
     2.  If |input| is equal to "*", return "`Matches`".
 
-    3.  Let |normalizedInput| be null if |input| is the empty string; otherwise |input| interpreted as decimal number.
+    3.  Let |normalizedInput| be null if |input| null; otherwise |input|
+        interpreted as decimal number.
     
     4.  If |normalizedInput| equals |url|'s [=url/port=], return "`Matches`".
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/435.html" title="Last updated on Dec 17, 2024, 8:38 AM UTC (7a30255)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/435/19c98a2...antosart:7a30255.html" title="Last updated on Dec 17, 2024, 8:38 AM UTC (7a30255)">Diff</a>