### PR TITLE
Meta: export algorithms used by Fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,6 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
+  <meta content="809b8d79154e61172358642312bbd8ca9763f1f3" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2029,7 +2030,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <li>
        <a href="#fetch-integration"><span class="secno">4.1</span> <span class="content"> Integration with Fetch </span></a>
        <ol class="toc">
-        <li><a href="#set-response-csp-list"><span class="secno">4.1.1</span> <span class="content"> Set <var>response</var>’s <code>CSP list</code> </span></a>
+        <li><a href="#set-response-csp-list"><span class="secno">4.1.1</span> <span class="content"> Set <var>response</var>’s CSP list </span></a>
         <li><a href="#report-for-request"><span class="secno">4.1.2</span> <span class="content"> Report Content Security Policy violations for <var>request</var> </span></a>
         <li><a href="#should-block-request"><span class="secno">4.1.3</span> <span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span></a>
         <li><a href="#should-block-response"><span class="secno">4.1.4</span> <span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span></a>
@@ -2562,15 +2563,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <ol>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-pre-request-check">pre-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑦">policy</a> as an argument, and is executed
-  during <a href="#should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
+  during <a href="#should-block-request" id="ref-for-should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a>. This algorithm returns "<code>Allowed</code>" unless
   otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-post-request-check">post-request check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑧">policy</a> as arguments,
-  and is executed during <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
+  and is executed during <a href="#should-block-response" id="ref-for-should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>A <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-response-check">response check</dfn>, which takes a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①">response</a>, and a <a data-link-type="dfn" href="#content-security-policy-object" id="ref-for-content-security-policy-object⑨">policy</a> as arguments,
-  and is executed during <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
+  and is executed during <a href="#should-block-response" id="ref-for-should-block-response①">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>. This algorithm returns
   "<code>Allowed</code>" unless otherwise specified.</p>
      <li data-md>
       <p>An <dfn class="dfn-paneled" data-dfn-for="directive" data-dfn-type="dfn" data-export id="directive-inline-check">inline check</dfn>, which takes an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code>, a
@@ -2829,12 +2830,12 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error">network error</a>.</p>
     <ol>
      <li data-md>
-      <p><a href="#should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a> is called as part of step 2.4 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch">Main
+      <p><a href="#should-block-request" id="ref-for-should-block-request①">§ 4.1.3 Should request be blocked by Content Security Policy?</a> is called as part of step 2.4 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-pre-request-check" id="ref-for-directive-pre-request-check">pre-request checks</a> to be executed against each <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑦">request</a> before it hits the network,
   and against each redirect that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑧">request</a> might go through on its
   way to reaching a resource.</p>
      <li data-md>
-      <p><a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a> is called as part of step 11 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
+      <p><a href="#should-block-response" id="ref-for-should-block-response②">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a> is called as part of step 11 of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-main-fetch" id="ref-for-concept-main-fetch①">Main
   Fetch</a> algorithm. This allows directives' <a data-link-type="dfn" href="#directive-post-request-check" id="ref-for-directive-post-request-check">post-request checks</a> and <a data-link-type="dfn" href="#directive-response-check" id="ref-for-directive-response-check">response checks</a> to be executed on the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑤">response</a> delivered
   from the network or from a Service Worker.</p>
     </ol>
@@ -2846,7 +2847,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a> has an associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list">CSP list</a> which
   contains any policy objects delivered in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑧">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a>.</p>
      <li data-md>
-      <p><a href="#set-response-csp-list">§ 4.1.1 Set response’s CSP list</a> is called in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithms.</p>
+      <p><a href="#set-response-csp-list" id="ref-for-set-response-csp-list">§ 4.1.1 Set response’s CSP list</a> is called in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithms.</p>
       <p class="note" role="note"><span>Note:</span> These two calls should ensure that a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑨">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list①">CSP list</a> is set, regardless of how the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①⓪">response</a> is created. If we hit the network (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch①">HTTP-network
   fetch</a>, then we parse the policy before we handle the <code>Set-Cookie</code> header. If we get a response from a Service Worker (via <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch①">HTTP fetch</a>,
   we’ll process its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list②">CSP list</a> before handing the
@@ -2855,7 +2856,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   Any <a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy②">Content-Security-Policy</a> headers found in a redirect
   response are ignored.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Set response’s CSP list" data-level="4.1.1" id="set-response-csp-list"><span class="secno">4.1.1. </span><span class="content"> Set <var>response</var>’s <code>CSP list</code> </span><a class="self-link" href="#set-response-csp-list"></a></h4>
+    <h4 class="heading settled dfn-paneled algorithm" data-algorithm="Set response’s CSP list" data-dfn-type="dfn" data-export data-level="4.1.1" data-lt="Set response’s CSP list" id="set-response-csp-list"><span class="secno">4.1.1. </span><span class="content"> Set <var>response</var>’s CSP list </span><a class="self-link" href="#set-response-csp-list" id="ref-for-set-response-csp-list①"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①①">response</a> (<var>response</var>), this algorithm evaluates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list①">header list</a> for <a data-link-type="dfn" href="#serialized-csp" id="ref-for-serialized-csp⑥">serialized CSP</a> values, and
   populates its <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list③">CSP list</a> accordingly:</p>
     <ol class="algorithm">
@@ -2874,7 +2875,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>Insert <var>policy</var> into <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-csp-list" id="ref-for-concept-response-csp-list⑤">CSP list</a>.</p>
       </ol>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Report Content Security Policy violations for request" data-level="4.1.2" id="report-for-request"><span class="secno">4.1.2. </span><span class="content"> Report Content Security Policy violations for <var>request</var> </span><a class="self-link" href="#report-for-request"></a></h4>
+    <h4 class="heading settled dfn-paneled algorithm" data-algorithm="Report Content Security Policy violations for request" data-dfn-type="dfn" data-export data-level="4.1.2" data-lt="Report Content Security Policy violations for request" id="report-for-request"><span class="secno">4.1.2. </span><span class="content"> Report Content Security Policy violations for <var>request</var> </span><a class="self-link" href="#report-for-request" id="ref-for-report-for-request"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑨">request</a> (<var>request</var>), this algorithm reports violations based
   on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>’s "report only" policies.</p>
     <ol>
@@ -2892,7 +2893,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
         <p>If <var>violates</var> is not "<code>Does Not Violate</code>", then execute <a href="#report-violation">§ 5.3 Report a violation</a> on the result of executing <a href="#create-violation-for-request">§ 2.4.2 Create a violation object for request, and policy.</a> on <var>request</var>, and <var>policy</var>.</p>
       </ol>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Should request be blocked by Content Security Policy?" data-level="4.1.3" id="should-block-request"><span class="secno">4.1.3. </span><span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-request"></a></h4>
+    <h4 class="heading settled dfn-paneled algorithm" data-algorithm="Should request be blocked by Content Security Policy?" data-dfn-type="dfn" data-export data-level="4.1.3" data-lt="Should request be blocked by Content Security Policy?" id="should-block-request"><span class="secno">4.1.3. </span><span class="content"> Should <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-request" id="ref-for-should-block-request②"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①⓪">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code> and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>’s Content Security Policy.</p>
     <ol>
      <li data-md>
@@ -2919,7 +2920,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p>Return <var>result</var>.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Should response to request be blocked by Content Security Policy?" data-level="4.1.4" id="should-block-response"><span class="secno">4.1.4. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-response"></a></h4>
+    <h4 class="heading settled dfn-paneled algorithm" data-algorithm="Should response to request be blocked by Content Security Policy?" data-dfn-type="dfn" data-export data-level="4.1.4" data-lt="Should response to request be blocked by Content Security Policy?" id="should-block-response"><span class="secno">4.1.4. </span><span class="content"> Should <var>response</var> to <var>request</var> be blocked by Content Security Policy? </span><a class="self-link" href="#should-block-response" id="ref-for-should-block-response③"></a></h4>
     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response①②">response</a> (<var>response</var>) and a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①①">request</a> (<var>request</var>), this algorithm returns <code>Blocked</code> or <code>Allowed</code>, and reports violations based on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>’s Content Security Policy.</p>
     <ol>
      <li data-md>
@@ -3009,7 +3010,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
      <li data-md>
       <p><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy" id="ref-for-should-plugin-element-be-blocked-a-priori-by-content-security-policy">§ 6.2.2.2 Should plugin element be blocked a priori by Content
     Security Policy?:</a> is called during the processing of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element" id="ref-for-the-object-element">object</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element" id="ref-for-the-embed-element">embed</a></code>, and <a data-link-type="dfn"><code>applet</code></a> elements to determine whether they may trigger a fetch.</p>
-      <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
+      <p class="note" role="note"><span>Note:</span> Fetched plugin resources are handled in <a href="#should-block-response" id="ref-for-should-block-response④">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
       <p><a href="#should-block-navigation-request" id="ref-for-should-block-navigation-request②">§ 4.2.5 Should navigation request of type be blocked
     by Content Security Policy?</a> is called during the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch" id="ref-for-process-a-navigate-fetch">process a
@@ -3848,7 +3849,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>If a <a data-link-type="dfn" href="#default-src" id="ref-for-default-src①">default-src</a> directive is present in a policy, its value will be
   used as the policy’s default source list. That is, given <code>default-src 'none'; script-src 'self'</code>, script requests will use <code>'self'</code> as the <a data-link-type="dfn" href="#source-lists" id="ref-for-source-lists②">source
   list</a> to match against. Other requests will use <code>'none'</code>. This is spelled
-  out in more detail in the <a href="#should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
+  out in more detail in the <a href="#should-block-request" id="ref-for-should-block-request③">§ 4.1.3 Should request be blocked by Content Security Policy?</a> and <a href="#should-block-response" id="ref-for-should-block-response⑤">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a> algorithms.</p>
     <div class="example" id="example-327c55f5">
      <a class="self-link" href="#example-327c55f5"></a> The following header: 
 <pre><a data-link-type="http-header" href="#header-content-security-policy" id="ref-for-header-content-security-policy⑤">Content-Security-Policy</a>: <a data-link-type="dfn" href="#default-src" id="ref-for-default-src②">default-src</a> <a data-link-type="grammar" href="#grammardef-self" id="ref-for-grammardef-self⑥">'self'</a>
@@ -4284,9 +4285,9 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <code>script-src</code> directive governs five things:</p>
     <ol>
      <li data-md>
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">requests</a> MUST pass through <a href="#should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④②">requests</a> MUST pass through <a href="#should-block-request" id="ref-for-should-block-request④">§ 4.1.3 Should request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
-      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">responses</a> MUST pass through <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
+      <p>Script <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response②⑧">responses</a> MUST pass through <a href="#should-block-response" id="ref-for-should-block-response⑥">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script" id="ref-for-script⑤">script</a></code> blocks MUST pass through <a href="#should-block-inline" id="ref-for-should-block-inline④">§ 4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. Their
   behavior will be blocked unless every policy allows inline script, either
@@ -4442,7 +4443,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
     <p>The <code>style-src</code> directive governs several things:</p>
     <ol>
      <li data-md>
-      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">requests</a> MUST pass through <a href="#should-block-request">§ 4.1.3 Should request be blocked by Content Security Policy?</a>. This
+      <p>Style <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④⑦">requests</a> MUST pass through <a href="#should-block-request" id="ref-for-should-block-request⑤">§ 4.1.3 Should request be blocked by Content Security Policy?</a>. This
   includes:</p>
       <ol>
        <li data-md>
@@ -4454,7 +4455,7 @@ directive-value = <a data-link-type="grammar" href="#grammardef-serialized-sourc
   field <a data-link-type="biblio" href="#biblio-rfc8288">[RFC8288]</a>.</p>
       </ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">Responses</a> to style requests MUST pass through <a href="#should-block-response">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response③①">Responses</a> to style requests MUST pass through <a href="#should-block-response" id="ref-for-should-block-response⑦">§ 4.1.4 Should response to request be blocked by Content Security Policy?</a>.</p>
      <li data-md>
       <p>Inline <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a></code> blocks MUST pass through <a href="#should-block-inline" id="ref-for-should-block-inline⑤">§ 4.2.4 Should element’s inline type behavior be blocked by Content Security Policy?</a>. The
   styles will be blocked unless every policy allows inline style, either
@@ -6441,6 +6442,7 @@ rest of Google’s CSP Cabal.</p>
      <li><a href="#dom-securitypolicyviolationeventinit-referrer">dict-member for SecurityPolicyViolationEventInit</a><span>, in §5.1</span>
     </ul>
    <li><a href="#dom-securitypolicyviolationeventdisposition-report">"report"</a><span>, in §5.1</span>
+   <li><a href="#report-for-request">Report Content Security Policy violations for request</a><span>, in §4.1.1</span>
    <li><a href="#grammardef-report-sample">'report-sample'</a><span>, in §2.3.1</span>
    <li><a href="#report-to">report-to</a><span>, in §6.4.2</span>
    <li><a href="#report-uri">report-uri</a><span>, in §6.4.1</span>
@@ -6477,10 +6479,13 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#grammardef-serialized-policy-list">serialized-policy-list</a><span>, in §2.2</span>
    <li><a href="#serialized-source-list">serialized source list</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-serialized-source-list">serialized-source-list</a><span>, in §2.3.1</span>
+   <li><a href="#set-response-csp-list">Set response’s CSP list</a><span>, in §4.1</span>
    <li><a href="#should-block-inline">Should element’s inline type behavior be blocked by Content Security Policy?</a><span>, in §4.2.3</span>
    <li><a href="#should-block-navigation-request">Should navigation request of type be blocked by Content Security Policy?</a><span>, in §4.2.4</span>
    <li><a href="#should-block-navigation-response">Should navigation response to navigation request of type in target be blocked by Content Security Policy?</a><span>, in §4.2.5</span>
    <li><a href="#should-plugin-element-be-blocked-a-priori-by-content-security-policy">Should plugin element be blocked a priori by Content Security Policy?:</a><span>, in §6.2.2.1</span>
+   <li><a href="#should-block-request">Should request be blocked by Content Security Policy?</a><span>, in §4.1.2</span>
+   <li><a href="#should-block-response">Should response to request be blocked by Content Security Policy?</a><span>, in §4.1.3</span>
    <li><a href="#policy-source">source</a><span>, in §2.2</span>
    <li><a href="#source-expression">source expression</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-source-expression">source-expression</a><span>, in §2.3.1</span>
@@ -9928,6 +9933,50 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy-report-only②">3.3. 
     The &lt;meta> element </a>
     <li><a href="#ref-for-header-content-security-policy-report-only③">6.2.3. sandbox</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="set-response-csp-list">
+   <b><a href="#set-response-csp-list">#set-response-csp-list</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-set-response-csp-list">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-set-response-csp-list">4.1.1. 
+    Set response’s CSP list </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="report-for-request">
+   <b><a href="#report-for-request">#report-for-request</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-report-for-request">4.1.2. 
+    Report Content Security Policy violations for request </a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="should-block-request">
+   <b><a href="#should-block-request">#should-block-request</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-should-block-request">2.3. Directives</a>
+    <li><a href="#ref-for-should-block-request">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-should-block-request">4.1.3. 
+    Should request be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-should-block-request">6.1.3. default-src</a>
+    <li><a href="#ref-for-should-block-request">6.1.11. script-src</a>
+    <li><a href="#ref-for-should-block-request">6.1.14. style-src</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="should-block-response">
+   <b><a href="#should-block-response">#should-block-response</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-should-block-response">2.3. Directives</a> <a href="#ref-for-should-block-response">(2)</a>
+    <li><a href="#ref-for-should-block-response">4.1. 
+    Integration with Fetch </a>
+    <li><a href="#ref-for-should-block-response">4.1.4. 
+    Should response to request be blocked by Content Security Policy? </a>
+    <li><a href="#ref-for-should-block-response">4.2. 
+    Integration with HTML </a>
+    <li><a href="#ref-for-should-block-response">6.1.3. default-src</a>
+    <li><a href="#ref-for-should-block-response">6.1.11. script-src</a>
+    <li><a href="#ref-for-should-block-response">6.1.14. style-src</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="global-object-csp-list">

--- a/index.src.html
+++ b/index.src.html
@@ -994,8 +994,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       Any <a http-header>Content-Security-Policy</a> headers found in a redirect
       response are ignored.
 
-  <h4 id="set-response-csp-list" algorithm>
-    Set |response|'s `CSP list`
+  <h4 id="set-response-csp-list" algorithm dfn export>
+    Set |response|'s CSP list
   </h4>
 
   Given a <a>response</a> (|response|), this algorithm evaluates its
@@ -1024,7 +1024,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         2.  Insert |policy| into |response|'s <a for="response">CSP list</a>.
   </ol>
 
-  <h4 id="report-for-request" algorithm>
+  <h4 id="report-for-request" algorithm dfn export>
     Report Content Security Policy violations for |request|
   </h4>
 
@@ -1047,7 +1047,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           [[#report-violation]] on the result of executing
           [[#create-violation-for-request]] on |request|, and |policy|.
 
-  <h4 id="should-block-request" algorithm>
+  <h4 id="should-block-request" algorithm dfn export>
     Should |request| be blocked by Content Security Policy?
   </h4>
 
@@ -1078,7 +1078,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   4.  Return |result|.
 
-  <h4 id="should-block-response" algorithm>
+  <h4 id="should-block-response" algorithm dfn export>
     Should |response| to |request| be blocked by Content Security Policy?
   </h4>
 


### PR DESCRIPTION
For https://github.com/whatwg/fetch/pull/1111.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/445.html" title="Last updated on Nov 4, 2020, 6:44 PM UTC (7affcbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/445/787d240...7affcbb.html" title="Last updated on Nov 4, 2020, 6:44 PM UTC (7affcbb)">Diff</a>