### PR TITLE
Meta: correct percent-decode reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="809b8d79154e61172358642312bbd8ca9763f1f3" name="document-revision">
+  <meta content="2d9b52594894cdcf9eb9a4f11c2d2ff60e91a1fc" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1920,7 +1920,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-11-04">4 November 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-11-05">5 November 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5409,9 +5409,9 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
        <li data-md>
         <p>Let <var>piece B</var> be the next item in <var>path list B</var>.</p>
        <li data-md>
-        <p><a data-link-type="dfn">Percent decode</a> <var>piece A</var>.</p>
+        <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode">Percent-decode</a> <var>piece A</var>.</p>
        <li data-md>
-        <p><a data-link-type="dfn">Percent decode</a> <var>piece B</var>.</p>
+        <p><a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode①">Percent-decode</a> <var>piece B</var>.</p>
        <li data-md>
         <p>If <var>piece A</var> is not a <a data-link-type="dfn">case-sensitive</a> match
   for <var>piece B</var>, return "<code>Does Not Match</code>".</p>
@@ -8188,6 +8188,13 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-string-percent-decode">
+   <a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-percent-decode">6.6.2.10. 
+    path-part matching </a> <a href="#ref-for-string-percent-decode①">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-port">
    <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
@@ -8536,6 +8543,7 @@ rest of Google’s CSP Cabal.</p>
      <li><span class="dfn-paneled" id="term-for-concept-ipv6">ipv6 address</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-origin">origin</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-path">path</span>
+     <li><span class="dfn-paneled" id="term-for-string-percent-decode">percent-decode</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-port">port <small>(for url)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-url-scheme">scheme</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-parser">url parser</span>

--- a/index.src.html
+++ b/index.src.html
@@ -48,7 +48,6 @@ spec:fetch
 spec:url
   type: dfn
     text: default port
-    text: percent decode
     text: base url
   type:interface;
     text:URL
@@ -4300,9 +4299,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
         1.  Let |piece B| be the next item in |path list B|.
 
-        2.  <a>Percent decode</a> |piece A|.
+        2.  <a for="string">Percent-decode</a> |piece A|.
 
-        3.  <a>Percent decode</a> |piece B|.
+        3.  <a for="string">Percent-decode</a> |piece B|.
 
         4.  If |piece A| is not a <a>case-sensitive</a> match
             for |piece B|, return "`Does Not Match`".


### PR DESCRIPTION
Now it seems this assumes the algorithm modifies in place, which isn't the case. It returns a byte sequence...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/447.html" title="Last updated on Nov 5, 2020, 7:52 AM UTC (56f86ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/447/2d9b525...56f86ed.html" title="Last updated on Nov 5, 2020, 7:52 AM UTC (56f86ed)">Diff</a>