### PR TITLE
Restore CSP Level 2 reporting envelope

### DIFF
--- a/index.html
+++ b/index.html
@@ -1321,9 +1321,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
+  <meta content="Bikeshed version eb6d17d1, updated Tue Oct 20 23:26:51 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/CSP3/" rel="canonical">
-  <meta content="a0114dd211fa3e3ad11742aca80993a75d18225a" name="document-revision">
+  <meta content="9a4070d6a19b99e7a10e1864906794d0f9002b29" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1920,7 +1920,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Content Security Policy Level 3</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-11-05">5 November 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-01-11">11 January 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1942,7 +1942,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -3407,7 +3407,7 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
   endpoint associated with the deprecated <a data-link-type="dfn" href="#report-uri" id="ref-for-report-uri"><code>report-uri</code></a> directive.</p>
     <ol>
      <li data-md>
-      <p>Let <var>object</var> be a new JavaScript object with properties initialized as
+      <p>Let <var>body</var> be a new JavaScript object with properties initialized as
   follows:</p>
       <dl>
        <dt data-md>"<code>document-url</code>"
@@ -3453,24 +3453,32 @@ ISSUE: Bikeshed <code>unsafe-allow-redirects</code>.
       <p>If <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file②">source file</a> is not <code>null</code>:</p>
       <ol>
        <li data-md>
-        <p>Set <var>object</var>’s "<code>source-file</code>" property to the result of executing
+        <p>Set <var>body</var>’s "<code>source-file</code>" property to the result of executing
   the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer③">URL serializer</a> on <var>violation</var>’s <a data-link-type="dfn" href="#violation-source-file" id="ref-for-violation-source-file③">source
   file</a>, with the <code>exclude fragment</code> flag set.</p>
        <li data-md>
-        <p>Set <var>object</var>’s "<code>lineno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number①">line number</a>.</p>
+        <p>Set <var>body</var>’s "<code>lineno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number①">line number</a>.</p>
        <li data-md>
-        <p>Set <var>object</var>’s "<code>line-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number②">line number</a>.</p>
+        <p>Set <var>body</var>’s "<code>line-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-line-number" id="ref-for-violation-line-number②">line number</a>.</p>
        <li data-md>
-        <p>Set <var>object</var>’s "<code>colno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number①">column number</a>.</p>
+        <p>Set <var>body</var>’s "<code>colno</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number①">column number</a>.</p>
        <li data-md>
-        <p>Set <var>object</var>’s "<code>column-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number②">column number</a>.</p>
+        <p>Set <var>body</var>’s "<code>column-number</code>" property to <var>violation</var>’s <a data-link-type="dfn" href="#violation-column-number" id="ref-for-violation-column-number②">column number</a>.</p>
         <p class="note" role="note"><span>Note:</span> the "<code>line-number</code>" and "<code>column-number</code>" properties are
   maintained for historical reasons and are duplicates of "<code>lineno</code>"
   and "<code>colno</code>" respectively.</p>
       </ol>
      <li data-md>
-      <p class="assertion">Assert: If <var>object</var>’s "<code>blocked-url</code>" property is not "<code>inline</code>", then its "<code>sample</code>"
+      <p class="assertion">Assert: If <var>body</var>’s "<code>blocked-url</code>" property is not "<code>inline</code>", then its "<code>sample</code>"
   property is the empty string.</p>
+     <li data-md>
+      <p>Let <var>object</var> be a new JavaScript object with properties initialized as
+  follows:</p>
+      <dl>
+       <dt data-md>"<code>csp-report</code>"
+       <dd data-md>
+        <p><var>body</var></p>
+      </dl>
      <li data-md>
       <p>Return the result of executing <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262#sec-json.stringify" id="ref-for-sec-json.stringify">JSON.stringify()</a></code> on <var>object</var>.</p>
     </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -1644,7 +1644,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   string representation of the violation, suitable for submission to a reporting
   endpoint associated with the deprecated <a>`report-uri`</a> directive.
 
-  1.  Let |object| be a new JavaScript object with properties initialized as
+  1.  Let |body| be a new JavaScript object with properties initialized as
       follows:
 
       :   "`document-url`"
@@ -1684,30 +1684,36 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
   2.  If |violation|'s <a for="violation">source file</a> is not `null`:
 
-      1.  Set |object|'s "`source-file`" property to the result of executing
+      1.  Set |body|'s "`source-file`" property to the result of executing
           the <a>URL serializer</a> on |violation|'s <a for="violation">source
           file</a>, with the `exclude fragment` flag set.
 
-      2.  Set |object|'s "`lineno`" property to |violation|'s
+      2.  Set |body|'s "`lineno`" property to |violation|'s
           <a for="violation">line number</a>.
 
-      3.  Set |object|'s "`line-number`" property to |violation|'s
+      3.  Set |body|'s "`line-number`" property to |violation|'s
           <a for="violation">line number</a>.
 
-      4.  Set |object|'s "`colno`" property to |violation|'s
+      4.  Set |body|'s "`colno`" property to |violation|'s
           <a for="violation">column number</a>.
 
-      5.  Set |object|'s "`column-number`" property to |violation|'s
+      5.  Set |body|'s "`column-number`" property to |violation|'s
           <a for="violation">column number</a>.
 
           Note: the "`line-number`" and "`column-number`" properties are
           maintained for historical reasons and are duplicates of "`lineno`"
           and "`colno`" respectively.
 
-  3.  Assert: If |object|'s "`blocked-url`" property is not "`inline`", then its "`sample`"
+  3.  Assert: If |body|'s "`blocked-url`" property is not "`inline`", then its "`sample`"
       property is the empty string.
 
-  4.  Return the result of executing {{JSON.stringify()}} on |object|.
+  4.  Let |object| be a new JavaScript object with properties initialized as
+      follows:
+
+      :   "`csp-report`"
+      ::  |body|
+
+  5.  Return the result of executing {{JSON.stringify()}} on |object|.
 
   <h3 id="report-violation" algorithm>
     Report a |violation|


### PR DESCRIPTION
When CSP Level 3 was defined, the report format was changed slightly; CSP Level 2 reports have an outer `{"csp-report": <body>}` structure, while Level 3 removed that, just leaving the body.

It appears that Chrome has never changed to this new format, which is still allowed by WPT. (Have not tested other engines). The `report-uri` directive should be deprecated in favor of `report-to` in any case, so it doesn't seem to make sense to do anything new for `report-uri`, other than to codify the previous format as correct.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/webappsec-csp/pull/454.html" title="Last updated on Jan 12, 2021, 3:12 PM UTC (d299d7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/454/9a4070d...clelland:d299d7a.html" title="Last updated on Jan 12, 2021, 3:12 PM UTC (d299d7a)">Diff</a>