### PR TITLE
Meta: align with Fetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,7 +43,6 @@ spec:fetch
     text: main fetch
     text: http-network fetch
     text: http fetch
-    text: keepalive flag
     text: response; for: /
 spec:url
   type: dfn
@@ -340,8 +339,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       hashes. Details in [[#unsafe-hashes-usage]].
 
   9.  The <a>source expression</a> matching has been changed to require explicit presence
-      of any non-<a>network scheme</a>, rather than <a>local scheme</a>,
-      unless that non-<a>network scheme</a> is the same as the scheme of protected resource,
+      of any non-<a>HTTP(S) scheme</a>, rather than <a>local scheme</a>,
+      unless that non-<a>HTTP(S) scheme</a> is the same as the scheme of protected resource,
       as described in [[#match-url-to-source-expression]].
 
   10. Hash-based source expressions may now match external scripts if the
@@ -1815,7 +1814,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
                   ::  ""
                   :   <a for="request">credentials mode</a>
                   ::  "`same-origin`"
-                  :   <a for="request">keepalive flag</a>
+                  :   <a for="request">keepalive</a>
                   ::  "`true`"
                   :   <a for="request">header list</a>
                   ::  A header list containing a single header whose name is
@@ -3949,11 +3948,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   1.  If |expression| is the string "*", return "`Matches`" if one or more of
       the following conditions is met:
 
-      1. |url|'s <a for="url">scheme</a> is a <a>network scheme</a>.
+      1. |url|'s <a for="url">scheme</a> is an <a>HTTP(S) scheme</a>.
 
       2. |url|'s <a for="url">scheme</a> is the same as |origin|'s <a for="origin">scheme</a>.
 
-      Note: This logic means that in order to allow a resource from a non-<a>network scheme</a>,
+      Note: This logic means that in order to allow a resource from a non-<a>HTTP(S) scheme</a>,
       it has to be either explicitly specified (e.g.
       `default-src * data: custom-scheme-1: custom-scheme-2:`),
       or the protected resource must be loaded from the same scheme.


### PR DESCRIPTION
Network scheme is now reduced to HTTP(S) scheme and request's keepalive flag was renamed to keepalive.

See https://github.com/whatwg/fetch/pull/1166 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/461.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (6938eb9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/461/483800d...6938eb9.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (6938eb9)">Diff</a>