### PR TITLE
Fix calls to “percent-decode” algorithm

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4304,12 +4304,14 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
         1.  Let |piece B| be the next item in |path list B|.
 
-        2.  <a for="string">Percent-decode</a> |piece A|.
+        2.  Let |decoded piece A| be the <a>UTF-8 decoding</a> of the
+            <a for=string lt=percent-decode>percent-decoding</a> of |piece A|.
 
-        3.  <a for="string">Percent-decode</a> |piece B|.
+        3.  Let |decoded piece B| be the <a>UTF-8 decoding</a> of the
+            <a for=string lt=percent-decode>percent-decoding</a> of |piece B|.
 
-        4.  If |piece A| is not a <a>case-sensitive</a> match
-            for |piece B|, return "`Does Not Match`".
+        4.  If |decoded piece A| is not an <a>ASCII case-insensitive</a> match
+            for |decoded piece B|, return "`Does Not Match`".
 
     9.  Return "`Matches`".
   </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -4304,13 +4304,13 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
         1.  Let |piece B| be the next item in |path list B|.
 
-        2.  Let |decoded piece A| be the <a>UTF-8 decoding</a> of the
-            <a for=string lt=percent-decode>percent-decoding</a> of |piece A|.
+        2.  Let |decoded piece A| be the <a for=string lt=percent-decode>percent-decoding</a> of
+            |piece A|.
 
-        3.  Let |decoded piece B| be the <a>UTF-8 decoding</a> of the
-            <a for=string lt=percent-decode>percent-decoding</a> of |piece B|.
+        3.  Let |decoded piece B| be the <a for=string lt=percent-decode>percent-decoding</a> of
+            |piece B|.
 
-        4.  If |decoded piece A| is not an <a>ASCII case-insensitive</a> match
+        4.  If |decoded piece A| is not an <a>byte-case-insensitive</a> match
             for |decoded piece B|, return "`Does Not Match`".
 
     9.  Return "`Matches`".

--- a/index.src.html
+++ b/index.src.html
@@ -4310,8 +4310,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         3.  Let |decoded piece B| be the <a for=string lt=percent-decode>percent-decoding</a> of
             |piece B|.
 
-        4.  If |decoded piece A| is not an <a>byte-case-insensitive</a> match
-            for |decoded piece B|, return "`Does Not Match`".
+        4.  If |decoded piece A| is not |decoded piece B|, return "`Does Not Match`".
 
     9.  Return "`Matches`".
   </ol>


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/448


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/462.html" title="Last updated on Feb 18, 2021, 8:31 AM UTC (f321774)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/462/1bacede...f321774.html" title="Last updated on Feb 18, 2021, 8:31 AM UTC (f321774)">Diff</a>