### PR TITLE
Use “hash-algorithm” name (not old CSP2 “hash-algo” name)

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3913,7 +3913,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
               1.  If |directive|'s <a for="directive">value</a> does not
                   contain a <a>source expression</a> whose
                   <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
-                  for |source|'s `hash-algo` component, and whose
+                  for |source|'s <a grammar>hash-algorithm</a>, and whose
                   <a grammar>base64-value</a> is a <a>case-sensitive</a> match
                   for |source|'s `base64-value`, then set |bypass due to
                   integrity match| to `false`.


### PR DESCRIPTION
Fixes https://github.com/w3c/webappsec-csp/issues/418


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/463.html" title="Last updated on Feb 18, 2021, 7:48 AM UTC (89e8195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/463/1bacede...89e8195.html" title="Last updated on Feb 18, 2021, 7:48 AM UTC (89e8195)">Diff</a>