### PR TITLE
Match hash-algorithm parts case-insensitively (as CSP2)

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3912,7 +3912,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
 
               1.  If |directive|'s <a for="directive">value</a> does not
                   contain a <a>source expression</a> whose
-                  <a grammar>hash-algorithm</a> is a <a>case-sensitive</a> match
+                  <a grammar>hash-algorithm</a> is an <a>ASCII case-insensitive</a> match
                   for |source|'s <a grammar>hash-algorithm</a>, and whose
                   <a grammar>base64-value</a> is a <a>case-sensitive</a> match
                   for |source|'s `base64-value`, then set |bypass due to


### PR DESCRIPTION
At https://w3.org/TR/CSP2/#source-list-valid-hashes the CSP2 spec says a case-insensitive match must be performed for checking hash-algorithm parts, and that’s how implementations actually do it.

So this change makes the current CSP spec also say that’s how it must be done.

Otherwise, without this change, the CSP spec says that the match must be done case-sensitively. So conforming to that spec language as written would require implementations to change their behavior in a backward-incompatible way.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/464.html" title="Last updated on Feb 19, 2021, 2:53 AM UTC (3cdcd9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/464/a036e31...3cdcd9a.html" title="Last updated on Feb 19, 2021, 2:53 AM UTC (3cdcd9a)">Diff</a>