### PR TITLE
Editorial: Drop Previous Version link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,6 @@
 Status: WD
 ED: https://w3c.github.io/webappsec-csp/
 TR: https://www.w3.org/TR/CSP3/
-Previous Version: https://www.w3.org/TR/2018/WD-CSP3-20181015/
 Shortname: CSP3
 Level: None
 Editor: Mike West 56384, Google Inc., mkwst@google.com


### PR DESCRIPTION
The Previous Version link seems to be causing autopublishing to fail:

https://labs.w3.org/echidna/api/status?id=a04327e5-f215-443a-8c65-6ddb300350ea

> "key": "latest-is-not-previous",
> "detailMessage": "Retrieved \"previous\" and \"latest\" documents, but their contents don't match.",