### PR TITLE
Editorial: Use "Previous Version: from biblio"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,6 +3,7 @@
 Status: WD
 ED: https://w3c.github.io/webappsec-csp/
 TR: https://www.w3.org/TR/CSP3/
+Previous Version: from biblio
 Shortname: CSP3
 Level: None
 Editor: Mike West 56384, Google Inc., mkwst@google.com


### PR DESCRIPTION
This change causes Bikeshed to automatically set the value of the "Previous Version" metadata/link.