### PR TITLE
CI: (re)Drop Previous Version bikeshed metadata

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -18,3 +18,5 @@ jobs:
           VALIDATE_MARKUP: true
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0170.html
+          W3C_BUILD_OVERRIDE: |
+            shortname: CSP3

--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,6 @@
 Status: WD
 ED: https://w3c.github.io/webappsec-csp/
 TR: https://www.w3.org/TR/CSP3/
-Previous Version: from biblio
 Shortname: CSP3
 Level: None
 Editor: Mike West 56384, Google Inc., mkwst@google.com


### PR DESCRIPTION
This change drops the Previous Version metadata from he index.bs source, and re-configures the spec-prod config to have our GitHub Actions setup add it to the published doc.