### PR TITLE
Use request's policy container for checks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1037,11 +1037,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   </h4>
 
   Given a <a for="/">request</a> (|request|), this algorithm reports violations based
-  on <a for="request">client</a>'s "report only" policies.
+  on [=request/policy container=]'s [=policy container/CSP list=] "report only" policies.
 
-  1.  Let |CSP list| be |request|'s
-      <a for="request">client</a>'s <a for="environment settings object">global object</a>'s
-      <a for="global object">CSP list</a>.
+  1.  Let |CSP list| be |request|'s [=request/policy container=]'s [=policy container/CSP list=].
 
   2.  For each |policy| in |CSP list|:
 
@@ -1059,13 +1057,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Should |request| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a for="/">request</a> (|request|), this algorithm returns
-  `Blocked` or `Allowed` and reports violations based on |request|'s
-  <a for="request">client</a>'s Content Security Policy.
+  Given a <a for="/">request</a> (|request|), this algorithm returns `Blocked` or `Allowed` and
+  reports violations based on |request|'s [=request/policy container=]'s
+  [=policy container/CSP list=].
 
-  1.  Let |CSP list| be |request|'s
-      <a for="request">client</a>'s <a for="environment settings object">global object</a>'s
-      <a for="global object">CSP list</a>.
+  1.  Let |CSP list| be |request|'s [=request/policy container=]'s [=policy container/CSP list=].
 
   2.  Let |result| be "`Allowed`".
 
@@ -1090,14 +1086,11 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     Should |response| to |request| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a>response</a> (|response|) and a <a for="/">request</a>
-  (|request|), this algorithm returns `Blocked` or
-  `Allowed`, and reports violations based on |request|'s
-  <a for="request">client</a>'s Content Security Policy.
+  Given a <a>response</a> (|response|) and a <a for="/">request</a> (|request|), this algorithm
+  returns `Blocked` or `Allowed`, and reports violations based on |request|'s
+  [=request/policy container=]'s [=policy container/CSP list=].
 
-  1.  Let |CSP list| be |request|'s
-      <a for="request">client</a>'s <a for="environment settings object">global object</a>'s
-      <a for="global object">CSP list</a>.
+  1.  Let |CSP list| be |request|'s [=request/policy container=]'s [=policy container/CSP list=].
 
   2.  Let |result| be "`Allowed`".
 
@@ -1280,9 +1273,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
-        <a for="environment settings object">global object</a>'s
-        <a for="global object">CSP list</a>:
+    2.  For each |policy| in |navigation request|'s <a for="request">policy container</a>'s
+        <a for="policy container">CSP list</a>:
 
         1.  For each |directive| in |policy|:
 
@@ -1377,9 +1369,8 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
             5.  If |policy|'s <a for="policy">disposition</a> is "`enforce`", then
                 set |result| to "`Blocked`".
 
-    3.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
-        <a for="environment settings object">global object</a>'s
-        <a for="global object">CSP list</a>:
+    3.  For each |policy| in |navigation request|'s <a for="request">policy container</a>'s
+        <a for="policy container">CSP list</a>:
 
         Note: Some directives in the |navigation request|'s context (like <a>navigate-to</a>)
         need the |response| before acting on the navigation.


### PR DESCRIPTION
This change depends on https://github.com/whatwg/fetch/pull/1231 and https://github.com/whatwg/html/pull/6659 which add and populate a request's policy container. This change relies on the request's policy container CSP list (instead of the request's client's environment setting object's CSP list) for the checks. This enforces consistency, since the the request's client's environment setting object's CSP list can change during the lifetime of an asynchronous fetch (for example, when following redirects, or when doing a response check), while the request's policy container CSP list is a snapshot at request's creation time.