### PR TITLE
Revert changing names of SPV event members

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1465,11 +1465,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     [Exposed=(Window,Worker)]
     interface SecurityPolicyViolationEvent : Event {
         constructor(DOMString type, optional SecurityPolicyViolationEventInit eventInitDict = {});
-        readonly    attribute USVString      documentURL;
-        readonly    attribute USVString      documentURI; // historical alias of documentURL
+        readonly    attribute USVString      documentURI;
         readonly    attribute USVString      referrer;
-        readonly    attribute USVString      blockedURL;
-        readonly    attribute USVString      blockedURI; // historical alias of blockedURL
+        readonly    attribute USVString      blockedURI;
         readonly    attribute DOMString      effectiveDirective;
         readonly    attribute DOMString      violatedDirective; // historical alias of effectiveDirective
         readonly    attribute DOMString      originalPolicy;
@@ -1477,41 +1475,25 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
         readonly    attribute DOMString      sample;
         readonly    attribute SecurityPolicyViolationEventDisposition      disposition;
         readonly    attribute unsigned short statusCode;
-        readonly    attribute unsigned long  lineno;
-        readonly    attribute unsigned long  lineNumber; // historical alias of lineno
-        readonly    attribute unsigned long  colno;
-        readonly    attribute unsigned long  columnNumber; // historical alias of colno
+        readonly    attribute unsigned long  lineNumber;
+        readonly    attribute unsigned long  columnNumber;
     };
 
     dictionary SecurityPolicyViolationEventInit : EventInit {
-        required USVString      documentURL;
+        required USVString      documentURI;
                  USVString      referrer = "";
-                 USVString      blockedURL = "";
+                 USVString      blockedURI = "";
+        required DOMString      violatedDirective;
         required DOMString      effectiveDirective;
         required DOMString      originalPolicy;
                  USVString      sourceFile = "";
                  DOMString      sample = "";
         required SecurityPolicyViolationEventDisposition disposition;
         required unsigned short statusCode;
-                 unsigned long  lineno = 0;
-                 unsigned long  colno = 0;
+                 unsigned long  lineNumber = 0;
+                 unsigned long  columnNumber = 0;
     };
   </pre>
-
-  The <dfn for="SecurityPolicyViolationEvent" attribute export>documentURI</dfn> attribute's
-  getter must return the value of the object's {{SecurityPolicyViolationEvent/documentURL}} property.
-
-  The <dfn for="SecurityPolicyViolationEvent" attribute export>blockedURI</dfn> attribute's
-  getter must return the value of the object's {{SecurityPolicyViolationEvent/blockedURL}} property.
-
-  The <dfn for="SecurityPolicyViolationEvent" attribute export>violatedDirective</dfn> attribute's
-  getter must return the value of the object's {{SecurityPolicyViolationEvent/effectiveDirective}} property.
-
-  The <dfn for="SecurityPolicyViolationEvent" attribute export>lineNumber</dfn> attribute's
-  getter must return the value of the object's {{SecurityPolicyViolationEvent/lineno}} property.
-
-  The <dfn for="SecurityPolicyViolationEvent" attribute export>columnNumber</dfn> attribute's
-  getter must return the value of the object's {{SecurityPolicyViolationEvent/colno}} property.
 
   <h3 id="deprecated-serialize-violation">
     Obtain the deprecated serialization of |violation|
@@ -1524,23 +1506,19 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   1.  Let |body| be a <a lt="ordered map">map</a> with its keys initialized as
       follows:
 
-      :   "`document-url`"
+      :   "`document-uri`"
       ::  The result of executing the <a>URL serializer</a> on |violation|'s
           <a for="violation">url</a>, with the `exclude fragment` flag set.
-      :   "`document-uri`"
-      ::  A copy of the "`document-url`" property, kept for historical reasons
       :   "`referrer`"
       ::  The result of executing the <a>URL serializer</a> on |violation|'s
           <a for="violation">referrer</a>, with the `exclude fragment` flag set.
-      :   "`blocked-url`"
+      :   "`blocked-uri`"
       ::  The result of executing the <a>URL serializer</a> on |violation|'s
           <a for="violation">resource</a>, with the `exclude fragment` flag set.
-      :   "`blocked-uri`"
-      ::  A copy of the "`blocked-url`" property, kept for historical reasons
       :   "`effective-directive`"
       ::  |violation|'s <a for="violation">effective directive</a>
       :   "`violated-directive`"
-      ::  A copy of the "`effective-directive`" property, kept for historical reasons
+      ::  |violation|'s <a for="violation">effective directive</a>
       :   "`original-policy`"
       ::  The <a lt="serialized CSP">serialization</a> of |violation|'s
           <a for="violation">policy</a>
@@ -1565,23 +1543,13 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           the <a>URL serializer</a> on |violation|'s <a for="violation">source
           file</a>, with the `exclude fragment` flag set.
 
-      2.  Set |body|["`lineno`"] to |violation|'s
+      2.  Set |body|["`line-number`"] to |violation|'s
           <a for="violation">line number</a>.
 
-      3.  Set |body|["`line-number`"] to |violation|'s
-          <a for="violation">line number</a>.
-
-      4.  Set |body|["`colno`"] to |violation|'s
+      3.  Set |body|["`column-number`"] to |violation|'s
           <a for="violation">column number</a>.
 
-      5.  Set |body|["`column-number`"] to |violation|'s
-          <a for="violation">column number</a>.
-
-          Note: the "`line-number`" and "`column-number`" keys are
-          maintained for historical reasons and are duplicates of "`lineno`"
-          and "`colno`" respectively.
-
-  3.  Assert: If |body|["`blocked-url`"] is not "`inline`", then |body|["`sample`"]
+  3.  Assert: If |body|["`blocked-uri`"] is not "`inline`", then |body|["`sample`"]
       is the empty string.
 
   4.  Return the result of <a>serialize an infra value to JSON bytes</a> given
@@ -1628,16 +1596,18 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           that uses the {{SecurityPolicyViolationEvent}} interface at |target| with
           its attributes initialized as follows:
 
-          :  {{SecurityPolicyViolationEvent/documentURL}}
+          :  {{SecurityPolicyViolationEvent/documentURI}}
           ::  The result of executing the <a>URL serializer</a> on |violation|'s
               <a for="violation">url</a>, with the `exclude fragment` flag set.
           :  {{SecurityPolicyViolationEvent/referrer}}
           ::  The result of executing the <a>URL serializer</a> on |violation|'s
               <a for="violation">referrer</a>, with the `exclude fragment` flag set.
-          :  {{SecurityPolicyViolationEvent/blockedURL}}
+          :  {{SecurityPolicyViolationEvent/blockedURI}}
           ::  The result of executing the <a>URL serializer</a> on |violation|'s
               <a for="violation">resource</a>, with the `exclude fragment` flag set.
           :  {{SecurityPolicyViolationEvent/effectiveDirective}}
+          :: |violation|'s <a for="violation">effective directive</a>
+          :  {{SecurityPolicyViolationEvent/violatedDirective}}
           :: |violation|'s <a for="violation">effective directive</a>
           :  {{SecurityPolicyViolationEvent/originalPolicy}}
           ::  The <a lt="serialized CSP">serialization</a> of |violation|'s
@@ -1651,9 +1621,9 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
              it not `null` and the empty string otherwise.
           :  {{SecurityPolicyViolationEvent/statusCode}}
           :: |violation|'s <a for="violation">status</a>
-          :  {{SecurityPolicyViolationEvent/lineno}}
+          :  {{SecurityPolicyViolationEvent/lineNumber}}
           :: |violation|'s <a for="violation">line number</a>
-          :  {{SecurityPolicyViolationEvent/colno}}
+          :  {{SecurityPolicyViolationEvent/columnNumber}}
           :: |violation|'s <a for="violation">column number</a>
           :  {{SecurityPolicyViolationEvent/sample}}
           :: |violation|'s <a for="violation">sample</a>
@@ -1666,6 +1636,10 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
           can be captured on its way into, and will bubble its way out of a shadow
           tree. {{Event/target}}, et al will be automagically scoped correctly for
           the main tree.
+
+          Note: Both {{SecurityPolicyViolationEvent/effectiveDirective}} and
+          {{SecurityPolicyViolationEvent/violatedDirective}} are the same value.
+          This is intentional to maintain backwards compatibility.
 
       4.  If |violation|'s <a for="violation">policy</a>'s <a for="policy">directive
           set</a> contains a <a>directive</a> named "<a>`report-uri`</a>"


### PR DESCRIPTION
As discussed in #498, this change reverts #353 since it was never implemented by vendors.

Moreover, this change restores the `violatedDirective` property of `SecurityPolicyViolationEventInit`.