### PR TITLE
Clarify what the hash in the unsafe-hashes example refers to

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4781,7 +4781,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
       </pre>
 
       Rather than reducing security by specifying "`'unsafe-inline'`", they decide to use
-      "`'unsafe-hashes'`" along with a hash source expression, as follows:
+      "`'unsafe-hashes'`" along with a hash source expression corresponding to `doSubmit()`, as follows:
 
       <pre>
         <a http-header>Content-Security-Policy</a>:  <a>script-src</a> <a grammar>'unsafe-hashes'</a> 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='


### PR DESCRIPTION
Maybe it's just me, but I was confused about this on my first read through this example. I thought the hash was there as an example of how to stack this with other CSP directives and didn't realize that it was the hash of the contents of the attribute.

Of course, that's key to why `unsafe-hashes` is better than `unsafe-inline` :)