### PR TITLE
Enforce build success in github actions

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          BUILD_FAIL_ON: nothing
-          VALIDATE_LINKS: false
-          VALIDATE_MARKUP: true
+          BUILD_FAIL_ON: everything
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0170.html
           W3C_BUILD_OVERRIDE: |


### PR DESCRIPTION
I've noticed that the build check on PRs always succeeds since in the github action we set `BUILD_FAIL_ON: nothing`. Since main is building without errors, I'd say we should enforce that also for PRs.