### PR TITLE
[CSP] Remove outdated comment about workers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -311,8 +311,6 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
          if not present (which likewise defers to `script-src` and
          eventually `default-src`).
 
-      3. Dedicated workers now always inherit their creator's policy.
-
   3.  The URL matching algorithm now treats insecure schemes and ports as
       matching their secure variants. That is, the source expression
       `http://example.com:80` will match both `http://example.com:80` and


### PR DESCRIPTION
This removes an outdated line in the Introduction saying that dedicated workers inherit their creator's policy, since this is no longer true (cf. also https://github.com/w3c/webappsec-csp/issues/336)