### PR TITLE
Fix violation's resource for eval violations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1399,7 +1399,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
               1.  Let |violation| be the result of executing [[#create-violation-for-global]] on
                   |global|, |policy|, and "`script-src`".
 
-              2.  Set |violation|'s [=violation/resource=] to "`inline`".
+              2.  Set |violation|'s [=violation/resource=] to "`eval`".
 
               3.  If |source-list| [=list/contains=] the expression
                   "<a grammar>`'report-sample'`</a>", then set |violation|'s [=violation/sample=] to


### PR DESCRIPTION
BlockedURI for eval violations should be `eval`, not `inline`. This is also tested in WPTs: https://wpt.fyi/results/content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report.html?label=experimental&label=master&aligned