### PR TITLE
Introduce "Strip URL for use in reports".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1648,9 +1648,6 @@ this algorithm returns normally if compilation is allowed, and throws a
   1. Return |url|'s <a for="url">scheme</a>, if it is not one of:
      - "`http`"
      - "`https`"
-     - "`ftp`"
-     - "`ws`"
-     - "`wss`"
 
   2. Set |url|’s <a for="url">fragment</a> to the empty string.
 

--- a/index.bs
+++ b/index.bs
@@ -1577,8 +1577,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   1. Assert: |resource| is a {{URL}} or a [=string=].
 
-  2. If |resource| is a {{URL}}, return the result of executing the <a>URL
-     serializer</a> on |resource|, with the `exclude fragment` flag set.
+  2. If |resource| is a {{URL}}, return the result of executing [[#strip-url-for-use-in-reports]] on
+     |resource|.
 
   3. Return |resource|.
 
@@ -1594,11 +1594,11 @@ this algorithm returns normally if compilation is allowed, and throws a
       follows:
 
       :   "`document-uri`"
-      ::  The result of executing the <a>URL serializer</a> on |violation|'s
-          <a for="violation">url</a>, with the `exclude fragment` flag set.
+      ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+          <a for="violation">url</a>.
       :   "`referrer`"
-      ::  The result of executing the <a>URL serializer</a> on |violation|'s
-          <a for="violation">referrer</a>, with the `exclude fragment` flag set.
+      ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+          <a for="violation">referrer</a>.
       :   "`blocked-uri`"
       ::  The result of executing [[#obtain-violation-blocked-uri]] on |violation|'s
           <a for="violation">resource</a>.
@@ -1626,9 +1626,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   2.  If |violation|'s <a for="violation">source file</a> is not `null`:
 
-      1.  Set |body|["`source-file`"] to the result of executing
-          the <a>URL serializer</a> on |violation|'s <a for="violation">source
-          file</a>, with the `exclude fragment` flag set.
+      1.  Set |body|["`source-file`'] to the result of executing [[#strip-url-for-use-in-reports]]
+          on |violation|'s <a for="violation">source file</a>.
 
       2.  Set |body|["`line-number`"] to |violation|'s
           <a for="violation">line number</a>.
@@ -1641,6 +1640,31 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   4.  Return the result of <a>serialize an infra value to JSON bytes</a> given
       «[ "csp-report" → body ]».
+
+  <h3 id="strip-url-for-use-in-reports" algorithm>Strip URL for use in reports</h3>
+  Given a {{URL}} (|url|), this algorithm returns a string representing the URL for use in violation
+  reports:
+
+  1. If |url| is null, return the empty string.
+
+  2. If |url| is not a valid {{URL}}, return the empty string;
+
+  3. If |url|'s <a for="url">scheme</a> is 'file', return 'file';
+
+     Note: file: URLs leak interesting information through pathnames, like the user's local username
+     and their download folder. They aren't included in reports.
+
+  4. If |url|'s <a for="url">scheme</a> is 'data', return 'data';
+
+     Note: data URLs can be huge. They aren't included in reports.
+
+  5. Set |url|’s <a for="url">fragment</a> to the empty string.
+
+  6. Set |url|’s <a for="url">username</a> to the empty string.
+
+  7. Set |url|’s <a for="url">password</a> to the empty string.
+
+  8. Return the result of executing the <a>URL serializer</a> on |url|.
 
   <h3 id="report-violation" algorithm>
     Report a |violation|
@@ -1684,11 +1708,11 @@ this algorithm returns normally if compilation is allowed, and throws a
           its attributes initialized as follows:
 
           :  {{SecurityPolicyViolationEvent/documentURI}}
-          ::  The result of executing the <a>URL serializer</a> on |violation|'s
-              <a for="violation">url</a>, with the `exclude fragment` flag set.
+          ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+              <a for="violation">url</a>.
           :  {{SecurityPolicyViolationEvent/referrer}}
-          ::  The result of executing the <a>URL serializer</a> on |violation|'s
-              <a for="violation">referrer</a>, with the `exclude fragment` flag set.
+          ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+              <a for="violation">referrer</a>.
           :  {{SecurityPolicyViolationEvent/blockedURI}}
           ::  The result of executing [[#obtain-violation-blocked-uri]] on |violation|'s
               <a for="violation">resource</a>.
@@ -1702,10 +1726,8 @@ this algorithm returns normally if compilation is allowed, and throws a
           :  {{SecurityPolicyViolationEvent/disposition}}
           :: |violation|'s <a for="violation">disposition</a>
           :  {{SecurityPolicyViolationEvent/sourceFile}}
-          :: The result of executing the <a>URL serializer</a> on |violation|'s
-             <a for="violation">source file</a>, with the `exclude fragment`
-             flag set if the |violation|'s <a for="violation">source file</a>
-             it not `null` and the empty string otherwise.
+          ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+              <a for="violation">source file</a>.
           :  {{SecurityPolicyViolationEvent/statusCode}}
           :: |violation|'s <a for="violation">status</a>
           :  {{SecurityPolicyViolationEvent/lineNumber}}
@@ -1797,12 +1819,12 @@ this algorithm returns normally if compilation is allowed, and throws a
               follows:
 
               :   {{CSPViolationReportBody/documentURL}}
-              ::  The result of executing the <a>URL serializer</a> on |violation|'s
-                  <a for="violation">url</a>, with the `exclude fragment` flag set.
+              ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+                  <a for="violation">url</a>.
 
               :   {{CSPViolationReportBody/referrer}}
-              ::  The result of executing the <a>URL serializer</a> on |violation|'s
-                  <a for="violation">referrer</a>, with the `exclude fragment` flag set.
+              ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+                  <a for="violation">referrer</a>.
 
               :   {{CSPViolationReportBody/blockedURL}}
               ::  The result of executing [[#obtain-violation-blocked-uri]] on |violation|'s
@@ -1816,11 +1838,8 @@ this algorithm returns normally if compilation is allowed, and throws a
                   <a for="violation">policy</a>.
 
               :   {{CSPViolationReportBody/sourceFile}}
-              ::  The result of executing the <a>URL serializer</a> on
-                  |violation|'s <a for="violation">source file</a>, with the
-                  `exclude fragment` flag set, if |violation|'s
-                  <a for="violation">source file</a> is not null, or null
-                  otherwise.
+              ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
+                  <a for="violation">source file</a>.
 
               :   {{CSPViolationReportBody/sample}}
               ::  |violation|'s <a for="violation">sample</a>.

--- a/index.bs
+++ b/index.bs
@@ -1645,24 +1645,20 @@ this algorithm returns normally if compilation is allowed, and throws a
   Given a [=/URL=] (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
-  1. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
+  1. Return |url|'s <a for="url">scheme</a>, if it is not one of:
+     - "`http`"
+     - "`https`"
+     - "`ftp`"
+     - "`ws`"
+     - "`wss`"
 
-     Note: As of 2021, we are not entirely sure why this is done. Some argue that file: URLs leak
-     interesting information through pathnames, like the user's local username and their download
-     folder. However, those are "pre-redirect" URLs, so the document already has access to this
-     information.
+  2. Set |url|’s <a for="url">fragment</a> to the empty string.
 
-  2. If |url|'s <a for="url">scheme</a> is "`data`", return "`data`";
+  3. Set |url|’s <a for="url">username</a> to the empty string.
 
-     Note: data: URLs can be huge. They aren't included in reports.
+  4. Set |url|’s <a for="url">password</a> to the empty string.
 
-  3. Set |url|’s <a for="url">fragment</a> to the empty string.
-
-  4. Set |url|’s <a for="url">username</a> to the empty string.
-
-  5. Set |url|’s <a for="url">password</a> to the empty string.
-
-  6. Return the result of executing the <a>URL serializer</a> on |url|.
+  5. Return the result of executing the <a>URL serializer</a> on |url|.
 
   <h3 id="report-violation" algorithm>
     Report a |violation|

--- a/index.bs
+++ b/index.bs
@@ -1642,7 +1642,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       «[ "csp-report" → body ]».
 
   <h3 id="strip-url-for-use-in-reports" algorithm>Strip URL for use in reports</h3>
-  Given a [=/URL=]} (|url|), this algorithm returns a string representing the URL for use in violation
+  Given a [=/URL=] (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
   1. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";

--- a/index.bs
+++ b/index.bs
@@ -1645,26 +1645,22 @@ this algorithm returns normally if compilation is allowed, and throws a
   Given a {{URL}} (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
-  1. If |url| is null, return the empty string.
-
-  2. If |url| is not a valid {{URL}}, return the empty string;
-
-  3. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
+  1. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
 
      Note: file: URLs leak interesting information through pathnames, like the user's local username
      and their download folder. They aren't included in reports.
 
-  4. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
+  2. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
 
      Note: data URLs can be huge. They aren't included in reports.
 
-  5. Set |url|’s <a for="url">fragment</a> to the empty string.
+  3. Set |url|’s <a for="url">fragment</a> to the empty string.
 
-  6. Set |url|’s <a for="url">username</a> to the empty string.
+  4. Set |url|’s <a for="url">username</a> to the empty string.
 
-  7. Set |url|’s <a for="url">password</a> to the empty string.
+  5. Set |url|’s <a for="url">password</a> to the empty string.
 
-  8. Return the result of executing the <a>URL serializer</a> on |url|.
+  6. Return the result of executing the <a>URL serializer</a> on |url|.
 
   <h3 id="report-violation" algorithm>
     Report a |violation|
@@ -1727,7 +1723,8 @@ this algorithm returns normally if compilation is allowed, and throws a
           :: |violation|'s <a for="violation">disposition</a>
           :  {{SecurityPolicyViolationEvent/sourceFile}}
           ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
-              <a for="violation">source file</a>.
+              <a for="violation">source file</a>, if |violation|'s
+              <a for="violation">source file</a> is not null, or null otherwise.
           :  {{SecurityPolicyViolationEvent/statusCode}}
           :: |violation|'s <a for="violation">status</a>
           :  {{SecurityPolicyViolationEvent/lineNumber}}
@@ -1839,7 +1836,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
               :   {{CSPViolationReportBody/sourceFile}}
               ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
-                  <a for="violation">source file</a>.
+                  <a for="violation">source file</a>, if |violation|'s
+                  <a for="violation">source file</a> is not null, or null otherwise.
 
               :   {{CSPViolationReportBody/sample}}
               ::  |violation|'s <a for="violation">sample</a>.

--- a/index.bs
+++ b/index.bs
@@ -1645,9 +1645,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   Given a [=/URL=] (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
-  1. Return |url|'s <a for="url">scheme</a>, if it is not one of:
-     - "`http`"
-     - "`https`"
+  1. If |url|'s <a for="url">scheme</a> is not an <a>HTTP(S) scheme</a>,
+     then return |url|'s <a for="url">scheme</a>.
 
   2. Set |url|’s <a for="url">fragment</a> to the empty string.
 

--- a/index.bs
+++ b/index.bs
@@ -1649,12 +1649,12 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   2. If |url| is not a valid {{URL}}, return the empty string;
 
-  3. If |url|'s <a for="url">scheme</a> is 'file', return 'file';
+  3. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
 
      Note: file: URLs leak interesting information through pathnames, like the user's local username
      and their download folder. They aren't included in reports.
 
-  4. If |url|'s <a for="url">scheme</a> is 'data', return 'data';
+  4. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
 
      Note: data URLs can be huge. They aren't included in reports.
 

--- a/index.bs
+++ b/index.bs
@@ -1575,9 +1575,9 @@ this algorithm returns normally if compilation is allowed, and throws a
   Given a violation's <a>resource</a> (|resource|), this algorithm returns a
   [=string=], to be used as the blocked URI field for violation reports.
 
-  1. Assert: |resource| is a {{URL}} or a [=string=].
+  1. Assert: |resource| is a [=/URL=] or a [=string=].
 
-  2. If |resource| is a {{URL}}, return the result of executing [[#strip-url-for-use-in-reports]] on
+  2. If |resource| is a [=/URL=], return the result of executing [[#strip-url-for-use-in-reports]] on
      |resource|.
 
   3. Return |resource|.
@@ -1642,17 +1642,19 @@ this algorithm returns normally if compilation is allowed, and throws a
       «[ "csp-report" → body ]».
 
   <h3 id="strip-url-for-use-in-reports" algorithm>Strip URL for use in reports</h3>
-  Given a {{URL}} (|url|), this algorithm returns a string representing the URL for use in violation
+  Given a [=/URL=]} (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
   1. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
 
-     Note: file: URLs leak interesting information through pathnames, like the user's local username
-     and their download folder. They aren't included in reports.
+     Note: As of 2021, we are not entirely sure why this is done. Some argue that file: URLs leak
+     interesting information through pathnames, like the user's local username and their download
+     folder. However, those are "pre-redirect" URLs, so the document already has access to this
+     information.
 
-  2. If |url|'s <a for="url">scheme</a> is "`file`", return "`file`";
+  2. If |url|'s <a for="url">scheme</a> is "`data`", return "`data`";
 
-     Note: data URLs can be huge. They aren't included in reports.
+     Note: data: URLs can be huge. They aren't included in reports.
 
   3. Set |url|’s <a for="url">fragment</a> to the empty string.
 


### PR DESCRIPTION
Introduce "Strip URL for use in reports".

Omit informations from URLs in reports for:
- `blockedURI`
- `document-uri`
- `referrer`
- `source-file`

This is the de-facto standard, implemented in:
- [Chrome] with `StripURLForUseInReports(...)`
- [Firefox] with `StripURIForReporting(...)`
- [Safari] with `deprecatedURLForReporting(...)`

The 3 implementations differ slightly. This patch proposes making
it part of the specification.

The original goal was to address this [user's need], with this
[chrome's patch] but we decided to use an allow-list of scheme
instead, making it impossible to address.


See also related [firefox issue] and [webappsec-csp issue].

[Chrome]: https://source.chromium.org/search?q=StripURLForUseInReport
[Firefox]: https://searchfox.org/mozilla-central/search?q=StripURIForReporting
[Safari]: https://github.com/WebKit/WebKit/blob/eea907e63be4676ad5cc56cabe4d00edf109b398/Source/WebCore/page/csp/ContentSecurityPolicy.cpp#L716
[Chrome's patch]: https://chromium-review.googlesource.com/c/chromium/src/+/3263879
[user's need]: https://bugs.chromium.org/p/chromium/issues/detail?id=1264789
[firefox issue]: https://bugzilla.mozilla.org/show_bug.cgi?id=1705523
[webappsec-csp issue]: https://github.com/w3c/webappsec-csp/issues/489

+CC @Rob--W: Would you have an suggestions?
+CC @mikewest. Could you PTAL?
+CC @antosart FYI.