### PR TITLE
Add ['wss', 'ws'] in "Strip URLs for use in reports" allow-list.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1657,8 +1657,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   Given a [=/URL=] (|url|), this algorithm returns a string representing the URL for use in violation
   reports:
 
-  1. If |url|'s <a for="url">scheme</a> is not an <a>HTTP(S) scheme</a>,
-     then return |url|'s <a for="url">scheme</a>.
+  1. If |url|'s <a for="url">scheme</a> is not "`https`", "'http'", "`wss`" or "`ws`" then return
+     |url|'s <a for="url">scheme</a>.
 
   2. Set |url|’s <a for="url">fragment</a> to the empty string.
 


### PR DESCRIPTION
This is a follow-up to:
https://github.com/w3c/webappsec-csp/pull/527#issuecomment-975395259

This is needed, until browsers rewrite wss/ws URL in fetch before going
through CSP:
https://github.com/w3c/webappsec-csp

Associated WPT PR:
https://github.com/web-platform-tests/wpt/pull/31702