### PR TITLE
Editorial: Clarify the role of `'none'` in source lists.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3897,9 +3897,10 @@ this algorithm returns normally if compilation is allowed, and throws a
       as opposed to `script-src host1`) is equivalent to a source list containing `'none'`,
       and will not match any URL.
       
-      Note: `'none'` only has effect when it's the only item in a source list.
-      « `'none'` » does not match any URL. A list consisting of « `'none'`,
-      `https://example.com` », on the other hand, would match `https://example.com/`.
+      Note: The `'none'` keyword has no effect when other source expressions are
+      present. That is, the list « `'none'` » does not match any URL. A list consisting
+      of « `'none'`, `https://example.com` », on the other hand, would match
+      `https://example.com/`.
 
   4.  For each |expression| in |source list|:
 

--- a/index.bs
+++ b/index.bs
@@ -3889,13 +3889,17 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   2.  If |source list| is an empty list, return "`Does Not Match`".
 
-  3.  If |source list| contains a single item which is an <a>ASCII
+  3.  If |source list|'s [=list/size=] is 1, and |source list|[0] is an <a>ASCII
       case-insensitive</a> match for the string "`'none'`", return "`Does Not
       Match`".
 
       Note: An empty source list (that is, a directive without a value: `script-src`,
       as opposed to `script-src host1`) is equivalent to a source list containing `'none'`,
       and will not match any URL.
+      
+      Note: `'none'` only has effect when it's the only item in a source list.
+      « `'none'` » does not match any URL. A list consisting of « `'none'`,
+      `https://example.com` », on the other hand, would match `https://example.com/`.
 
   4.  For each |expression| in |source list|:
 

--- a/index.bs
+++ b/index.bs
@@ -3887,7 +3887,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   1.  Assert: |source list| is not `null`.
 
-  2.  If |source list| is an empty list, return "`Does Not Match`".
+  2.  If |source list| [=list/is empty=], return "`Does Not Match`".
 
   3.  If |source list|'s [=list/size=] is 1, and |source list|[0] is an <a>ASCII
       case-insensitive</a> match for the string "`'none'`", return "`Does Not


### PR DESCRIPTION
See the Twitter thread around https://mobile.twitter.com/mikewest/status/1468469807209189378
for context.