### PR TITLE
[auto-publish] Fail only on link-error

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          BUILD_FAIL_ON: everything
+          BUILD_FAIL_ON: link-error
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0170.html
           W3C_BUILD_OVERRIDE: |


### PR DESCRIPTION
Using `fail-on=everything` in the github actions with spec-prod seems difficult to maintain, since changes to bikeshed can result in the spec not compiling anymore.