### PR TITLE
Remove callerRealm param from EnsureCSPDoesNotBlockStringCompilation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1405,16 +1405,18 @@ spec: WebAssembly-web-api-api; urlPrefix: https://webassembly.github.io/spec/web
   to determine whether such compilation ought to be blocked.
 
   <h4 id="can-compile-strings" algorithm dfn export>
-    EnsureCSPDoesNotBlockStringCompilation(|callerRealm|, |calleeRealm|, |source|)
+    EnsureCSPDoesNotBlockStringCompilation(|realm|, |source|)
   </h4>
 
-  Given two <a>realms</a> (<var ignore>callerRealm</var> and |calleeRealm|),
-  and a string (|source|), this algorithm returns normally if string compilation
-  is allowed, and throws an "`EvalError`" if not:
+  Given a <a>realm</a> (|realm|) and a string (|source|), this algorithm
+  returns normally if string compilation is allowed, and throws an "`EvalError`"
+  if not:
 
   1.  Let |result| be "`Allowed`".
 
-  2.  For each |policy| in |calleeRealm|'s [=global object/CSP list=]:
+  2.  Let |global| be |realm|'s [=Realm/global object=].
+
+  3.  For each |policy| in |global|'s [=global object/CSP list=]:
 
       1.  Let |source-list| be `null`.
 
@@ -1429,7 +1431,7 @@ spec: WebAssembly-web-api-api; urlPrefix: https://webassembly.github.io/spec/web
           then:
 
           1.  Let |violation| be the result of executing [[#create-violation-for-global]] on
-              |calleeRealm|, |policy|, and "`script-src`".
+              |global|, |policy|, and "`script-src`".
 
           2.  Set |violation|'s [=violation/resource=] to "`eval`".
 
@@ -1442,14 +1444,11 @@ spec: WebAssembly-web-api-api; urlPrefix: https://webassembly.github.io/spec/web
           5.  If |policy|'s [=policy/disposition=] is "`enforce`", then set |result| to
               "`Blocked`".
 
-  3.  If |result| is "`Blocked`", throw an `EvalError` exception.
+  4.  If |result| is "`Blocked`", throw an `EvalError` exception.
 
   ISSUE(tc39/ecma262#938): {{HostEnsureCanCompileStrings()}} does not include the string which is
   going to be compiled as a parameter. We'll also need to update HTML to pipe that value through
   to CSP.
-
-  Note: The parameter |callerRealm| is ignored on purpose, see
-  <a href="https://github.com/w3c/webappsec-csp/issues/438">Issue 438</a>.
 
 <h3 id="wasm-integration">Integration with WebAssembly</h3>
 


### PR DESCRIPTION
This PR cleans up the `EnsureCSPDoesNotBlockStringCompilation` algorithm removing the `callerRealm` parameter, which is not used.

See also #540  and #438.