### PR TITLE
Check for an EventTarget before dispatching violation events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1742,7 +1742,7 @@ this algorithm returns normally if compilation is allowed, and throws a
           2.  If |target| is a {{Window}}, set |target| to |target|'s <a>associated
               `Document`</a>.
 
-      3.  If |target| is an {{EventTarget}}, <a>fire an event</a> named
+      3.  If |target| [=implements=] {{EventTarget}}, <a>fire an event</a> named
           `securitypolicyviolation` that uses the {{SecurityPolicyViolationEvent}}
           interface at |target| with its attributes initialized as follows:
 


### PR DESCRIPTION
Inside "Report a violation", `target` can be a WorkletGlobalScope, which is not an EventTarget. In this case, we cannot fire a violation event.