### PR TITLE
Fix build

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -100,13 +100,10 @@ spec: RFC5234; urlPrefix: https://tools.ietf.org/html/rfc5234
 spec: RFC5890; urlPrefix: https://tools.ietf.org/html/rfc5890
   type: dfn
     text: label; url: section-2.2
-spec: RFC7230; urlPrefix: https://tools.ietf.org/html/rfc7230
+spec: RFC9110; urlPrefix: https://tools.ietf.org/html/rfc9110
   type: grammar
-    text: BWS; url: section-3.2.3
-    text: OWS; url: section-3.2.3
-    text: RWS; url: section-3.2.3
-    text: quoted-string; url: section-3.2.6
-    text: token; url: section-3.2.6
+    text: OWS; url: section-5.6.3
+    text: token; url: section-5.6.2
 spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   type: dfn
     url: section-3
@@ -135,6 +132,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     text: content security policy state; url: attr-meta-http-equiv-content-security-policy
     text: create and initialize a new document object; url: initialise-the-document-object
     text: initializing a new Document object; url: initialise-the-document-object
+    text: prepare the script element; url: prepare-the-script-element
 
 spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   type: grammar
@@ -394,7 +392,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   This document uses ABNF grammar to specify syntax, as defined in [[!RFC5234]]. It also relies on
   the `#rule` ABNF extension defined in
-  <a href="https://tools.ietf.org/html/rfc7230#section-7">Section 7</a> of [[!RFC7230]],
+  <a href="https://tools.ietf.org/html/rfc9110#section-5.6.1">Section 5.6.1</a> of [[!RFC9110]],
   with the modification that <a grammar>OWS</a> is replaced with
   <a grammar>optional-ascii-whitespace</a>. That is, the `#rule` used in this
   document is defined as:
@@ -461,7 +459,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   <pre dfn-type="grammar" link-type="grammar">
     <dfn>serialized-policy-list</dfn> = 1#<a>serialized-policy</a>
-                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; The '#' rule is the one defined in section 5.6.1 of RFC 9110
                         ; but it incorporates the modifications specified
                         ; in section 2.1 of this document.
   </pre>
@@ -892,7 +890,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   <pre>
     Content-Security-Policy = 1#<a grammar>serialized-policy</a>
-                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; The '#' rule is the one defined in section 5.6.1 of RFC 9110
                         ; but it incorporates the modifications specified
                         ; in section 2.1 of this document.
   </pre>
@@ -927,7 +925,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   <pre>
     Content-Security-Policy-Report-Only = 1#<a grammar>serialized-policy</a>
-                        ; The '#' rule is the one defined in section 7 of RFC 7230
+                        ; The '#' rule is the one defined in section 5.6.1 of RFC 9110
                         ; but it incorporates the modifications specified
                         ; in section 2.1 of this document.
   </pre>
@@ -1133,7 +1131,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   4.  [[#run-document-csp-initialization]] is called during the <a>create and initialize a
       new `Document` object</a> algorithm.
 
-  5.  [[#should-block-inline]] is called during the <a>prepare a script</a> and
+  5.  [[#should-block-inline]] is called during the <a>prepare the script element</a> and
       <a>update a `style` block</a> algorithms in order to determine whether or
       not an inline script or style block is allowed to execute/render.
 


### PR DESCRIPTION
This PR replaces RFC7230 (which is obsolete) with RFC9110 and replaces "prepare a script" with "prepare the script element" after https://github.com/whatwg/html/pull/7876.