### PR TITLE
Return correct effective directive for worklets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4494,6 +4494,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
       : "`script`"
       : "`xslt`"
+      : "`audioworklet`"
+      : "`paintworklet`"
       ::
         1. Return `script-src-elem`.
 


### PR DESCRIPTION
The request destinations "audioworklet" and "paintworklet" where missing in "Get the effective directive for request". 

Fixes #554.