### PR TITLE
Update broken Wasm links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -144,14 +144,17 @@ spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
     text: new WebAssembly.Module(); url: #dom-module-module
     text: WebAssembly.compile(); url: #dom-webassembly-compile
     text: WebAssembly.instantiate(); url: #dom-webassembly-instantiate
-    text: HostEnsureCanCompileWasmBytes(); url:#dom-host-ensure-can-compile-wasm-bytes
+  type: exception
+    text: WebAssembly.CompileError; url: #exceptiondef-compileerror
 
-spec: WebAssembly-web-api-api; urlPrefix: https://webassembly.github.io/spec/web-api/
+spec: WebAssembly-web-api; urlPrefix: https://webassembly.github.io/spec/web-api/
   type: method
     text: WebAssembly.compileStreaming(); url: #dom-webassembly-compilestreaming
     text: WebAssembly.instantiateStreaming(); url: #dom-webassembly-instantiatestreaming
-  type: exception
-    text: WebAssembly.CompileError; url: #exceptiondef-compileerror
+
+spec: WebAssembly-js-csp-proposal; urlPrefix: https://webassembly.github.io/content-security-policy/js-api/
+  type: method
+    text: HostEnsureCanCompileWasmBytes(); url:#host-ensure-can-compile-wasm-bytes
 
 spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   type:dfn


### PR DESCRIPTION
It appears that since Wasm-related API definitions were merged parts of the Wasm spec have moved around a bit. This PR contains the following changes:

* Renamed "WebAssembly-web-api-api" to "WebAssembly-web-api" as the extra "-api" appeared to be a typo.
* Moved the definition of `WebAssembly.CompileError` from the `WebAssembly-web-api` spec to the `WebAssembly-js-api` spec as `CompileError` is not defined in the Web API spec.
* Added the `WebAssembly-js-csp-proposal` spec. The content of this spect is associated with the [WebAssembly/content-security-policy](https://github.com/WebAssembly/content-security-policy) repo, a fork of the main Wasm spec repo that contains work-in-progress changes to better integrate CSP into the Wasm spec.
* Moved `HostEnsureCanCompileWasmBytes()` from `WebAssembly-web-api` to `WebAssembly-js-csp-proposal` because this abstract operation is not defined in the primary spec but is present in the [content-security-policy](https://github.com/WebAssembly/content-security-policy) fork. 