### PR TITLE
Add support for the webidentity destination

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4399,6 +4399,10 @@ this algorithm returns normally if compilation is allowed, and throws a
       ::
         1. Return `worker-src`.
 
+      : "`webidentity`"
+      ::
+        1. Return `connect-src`.
+
   4.  Return `null`.
 
   <h4 id="effective-directive-for-inline-check" algorithm>


### PR DESCRIPTION
This is being added to fetch in https://github.com/whatwg/fetch/pull/1495

See also issue fedidcg/FedCM#353 and fedidcg/FedCM#320

Tests are in https://github.com/web-platform-tests/wpt/blob/master/credential-management/fedcm-network-requests.sub.https.html#L139