### PR TITLE
Define securitypolicyviolation event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1740,7 +1740,7 @@ this algorithm returns normally if compilation is allowed, and throws a
               `Document`</a>.
 
       3.  If |target| [=implements=] {{EventTarget}}, <a>fire an event</a> named
-          <a event for=HTMLElement>securitypolicyviolation</a> that uses the {{SecurityPolicyViolationEvent}}
+          <dfn event for="GlobalEventHandlers,WorkerGlobalScope">securitypolicyviolation</dfn> that uses the {{SecurityPolicyViolationEvent}}
           interface at |target| with its attributes initialized as follows:
 
           :  {{SecurityPolicyViolationEvent/documentURI}}


### PR DESCRIPTION
Following discussions in https://github.com/whatwg/html/issues/8340, the events index in the HTML spec will be restricted to event types that gets fired within the HTML spec. The `securitypolicyviolation` event will be dropped from the index as a result.

This turns the mention of `securitypolicyviolation` into a proper event type definition so that other specs (including the HTML spec to map `onsecuritypolicyviolation` to `securitypolicyviolation`) can reference it.

This also defines the event targets more precisely. In HTML, the event was defined as firing on `HTMLElement`. In practice, if I read the spec correcty, the event fires on interfaces that derive from `GlobalEventHandlers` in general (`HTMLElement`, `MathMLElement`, `SVGElement`, `Document`), and on `WorkerGlobalScope`.

I note that the definition of `WorkerGlobalScope` should probably also be amended in HTML to add an `onsecuritypolicyviolation` IDL attribute, as was done for `GlobalEventHandlers`.

The definition of "policy" suggests that the event could in theory also fire on `WorkletGlobalScope` but that interface does not inherit from `EventTarget`. That seems to be adequately covered by the "Report a violation" algorithm. If firing at `WorkletGlobalScope` is also expected, more changes would be needed.