### PR TITLE
Fix validation of CSS markup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -225,7 +225,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   a[href^="http:"]:after {
     color: red;
-    content: "🔓";
+    content: "\1F512";  /* A lock symbol: 🔓. */
   }
 
   .wip {


### PR DESCRIPTION
It looks like the W3C markup validation tooling does not like anymore literal unicode in CSS (example https://github.com/w3c/webappsec-csp/actions/runs/3161943169/jobs/5149960278). While we should fix the validator, this is a workaround to make the CSP spec validate anyway.