### PR TITLE
Fix for each iterations referring to infra

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -469,7 +469,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     1.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
         of |source|, and a [=policy/disposition=] of |disposition|.
 
-    2.  For each |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
+    2.  <a for=list>For each</a> |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
         the U+003B SEMICOLON character (`;`):
 
         1.  [=Strip leading and trailing ASCII whitespace=] from |token|.
@@ -552,7 +552,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
         |response|'s [=response/header list=], with a [=policy/source=] of "`header`", and a
         [=policy/disposition=] of "`report`".
 
-    3.  For each |policy| in |policies|:
+    3.  <a for=list>For each</a> |policy| of |policies|:
 
         1.  Set |policy|'s [=policy/self-origin=] to |response|'s [=response/url=]'s
             [=url/origin=].
@@ -1027,7 +1027,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   1.  Let |CSP list| be |request|'s [=request/policy container=]'s [=policy container/CSP list=].
 
-  2.  For each |policy| in |CSP list|:
+  2.  <a for=list>For each</a> |policy| of |CSP list|:
 
       1.  If |policy|'s <a for="policy">disposition</a> is "`enforce`",
           then skip to the next |policy|.
@@ -1051,7 +1051,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   2.  Let |result| be "`Allowed`".
 
-  3.  For each |policy| in |CSP list|:
+  3.  <a for=list>For each</a> |policy| of |CSP list|:
 
       1.  If |policy|'s <a for="policy">disposition</a> is "`report`",
           then skip to the next |policy|.
@@ -1080,9 +1080,9 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   2.  Let |result| be "`Allowed`".
 
-  3.  For each |policy| in |CSP list|:
+  3.  <a for=list>For each</a> |policy| of |CSP list|:
 
-      1.  For each |directive| in |policy|:
+      1.  <a for=set>For each</a> |directive| of |policy|:
 
           1.  If the result of executing |directive|'s
               <a for="directive">post-request check</a> is "`Blocked`", then:
@@ -1162,10 +1162,10 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   Given a {{Document}} (|document|), the user agent performs the following
   steps in order to initialize CSP for |document|:
 
-  1. For each |policy| in |document|'s [=Document/policy container=]'s
+  1. <a for=list>For each</a> |policy| of |document|'s [=Document/policy container=]'s
      [=policy container/CSP list=]:
 
-      1.  For each |directive| in |policy|:
+      1.  <a for=set>For each</a> |directive| of |policy|:
 
           1.  Execute |directive|'s <a for="directive">initialization</a>
               algorithm on |document|, and assert: its returned value is
@@ -1203,10 +1203,10 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
     2.  Let |result| be "`Allowed`".
 
-    3.  For each |policy| in |element|'s {{Document}}'s <a for="/">global object</a>'s
+    3.  <a for=list>For each</a> |policy| of |element|'s {{Document}}'s <a for="/">global object</a>'s
         <a for="global object">CSP list</a>:
 
-        1.  For each |directive| in |policy|'s <a for="policy">directive set</a>:
+        1.  <a for=set>For each</a> |directive| of |policy|'s <a for="policy">directive set</a>:
 
             1.  If |directive|'s <a for="directive">inline check</a> returns
                 "`Allowed`" when executed upon |element|, |type|, |policy| and |source|,
@@ -1249,10 +1249,10 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |navigation request|'s <a for="request">policy container</a>'s
+    2.  <a for=list>For each</a> |policy| of |navigation request|'s <a for="request">policy container</a>'s
         <a for="policy container">CSP list</a>:
 
-        1.  For each |directive| in |policy|:
+        1.  <a for=set>For each</a> |directive| of |policy|:
 
             1.  If |directive|'s <a for="directive">pre-navigation check</a>
                 returns "`Allowed`" when executed upon |navigation request|,
@@ -1274,11 +1274,11 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     3.  If |result| is "`Allowed`", and if |navigation request|'s
         <a for="request">current URL</a>'s <a for="url">scheme</a> is `javascript`:
 
-        1.  For each |policy| in |navigation request|'s <a for="request">client</a>'s
+        1.  <a for=list>For each</a> |policy| of |navigation request|'s <a for="request">client</a>'s
             <a for="environment settings object">global object</a>'s
             <a for="global object">CSP list</a>:
 
-            1.  For each |directive| in |policy|:
+            1.  <a for=set>For each</a> |directive| of |policy|:
 
                 1.  Let |directive-name| be the result of executing
                     [[#effective-directive-for-inline-check]] on |type|.
@@ -1318,12 +1318,12 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |response CSP list|:
+    2.  <a for=list>For each</a> |policy| of |response CSP list|:
 
         Note: Some directives (like <a>frame-ancestors</a>) allow a |response|'s
         <a>Content Security Policy</a> to act on the navigation.
 
-        1.  For each |directive| in |policy|:
+        1.  <a for=set>For each</a> |directive| of |policy|:
 
             1.  If |directive|'s <a for="directive">navigation response check</a>
                 returns "`Allowed`" when executed upon |navigation request|, |type|,
@@ -1345,13 +1345,13 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
             5.  If |policy|'s <a for="policy">disposition</a> is "`enforce`", then
                 set |result| to "`Blocked`".
 
-    3.  For each |policy| in |navigation request|'s <a for="request">policy container</a>'s
+    3.  <a for=list>For each</a> |policy| of |navigation request|'s <a for="request">policy container</a>'s
         <a for="policy container">CSP list</a>:
 
         Note: Some directives in the |navigation request|'s context (like <a>frame-ancestors</a>)
         need the |response| before acting on the navigation.
 
-        1.  For each |directive| in |policy|:
+        1.  <a for=set>For each</a> |directive| of |policy|:
 
             1.  If |directive|'s <a for="directive">navigation response check</a>
                 returns "`Allowed`" when executed upon |navigation request|, |type|,
@@ -1385,9 +1385,9 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |global|'s [=global object/CSP list=]:
+    2.  <a for=list>For each</a> |policy| of |global|'s [=global object/CSP list=]:
 
-        1.  For each |directive| in |policy|:
+        1.  <a for=set>For each</a> |directive| of |policy|:
 
             1. Execute |directive|'s <a for="directive">initialization</a> algorithm on
                |global|. If its returned value is "`Blocked`", then set |result| to
@@ -1411,8 +1411,8 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   <ol class="algorithm">
     1.  Let |result| be "`Allowed`".
 
-    2.  For each |policy| in |global|'s [=global object/CSP list=]:
-          1.  For each |directive| in |policy|:
+    2.  <a for=list>For each</a> |policy| of |global|'s [=global object/CSP list=]:
+          1.  <a for=set>For each</a> |directive| of |policy|:
               1.  If |directive|'s <a for="directive">webrtc pre-connect check</a>
                   returns "`Allowed`", [=iteration/continue=].
 
@@ -1450,7 +1450,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   2.  Let |global| be |realm|'s [=realm/global object=].
 
-  3.  For each |policy| in |global|'s [=global object/CSP list=]:
+  3.  <a for=list>For each</a> |policy| of |global|'s [=global object/CSP list=]:
 
       1.  Let |source-list| be `null`.
 
@@ -1504,7 +1504,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
 2.  Let |result| be "`Allowed`".
 
-3.  For each |policy| in |global|'s [=global object/CSP list=]:
+3.  <a for=list>For each</a> |policy| of |global|'s [=global object/CSP list=]:
 
     1.  Let |source-list| be `null`.
 
@@ -1791,9 +1791,8 @@ this algorithm returns normally if compilation is allowed, and throws a
               <a for="policy">directive set</a> contains a <a>directive</a> named
               "<a>`report-to`</a>", skip the remaining substeps.
 
-          2.  For each |token| returned by <a lt="split a string on ASCII whitespace">
-              splitting a string on ASCII whitespace</a> with |directive|'s
-              <a for="directive">value</a> as the `input`.
+          2.  <a for=set>For each</a> |token| of |directive|'s
+              <a for="directive">value</a>:
 
               1.  Let |endpoint| be the result of executing the <a>URL parser</a>
                   with |token| as the input, and |violation|'s
@@ -3412,7 +3411,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   returns "`Allowed`" if |base| may be used as the value of a <{base}>
   element's <{base/href}> attribute, and "`Blocked`" otherwise:
 
-  1.  For each |policy| in |document|'s <a for="/">global object</a>'s
+  1.  <a for=list>For each</a> |policy| of |document|'s <a for="/">global object</a>'s
       <a for="global object">csp list</a>:
 
       1.  Let |source list| be `null`.
@@ -3721,7 +3720,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
           3.  Let |bypass due to integrity match| be `true`.
 
-          4.  For each |source| in |integrity sources|:
+          4.  <a for=set>For each</a> |source| of |integrity sources|:
 
               1.  If |directive|'s <a for="directive">value</a> does not
                   contain a <a>source expression</a> whose
@@ -3797,7 +3796,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   1.  Let |violates| be "`Does Not Violate`".
 
-  2.  For each |directive| in |policy|:
+  2.  <a for=set>For each</a> |directive| of |policy|:
 
       1.  Let |result| be the result of executing |directive|'s
           <a for="directive">pre-request check</a> on |request| and |policy|.
@@ -3819,7 +3818,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   2.  If |nonce| is the empty string, return "`Does Not Match`".
 
-  3.  For each |expression| in |source list|:
+  3.  <a for=set>For each</a> |expression| of |source list|:
 
       1.  If |expression| matches the <a grammar>`nonce-source`</a> grammar,
           and |nonce| is <a for="string" lt="is">identical to</a> |expression|'s
@@ -3879,7 +3878,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       of « `'none'`, `https://example.com` », on the other hand, would match
       `https://example.com/`.
 
-  4.  For each |expression| in |source list|:
+  4.  <a for=set>For each</a> |expression| of |source list|:
 
       1.  If [[#match-url-to-source-expression]] returns "`Matches`" when
           executed upon |url|, |expression|, |origin|, and |redirect count|, return
@@ -4118,7 +4117,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
         2.  Remove the final item from |path list A|.
 
-    8.  For each |piece A| in |path list A|:
+    8.  <a for=list>For each</a> |piece A| of |path list A|:
 
         1.  Let |piece B| be the next item in |path list B|.
 
@@ -4147,8 +4146,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   1.  If |element| does not have an attribute named "`nonce`", return "`Not
       Nonceable`".
 
-  2.  If |element| is a <{script}> element, then for each |attribute| in
-      |element|:
+  2.  If |element| is a <{script}> element, then <a for=list>for each</a> |attribute| of
+      |element|'s <a for=Element>attribute list</a>:
 
       1.  If |attribute|'s name is an <a>ASCII case-insensitive</a> match for
           the string "<code>&lt;script</code>" or the string
@@ -4191,7 +4190,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   1.  Let |allow all inline| be `false`.
 
-  2.  For each |expression| in |list|:
+  2.  <a for=set>For each</a> |expression| of |list|:
 
       1.  If |expression| matches the <a grammar>`nonce-source`</a> or
           <a grammar>`hash-source`</a> grammar, return "`Does Not Allow`".
@@ -4257,7 +4256,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   2.  If |type| is "`script`" or "`style`", and [[#is-element-nonceable]]
       returns "`Nonceable`" when executed upon |element|:
 
-      1.  For each |expression| in |list|:
+      1.  <a for=set>For each</a> |expression| of |list|:
 
           1.  If |expression| matches the <a grammar>`nonce-source`</a> grammar,
               and |element| has a <{htmlsvg-global/nonce}> attribute whose value
@@ -4269,7 +4268,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   3.  Let |unsafe-hashes flag| be `false`.
 
-  4.  For each |expression| in |list|:
+  4.  <a for=set>For each</a> |expression| of |list|:
 
       1.  If |expression| is an <a>ASCII case-insensitive</a> match for the
           <a grammar>`keyword-source`</a>
@@ -4283,7 +4282,7 @@ this algorithm returns normally if compilation is allowed, and throws a
           on the result of executing <a for="JavaScript string" data-lt="convert">JavaScript string converting</a>
           on |source|.
 
-      2.  For each |expression| in |list|:
+      2.  <a for=set>For each</a> |expression| of |list|:
 
           1.  If |expression| matches the <a grammar>`hash-source`</a> grammar:
 
@@ -4503,7 +4502,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   1.  Let |directive fallback list| be the result of executing [[#directive-fallback-list]]
       on |effective directive name|.
 
-  2.  For each |fallback directive| in |directive fallback list|:
+  2.  <a for=set>For each</a> |fallback directive| of |directive fallback list|:
 
       1.  If |directive name| is |fallback directive|, Return "`Yes`".
 


### PR DESCRIPTION
Fix iteration over directive's value, which is an ordered set (Fixes #577).
Add proper references to infra for all "for each" iterations.
Fix iteration over element's attribute list.