### PR TITLE
Fix link text for "run CSP initialization for a global object"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1381,7 +1381,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   </ol>
 
   <h4 id="run-global-object-csp-initialization" algorithm dfn export>
-    Run `CSP` initialization for a global object.
+    Run `CSP` initialization for a global object
   </h4>
 
   Given a <a for="/">global object</a> (|global|), the user agent performs the


### PR DESCRIPTION
Otherwise, references needed `.` at the end.