### PR TITLE
[editorial] Drop parentheses around algorithm variables

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -469,8 +469,8 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Parse a serialized CSP
   </h4>
 
-  To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=string=] (|serialized|), a
-  [=policy/source=] (|source|), and a [=policy/disposition=] (|disposition|), execute the
+  To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=string=] |serialized|, a
+  [=policy/source=] |source|, and a [=policy/disposition=] |disposition|, execute the
   following steps.
 
   This algorithm returns a [=Content Security Policy object=]. If |serialized| could not be
@@ -519,7 +519,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   </h4>
 
   To <dfn abstract-op>parse a serialized CSP list</dfn>, given a [=byte sequence=] or [=string=]
-  (|list|), a [=policy/source=] (|source|), and a [=policy/disposition=] (|disposition|), execute
+  |list|, a [=policy/source=] |source|, and a [=policy/disposition=] |disposition|, execute
   the following steps.
 
   This algorithm returns a [=list=] of [=Content Security Policy objects=]. If |list| cannot be
@@ -549,7 +549,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   </h4>
 
   To <dfn abstract-op>parse a response's Content Security Policies</dfn> given a <a>response</a>
-  (|response|):
+  |response|:
 
   <ol class="algorithm">
     1.  Let |policies| be the result of <a abstract-op lt="parse a serialized CSP list">parsing</a>
@@ -805,8 +805,8 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Create a violation object for |global|, |policy|, and |directive|
   </h4>
 
-  Given a <a for="/">global object</a> (|global|), a <a for="/">policy</a> (|policy|), and a
-  <a>string</a> (|directive|), the following algorithm creates a new <a>violation</a>
+  Given a <a for="/">global object</a> |global|, a <a for="/">policy</a> |policy|, and a
+  <a>string</a> |directive|, the following algorithm creates a new <a>violation</a>
   object, and populates it with an initial set of data:
 
   1.  Let |violation| be a new <a>violation</a> whose <a for="violation">global
@@ -843,7 +843,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Create a violation object for |request|, and |policy|.
   </h4>
 
-  Given a <a for="/">request</a> (|request|), a <a for="/">policy</a> (|policy|),
+  Given a <a for="/">request</a> |request|, a <a for="/">policy</a> |policy|,
   the following algorithm creates a new <a>violation</a> object,
   and populates it with an initial set of data:
 
@@ -1033,7 +1033,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Report Content Security Policy violations for |request|
   </h4>
 
-  Given a <a for="/">request</a> (|request|), this algorithm reports violations based
+  Given a <a for="/">request</a> |request|, this algorithm reports violations based
   on [=request/policy container=]'s [=policy container/CSP list=] "report only" policies.
 
   1.  Let |CSP list| be |request|'s [=request/policy container=]'s [=policy container/CSP list=].
@@ -1054,7 +1054,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Should |request| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a for="/">request</a> (|request|), this algorithm returns `Blocked` or `Allowed` and
+  Given a <a for="/">request</a> |request|, this algorithm returns `Blocked` or `Allowed` and
   reports violations based on |request|'s [=request/policy container=]'s
   [=policy container/CSP list=].
 
@@ -1083,7 +1083,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Should |response| to |request| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a>response</a> (|response|) and a <a for="/">request</a> (|request|), this algorithm
+  Given a <a>response</a> |response| and a <a for="/">request</a> |request|, this algorithm
   returns `Blocked` or `Allowed`, and reports violations based on |request|'s
   [=request/policy container=]'s [=policy container/CSP list=].
 
@@ -1170,7 +1170,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Run `CSP` initialization for a `Document`
   </h4>
 
-  Given a {{Document}} (|document|), the user agent performs the following
+  Given a {{Document}} |document|, the user agent performs the following
   steps in order to initialize CSP for |document|:
 
   1. <a for=list>For each</a> |policy| of |document|'s [=Document/policy container=]'s
@@ -1201,7 +1201,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Should |element|'s inline |type| behavior be blocked by Content Security Policy?
   </h4>
 
-  Given an {{Element}} (|element|), a string (|type|), and a string (|source|)
+  Given an {{Element}} |element|, a string |type|, and a string |source|
   this algorithm returns "`Allowed`" if the element is allowed to have inline
   definition of a particular type of behavior (script execution, style
   application, event handlers, etc.), and "`Blocked`" otherwise:
@@ -1253,7 +1253,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     by Content Security Policy?
   </h4>
 
-  Given a <a for="/">request</a> (|navigation request|) and a string (|type|, either
+  Given a <a for="/">request</a> |navigation request| and a string |type| (either
   "`form-submission`" or "`other`"), this algorithm return "`Blocked`" if the active policy blocks
   the navigation, and "`Allowed`" otherwise:
 
@@ -1320,8 +1320,8 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     in |target| be blocked by Content Security Policy?
   </h4>
 
-  Given a <a for="/">request</a> (|navigation request|), a <a>response</a> |navigation
-  response|, a [=/CSP list=] |response CSP list|, a string (|type|, either
+  Given a <a for="/">request</a> |navigation request|, a <a>response</a> |navigation
+  response|, a [=/CSP list=] |response CSP list|, a string |type| (either
   "`form-submission`" or "`other`"), and a <a>navigable</a> |target|, this algorithm
   returns "`Blocked`" if the active policy blocks the navigation, and "`Allowed`"
   otherwise:
@@ -1389,7 +1389,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Run `CSP` initialization for a global object
   </h4>
 
-  Given a <a for="/">global object</a> (|global|), the user agent performs the
+  Given a <a for="/">global object</a> |global|, the user agent performs the
   following steps in order to initialize CSP for |global|. This algorithm
   returns "`Allowed`" if |global| is allowed, and "`Blocked`" otherwise:
 
@@ -1416,7 +1416,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Should RTC connections be blocked for |global|?
   </h4>
 
-  Given a [=/global object=] (|global|), this algorithm returns "`Blocked`"
+  Given a [=/global object=] |global|, this algorithm returns "`Blocked`"
   if the active policy for |global| blocks RTC connections, and "`Allowed`" otherwise:
 
   <ol class="algorithm">
@@ -1453,7 +1453,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     EnsureCSPDoesNotBlockStringCompilation(|realm|, |source|)
   </h4>
 
-  Given a <a>realm</a> (|realm|) and a string (|source|), this algorithm
+  Given a <a>realm</a> |realm| and a string |source|, this algorithm
   returns normally if string compilation is allowed, and throws an "`EvalError`"
   if not:
 
@@ -1504,10 +1504,10 @@ abstract operation which examines the relevant <a for="global object">CSP
 list</a> to determine whether such compilation ought to be blocked.
 
 <h4 id="can-compile-wasm-bytes" algorithm dfn>
-  EnsureCSPDoesNotBlockWasmByteCompilation(|realm|)
+  EnsureCSPDoesNotBlockWasmByteCompilation|realm|
 </h4>
 
-Given a <a>realm</a> (|realm|),
+Given a <a>realm</a> |realm|,
 this algorithm returns normally if compilation is allowed, and throws a
 {{WebAssembly.CompileError}} if not:
 
@@ -1625,7 +1625,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Obtain the {{SecurityPolicyViolationEvent/blockedURI}} of a violation's |resource|
   </h3>
 
-  Given a violation's <a for=violation>resource</a> (|resource|), this algorithm returns a
+  Given a violation's <a for=violation>resource</a> |resource|, this algorithm returns a
   [=string=], to be used as the blocked URI field for violation reports.
 
   1. Assert: |resource| is a [=/URL=] or a [=string=].
@@ -1639,7 +1639,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Obtain the deprecated serialization of |violation|
   </h3>
 
-  Given a <a>violation</a> (|violation|), this algorithm returns a JSON text
+  Given a <a>violation</a> |violation|, this algorithm returns a JSON text
   string representation of the violation, suitable for submission to a reporting
   endpoint associated with the deprecated <a>`report-uri`</a> directive.
 
@@ -1695,7 +1695,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       «[ "csp-report" → body ]».
 
   <h3 id="strip-url-for-use-in-reports" algorithm>Strip URL for use in reports</h3>
-  Given a [=/URL=] (|url|), this algorithm returns a string representing the URL for use in violation
+  Given a [=/URL=] |url|, this algorithm returns a string representing the URL for use in violation
   reports:
 
   1. If |url|'s <a for="url">scheme</a> is not an <a>HTTP(S) scheme</a>,
@@ -1713,7 +1713,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Report a |violation|
   </h3>
 
-  Given a <a>violation</a> (|violation|), this algorithm reports it to the endpoint specified in
+  Given a <a>violation</a> |violation|, this algorithm reports it to the endpoint specified in
   |violation|'s <a for="violation">policy</a>, and fires a {{SecurityPolicyViolationEvent}} at
   |violation|'s [=violation/element=], or at |violation|'s <a for="violation">global object</a>
   as described below:
@@ -1796,7 +1796,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
       4.  If |violation|'s <a for="violation">policy</a>'s <a for="policy">directive
           set</a> contains a <a>directive</a> named "<a>`report-uri`</a>"
-          (|directive|):
+          |directive|:
 
           1.  If |violation|'s <a for="violation">policy</a>'s
               <a for="policy">directive set</a> contains a <a>directive</a> named
@@ -1856,7 +1856,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
       5.  If |violation|'s <a for="violation">policy</a>'s <a for="policy">directive
           set</a> contains a <a>directive</a> named "<a>`report-to`</a>"
-          (|directive|):
+          |directive|:
 
           1.  Let |body| be a new {{CSPViolationReportBody}}, initialized as
               follows:
@@ -2003,7 +2003,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2022,8 +2022,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2098,7 +2098,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2118,8 +2118,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2224,7 +2224,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2243,8 +2243,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing
       [[#effective-directive-for-a-request]] on |request|.
@@ -2264,8 +2264,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
       on |type|.
@@ -2318,7 +2318,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2338,8 +2338,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2386,7 +2386,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2406,8 +2406,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2457,7 +2457,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2477,8 +2477,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2524,7 +2524,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2544,8 +2544,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2594,7 +2594,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2614,8 +2614,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2685,7 +2685,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2705,8 +2705,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2791,7 +2791,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2808,8 +2808,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2826,8 +2826,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Assert: |element| is not null or |type| is "`navigation`".
 
@@ -2870,7 +2870,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2887,8 +2887,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -2905,8 +2905,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Assert: |element| is not null or |type| is "`navigation`".
 
@@ -2940,8 +2940,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Assert: |element| is not null or |type| is "`navigation`".
 
@@ -3009,7 +3009,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3034,8 +3034,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3060,8 +3060,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
       on |type|.
@@ -3099,7 +3099,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3124,8 +3124,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3150,8 +3150,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
       on |type|.
@@ -3182,8 +3182,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">inline check</a> algorithm is as follows:
 
-  Given an {{Element}} (|element|), a string (|type|), a <a for="/">policy</a>
-  (|policy|) and a string (|source|):
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
       on |type|.
@@ -3296,7 +3296,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">pre-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3316,8 +3316,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|), and a
-  <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
 
   1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
       on |request|.
@@ -3356,7 +3356,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Is |base| allowed for |document|?
   </h5>
 
-  Given a {{URL}} (|base|), and a {{Document}} (|document|), this algorithm
+  Given a {{URL}} |base|, and a {{Document}} |document|, this algorithm
   returns "`Allowed`" if |base| may be used as the value of a <{base}>
   element's <{base/href}> attribute, and "`Blocked`" otherwise:
 
@@ -3423,8 +3423,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   {{Document}}'s <a for=Document>active sandboxing flag set</a> via the
   <a spec=html>CSP-derived sandboxing flags</a>.
 
-  Given a {{Document}} or <a for="/">global object</a> (|context|) and a <a for="/">policy</a>
-  (|policy|):
+  Given a {{Document}} or <a for="/">global object</a> |context| and a <a for="/">policy</a>
+  |policy|:
 
   1.  If |policy|'s <a for="policy">disposition</a> is not "`enforce`", or
       |context| is not a {{WorkerGlobalScope}}, then abort this algorithm.
@@ -3462,8 +3462,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     `form-action` Pre-Navigation Check
   </h5>
 
-  Given a <a for="/">request</a> (|request|), a string |navigation type| ("`form-submission`" or
-  "`other`"), and a <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if a form
+  Given a <a for="/">request</a> |request|, a string |navigation type| ("`form-submission`" or
+  "`other`"), and a <a for="/">policy</a> |policy| this algorithm returns "`Blocked`" if a form
   submission violates the `form-action` directive's constraints, and "`Allowed`"
   otherwise. This constitutes the `form-action` directive's <a>pre-navigation check</a>:
 
@@ -3508,11 +3508,11 @@ this algorithm returns normally if compilation is allowed, and throws a
     `frame-ancestors` Navigation Response Check
   </h5>
 
-  Given a <a for="/">request</a> (|request|), a string |navigation type|
+  Given a <a for="/">request</a> |request|, a string |navigation type|
   ("`form-submission`" or "`other`"), a
-  <a>response</a> (|navigation response|) a <a>navigable</a> (|target|),
+  <a>response</a> |navigation response| a <a>navigable</a> |target|,
   a string |check type| ("`source`" or "`response`"), and a
-  <a for="/">policy</a> (|policy|) this algorithm returns "`Blocked`" if one or
+  <a for="/">policy</a> |policy| this algorithm returns "`Blocked`" if one or
   more of the ancestors of |target| violate the `frame-ancestors` directive
   delivered with the response, and "`Allowed`" otherwise. This constitutes the
   `frame-ancestors` directive's <a>navigation response check</a>:
@@ -3644,8 +3644,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Script directives pre-request check
   </h5>
 
-  Given a <a for="/">request</a> (|request|), a <a>directive</a> (|directive|),
-  and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>directive</a> |directive|,
+  and a <a for="/">policy</a> |policy|:
 
   1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
 
@@ -3712,8 +3712,8 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   This directive's <a for="directive">post-request check</a> is as follows:
 
-  Given a <a for="/">request</a> (|request|), a <a>response</a> (|response|),
-  a <a>directive</a> (|directive|), and a <a for="/">policy</a> (|policy|):
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|,
+  a <a>directive</a> |directive|, and a <a for="/">policy</a> |policy|:
 
   1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
 
@@ -3739,7 +3739,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |request| violate |policy|?
   </h5>
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|), this
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|, this
   algorithm returns the violated <a>directive</a> if the request violates the
   policy, and "`Does Not Violate`" otherwise.
 
@@ -3761,7 +3761,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does resource hint |request| violate |policy|?
   </h5>
 
-  Given a <a for="/">request</a> (|request|) and a <a for="/">policy</a> (|policy|), this
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|, this
   algorithm returns the default <a>directive</a> if the resource-hint request violates all the
   policies, and "`Does Not Violate`" otherwise.
 
@@ -3784,7 +3784,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   </h5>
 
   Given a <a for="/">request</a>'s <a for="request">cryptographic nonce metadata</a>
-  (|nonce|) and a <a>source list</a> (|source list|), this algorithm returns
+  |nonce| and a <a>source list</a> |source list|, this algorithm returns
   "`Matches`" if the nonce matches one or more source expressions in the list,
   and "`Does Not Match`" otherwise:
 
@@ -3804,8 +3804,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |request| match |source list|?
   </h5>
 
-  Given a <a for="/">request</a> (|request|), a <a>source list</a> (|source list|),
-  and a <a for="/">policy</a> (|policy|), this algorithm returns the result of executing
+  Given a <a for="/">request</a> |request|, a <a>source list</a> |source list|,
+  and a <a for="/">policy</a> |policy|, this algorithm returns the result of executing
   [[#match-url-to-source-list]] on |request|'s <a for="request">current url</a>,
   |source list|, |policy|'s [=policy/self-origin=], and |request|'s
   <a for="request">redirect count</a>.
@@ -3817,8 +3817,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |response| to |request| match |source list|?
   </h5>
 
-  Given a <a for="/">request</a> (|request|), and a <a>source list</a> (|source list|),
-  and a <a for="/">policy</a> (|policy|), this algorithm returns the result of executing
+  Given a <a for="/">request</a> |request|, and a <a>source list</a> |source list|,
+  and a <a for="/">policy</a> |policy|, this algorithm returns the result of executing
   [[#match-url-to-source-list]] on |response|'s <a for="response">url</a>,
   |source list|, |policy|'s [=policy/self-origin=], and |request|'s
   <a for="request">redirect count</a>.
@@ -3830,8 +3830,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |url| match |source list| in |origin| with |redirect count|?
   </h5>
 
-  Given a {{URL}} (|url|), a <a>source list</a> (|source list|), an
-  <a for="/">origin</a> (|origin|), and a number (|redirect count|), this
+  Given a {{URL}} |url|, a <a>source list</a> |source list|, an
+  <a for="/">origin</a> |origin|, and a number |redirect count|, this
   algorithm returns "`Matches`" if the URL matches one or more source
   expressions in |source list|, or "`Does Not Match`" otherwise:
 
@@ -3864,8 +3864,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |url| match |expression| in |origin| with |redirect count|?
   </h5>
 
-  Given a {{URL}} (|url|), a <a>source expression</a> (|expression|), an
-  <a for="/">origin</a> (|origin|), and a number (|redirect count|), this algorithm
+  Given a {{URL}} |url|, a <a>source expression</a> |expression|, an
+  <a for="/">origin</a> |origin|, and a number |redirect count|, this algorithm
   returns "`Matches`" if |url| matches |expression|, and "`Does Not Match`"
   otherwise.
 
@@ -3964,7 +3964,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   to `script-src http: https:`, `script-src http://example.com` to `script-src http://example.com
   https://example.com`, and `connect-src ws:` to `connect-src ws: wss:`.
 
-  More formally, two <a>ASCII strings</a> (|A| and |B|) are said to <a>`scheme-part` match</a> if the
+  More formally, two <a>ASCII strings</a> |A| and |B| are said to <a>`scheme-part` match</a> if the
   following algorithm returns "`Matches`":
 
   <ol class="algorithm">
@@ -4025,8 +4025,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     `port-part` matching
   </h5>
 
-  An <a>ASCII string</a> (|port A|) <dfn export>`port-part` matches</dfn> two other <a>ASCII
-  strings</a> (|port B| and |scheme B|) if a CSP source expression that contained the first as a
+  An <a>ASCII string</a> |port A| <dfn export>`port-part` matches</dfn> two other <a>ASCII
+  strings</a> |port B| and |scheme B| if a CSP source expression that contained the first as a
   <a grammar>`port-part`</a> could potentially match a URL containing the latter as [=url/port=]
   and [=url/scheme=]. For example, "80" <a>`port-part` matches</a> matches "80"/"http".
 
@@ -4052,8 +4052,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     `path-part` matching
   </h5>
 
-  An <a>ASCII string</a> (|path A|) <dfn export lt="path-part match">`path-part` matches</dfn>
-  another <a>ASCII string</a> (|path B|) if a CSP source expression that contained the first as a
+  An <a>ASCII string</a> |path A| <dfn export lt="path-part match">`path-part` matches</dfn>
+  another <a>ASCII string</a> |path B| if a CSP source expression that contained the first as a
   <a grammar>`path-part`</a> could potentially match a URL containing the latter as a [=url/path=].
   For example, we say that "/subdirectory/" <a>`path-part` matches</a> "/subdirectory/file".
 
@@ -4106,7 +4106,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Is |element| nonceable?
   </h5>
 
-  Given an {{Element}} (|element|), this algorithm returns "`Nonceable`" if
+  Given an {{Element}} |element|, this algorithm returns "`Nonceable`" if
   a <a grammar>`nonce-source`</a> expression can match the element (as discussed
   in [[#security-nonce-hijacking]]), and "`Not Nonceable`" if such expressions
   should not be applied.
@@ -4152,7 +4152,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   expression <a grammar>`'unsafe-inline'`</a>, and does not override that
   expression as described in the following algorithm:
 
-  Given a <a>source list</a> (|list|) and a string (|type|), the following
+  Given a <a>source list</a> |list| and a string |type|, the following
   algorithm returns "`Allows`" if all inline content of a given |type| is
   allowed and "`Does Not Allow`" otherwise.
 
@@ -4211,8 +4211,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Does |element| match source list for |type| and |source|?
   </h5>
 
-  Given an {{Element}} (|element|), a <a>source list</a> (|list|), a string
-  (|type|), and a string (|source|), this algorithm returns "`Matches`" or
+  Given an {{Element}} |element|, a <a>source list</a> |list|, a string
+  |type|, and a string |source|, this algorithm returns "`Matches`" or
   "`Does Not Match`".
 
   Note: Regardless of the encoding of the document, |source| will be converted
@@ -4297,7 +4297,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   </h4>
 
   Each <a>fetch directive</a> controls a specific destination of <a for="/">request</a>. Given
-  a <a for="/">request</a> (|request|), the following algorithm returns either
+  a <a for="/">request</a> |request|, the following algorithm returns either
   null or the <a for="directive">name</a> of the request's
   <dfn for="request" export>effective directive</dfn>:
 
@@ -4364,7 +4364,7 @@ this algorithm returns normally if compilation is allowed, and throws a
     Get the effective directive for inline checks
   </h4>
 
-  Given a string (|type|), this algorithm returns the <a for="directive">name</a>
+  Given a string |type|, this algorithm returns the <a for="directive">name</a>
   of the effective directive.
 
   Note: While the <a for="request">effective directive</a> is only defined for
@@ -4396,7 +4396,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   The returned <a>ordered set</a> is sorted from most relevant to least relevant
   and it includes the effective directive itself.
 
-  Given a string (|directive name|):
+  Given a string |directive name|:
 
   1.  Switch on |directive name|:
 
@@ -4460,8 +4460,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   we are currently checking a worker request), a `default-src` directive
   should not execute if a `worker-src` or `script-src` directive exists.
 
-  Given a string (|effective directive name|), a string (|directive name|) and
-  a <a for="/">policy</a> (|policy|):
+  Given a string |effective directive name|, a string |directive name| and
+  a <a for="/">policy</a> |policy|:
 
   1.  Let |directive fallback list| be the result of executing [[#directive-fallback-list]]
       on |effective directive name|.

--- a/index.bs
+++ b/index.bs
@@ -3510,7 +3510,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   Given a <a for="/">request</a> |request|, a string |navigation type|
   ("`form-submission`" or "`other`"), a
-  <a>response</a> |navigation response| a <a>navigable</a> |target|,
+  <a>response</a> |navigation response|, a <a>navigable</a> |target|,
   a string |check type| ("`source`" or "`response`"), and a
   <a for="/">policy</a> |policy| this algorithm returns "`Blocked`" if one or
   more of the ancestors of |target| violate the `frame-ancestors` directive


### PR DESCRIPTION
Automatically generated with `sed -i  's/(|\([^|]*\)|)/|\1|/g' index.bs`, plus a few manual leftovers.

Closes #598. 