### PR TITLE
[editorial] Add backticks around null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1771,7 +1771,7 @@ this algorithm returns normally if compilation is allowed, and throws a
           :  {{SecurityPolicyViolationEvent/sourceFile}}
           ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
               <a for="violation">source file</a>, if |violation|'s
-              <a for="violation">source file</a> is not null, or null otherwise.
+              <a for="violation">source file</a> is not `null`, or `null` otherwise.
           :  {{SecurityPolicyViolationEvent/statusCode}}
           :: |violation|'s <a for="violation">status</a>
           :  {{SecurityPolicyViolationEvent/lineNumber}}
@@ -1883,7 +1883,7 @@ this algorithm returns normally if compilation is allowed, and throws a
               :   {{CSPViolationReportBody/sourceFile}}
               ::  The result of executing [[#strip-url-for-use-in-reports]] on |violation|'s
                   <a for="violation">source file</a>, if |violation|'s
-                  <a for="violation">source file</a> is not null, or null otherwise.
+                  <a for="violation">source file</a> is not `null`, or `null` otherwise.
 
               :   {{CSPViolationReportBody/sample}}
               ::  |violation|'s <a for="violation">sample</a>.
@@ -1896,13 +1896,13 @@ this algorithm returns normally if compilation is allowed, and throws a
 
               :   {{CSPViolationReportBody/lineNumber}}
               ::  |violation|'s <a for="violation">line number</a>, if
-                  |violation|'s <a for="violation">source file</a> is not null,
-                  or null otherwise.
+                  |violation|'s <a for="violation">source file</a> is not `null`,
+                  or `null` otherwise.
 
               :   {{CSPViolationReportBody/columnNumber}}
               ::  |violation|'s <a for="violation">column number</a>, if
-                  |violation|'s <a for="violation">source file</a> is not null,
-                  or null otherwise.
+                  |violation|'s <a for="violation">source file</a> is not `null`,
+                  or `null` otherwise.
 
           2.  Let |settings object| be |violation|'s <a for="violation">global
               object</a>'s <a>relevant settings object</a>.


### PR DESCRIPTION
We are writing null inside backticks everywhere else, so let's be coherent.