### PR TITLE
[editorial] Fix reference to navigable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -131,6 +131,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     text: initializing a new Document object; url: initialise-the-document-object
     text: prepare the script element; url: prepare-the-script-element
     text: plugin; url: #plugin
+    text: navigable; url: #navigable
   type: attr-value
     for: link/rel; text: prefetch; url: link-type-prefetch
     for: link/rel; text: preconnect; url: link-type-preconnect


### PR DESCRIPTION
Fixes the following build error:

```
The following refs show up multiple times in their spec, in a way that Bikeshed can't distinguish between. Either create a manual link, or ask the spec maintainer to add disambiguating attributes (usually a for='' attribute to all of them).
spec:html; type:dfn; for:/; text:navigable
  https://html.spec.whatwg.org/multipage/browsing-the-web.html#changing-nav-continuation-navigable
  https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-navigable
  https://html.spec.whatwg.org/multipage/document-sequences.html#navigable
<a data-link-type="dfn" data-lt="navigable">navigable</a>
```