### PR TITLE
Export DFNs used in Permissions-Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -682,10 +682,10 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
                              / <a>nonce-source</a> / <a>hash-source</a>
 
     ; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
-    <dfn>scheme-source</dfn> = <a>scheme-part</a> ":"
+    <dfn export>scheme-source</dfn> = <a>scheme-part</a> ":"
 
     ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
-    <dfn>host-source</dfn> = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ ":" <a>port-part</a> ] [ <a>path-part</a> ]
+    <dfn export>host-source</dfn> = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ ":" <a>port-part</a> ] [ <a>path-part</a> ]
     <dfn>scheme-part</dfn> = <a>scheme</a>
                   ; <a>scheme</a> is defined in section 3.1 of RFC 3986.
     <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
@@ -3861,7 +3861,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   5.  Return "`Does Not Match`".
 
-  <h5 id="match-url-to-source-expression" algorithm>
+  <h5 id="match-url-to-source-expression" algorithm dfn export>
     Does |url| match |expression| in |origin| with |redirect count|?
   </h5>
 


### PR DESCRIPTION
Specifically: `scheme-source`, `host-source`, and `Does url match expression in origin with redirect count?`. These are used in https://github.com/w3c/webappsec-permissions-policy/pull/516/

closes #604