### PR TITLE
Add `"json"` destination for `"connect-src"`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4354,6 +4354,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       ::
         1. Return `worker-src`.
 
+      : "`json`"
       : "`webidentity`"
       ::
         1. Return `connect-src`.


### PR DESCRIPTION
https://github.com/whatwg/fetch/pull/1691 adds `"json"` destinatino to the fetch spec (see https://github.com/whatwg/html/pull/9486 and https://github.com/whatwg/html/issues/7233 for motivation). Given that JSON modules are powerless and they they are so far usually loaded using `fetch()`, the intention is for them to re-use the `connect-src` CSP policy.

fyi @annevk @domenic 

Closes https://github.com/w3c/webappsec-csp/issues/573.