### PR TITLE
Reference the strict-dynamic issue for inline scripts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4287,6 +4287,8 @@ this algorithm returns normally if compilation is allowed, and throws a
       they will also apply to event handlers, style attributes and `javascript:`
       navigations.
 
+  ISSUE(w3c/webappsec-csp#426): This should handle `'strict-dynamic'` for dynamically inserted inline scripts.
+
   6.  Return "`Does Not Match`".
 
   <h3 id="directive-algorithms">Directive Algorithms</h3>


### PR DESCRIPTION
We just spent entirely too much time trying to figure out why the spec for inline scripts doesn't match the test behavior while re-implementing strict-dynamic in Firefox. This reference to https://github.com/w3c/webappsec-csp/issues/426 would have helped tremendously.
