### PR TITLE
[editorial] Fix reference to url

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -46,6 +46,7 @@ spec:url
     text: default port
     text: base url
     text: domain
+    text: url; for: /
   type:interface;
     text:URL
 spec:cssom


### PR DESCRIPTION
Apparently there is now also a url dfn in `spec:pub-manifest; type:dfn; text:url`. This PR fixes compilation defining a default link.