### PR TITLE
Remove RECOMMENDATION to not send multiple CSP headers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -908,10 +908,6 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   A server MAY send different `Content-Security-Policy` header field
   values with different <a>representations</a> of the same resource.
 
-  A server SHOULD NOT send more than one HTTP response header field named
-  "`Content-Security-Policy`" with a given <a>resource
-  representation</a>.
-
   When the user agent receives a `Content-Security-Policy` header field, it
   MUST <a abstract-op lt="parse a serialized CSP">parse</a> and <a>enforce</a> each
   <a>serialized CSP</a> it contains as described in [[#fetch-integration]],
@@ -948,10 +944,6 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   A server MAY send different `Content-Security-Policy-Report-Only`
   header field values with different <a>representations</a> of the same
   resource.
-
-  A server SHOULD NOT send more than one HTTP response header field named
-  "`Content-Security-Policy-Report-Only`" with a given <a>resource
-  representation</a>.
 
   When the user agent receives a `Content-Security-Policy-Report-Only` header
   field, it MUST <a abstract-op lt="parse a serialized CSP">parse</a> and <a>monitor</a>


### PR DESCRIPTION
See #361 

Currently, the spec discourages sending multiple CSP headers without a good reason and even uses multiple CSP headers in an example later.
This PR removes the sentences that one should not send multiple CSP headers.