### PR TITLE
Is-element-nonceable should check if the attribute's name |contains| <script or <style>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4108,13 +4108,11 @@ this algorithm returns normally if compilation is allowed, and throws a
   2.  If |element| is a <{script}> element, then <a for=list>for each</a> |attribute| of
       |element|'s <a for=Element>attribute list</a>:
 
-      1.  If |attribute|'s name is an <a>ASCII case-insensitive</a> match for
-          the string "<code>&lt;script</code>" or the string
-          "<code>&lt;style</code>", return "`Not Nonceable`".
+      1.  If |attribute|'s name contains an <a>ASCII case-insensitive</a> match for
+          "<code>&lt;script</code>" or "<code>&lt;style</code>", return "`Not Nonceable`".
 
-      2.  If |attribute|'s value contains an <a>ASCII case-insensitive</a> match
-          the string "<code>&lt;script</code>" or the string
-          "<code>&lt;style</code>", return "`Not Nonceable`".
+      2.  If |attribute|'s value contains an <a>ASCII case-insensitive</a> match for
+          "<code>&lt;script</code>" or "<code>&lt;style</code>", return "`Not Nonceable`".
 
   3.  If |element| had a [=duplicate-attribute=] [=parse error=] during tokenization, return
       "`Not Nonceable`".


### PR DESCRIPTION
1.  [Chrome](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/csp/content_security_policy.cc;l=160-164;drc=4d7afadfe6627fb828f7153f1e4f3d202def256d)/Safari both seem to check if `<style`/`</script` is _contained_ in the attribute's name, not just an exact match.
2. @mikewest mentioned this here https://github.com/w3c/webappsec-csp/issues/98#issuecomment-281079001

(I am actually not quite sure if this is specified correctly, because https://infra.spec.whatwg.org/#ascii-case-insensitive seems to talk about exact matches only?)