### PR TITLE
Add optional trailing dot to host-part

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -688,7 +688,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     <dfn export>host-source</dfn> = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ ":" <a>port-part</a> ] [ <a>path-part</a> ]
     <dfn>scheme-part</dfn> = <a>scheme</a>
                   ; <a>scheme</a> is defined in section 3.1 of RFC 3986.
-    <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
+    <dfn>host-part</dfn>   = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> ) [ "." ]
     <dfn>host-char</dfn>   = <a>ALPHA</a> / <a>DIGIT</a> / "-"
     <dfn>port-part</dfn>   = 1*<a>DIGIT</a> / "*"
     <dfn>path-part</dfn>   = <a>path-absolute</a> (but not including ";" or ",")


### PR DESCRIPTION
A valid host can end up having a trailing dot which violates the host-part ABNF. This request adds an optional dot at the end of host-part.
This is tested in [WPT](https://wpt.fyi/results/content-security-policy/generic/src-trailing-dot.sub.any.html).

Fixes #620 