### PR TITLE
Add `[SecureContext]` tag to the interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1555,7 +1555,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
-    [Exposed=Window]
+    [Exposed=Window, SecureContext]
     interface CSPViolationReportBody : ReportBody {
       [Default] object toJSON();
       readonly attribute USVString documentURL;


### PR DESCRIPTION
- addresses https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment a syntax section is missing the `[SecureContext]` tags so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/ed/idl/CSP.idl#L6).

The feature has been [marked available in secure context in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/CSPViolationReportBody). 

The PR adds the tag to the interface.
