### PR TITLE
Remove required condition on the attributes fror SecurityPolicyViolationEventInit dict

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1599,18 +1599,18 @@ this algorithm returns normally if compilation is allowed, and throws a
     };
 
     dictionary SecurityPolicyViolationEventInit : EventInit {
-        required USVString      documentURI;
-                 USVString      referrer = "";
-                 USVString      blockedURI = "";
-        required DOMString      violatedDirective;
-        required DOMString      effectiveDirective;
-        required DOMString      originalPolicy;
-                 USVString      sourceFile = "";
-                 DOMString      sample = "";
-        required SecurityPolicyViolationEventDisposition disposition;
-        required unsigned short statusCode;
-                 unsigned long  lineNumber = 0;
-                 unsigned long  columnNumber = 0;
+        USVString      documentURI = "";
+        USVString      referrer = "";
+        USVString      blockedURI = "";
+        DOMString      violatedDirective = "";
+        DOMString      effectiveDirective = "";
+        DOMString      originalPolicy = "";
+        USVString      sourceFile = "";
+        DOMString      sample = "";
+        SecurityPolicyViolationEventDisposition disposition = "enforce";
+        unsigned short statusCode;
+        unsigned long  lineNumber = 0;
+        unsigned long  columnNumber = 0;
     };
   </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1608,7 +1608,7 @@ this algorithm returns normally if compilation is allowed, and throws a
         USVString      sourceFile = "";
         DOMString      sample = "";
         SecurityPolicyViolationEventDisposition disposition = "enforce";
-        unsigned short statusCode;
+        unsigned short statusCode = 0;
         unsigned long  lineNumber = 0;
         unsigned long  columnNumber = 0;
     };


### PR DESCRIPTION
The dictionary SecurityPolicyViolationEventInit is optional in the constructor of SecurityPolicyViolationEvent. This change removes the required attributes from the properties of this dictionary and adds default values to them.

Tested in https://github.com/web-platform-tests/wpt/pull/44672.

Fixes: #631