### PR TITLE
Add notes about non-normativity.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4751,6 +4751,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     Usage of "`'strict-dynamic'`"
   </h3>
 
+  <em>This section is not normative.</em>
+
   Host- and path-based policies are tough to get right, especially on sprawling origins like CDNs.
   The <a href="https://github.com/cure53/XSSChallengeWiki/wiki/H5SC-Minichallenge-3:-%22Sh*t,-it%27s-CSP!%22#107-bytes">solutions
   to Cure53's H5SC Minichallenge 3: "Sh*t, it's CSP!"</a> [[H5SC3]] are good examples of the
@@ -4879,6 +4881,8 @@ this algorithm returns normally if compilation is allowed, and throws a
       Allowing external JavaScript via hashes
     </h3>
 
+    <em>This section is not normative.</em>
+
     In [[CSP2]], hash <a>source expressions</a> could only match inlined
     script, but now that Subresource Integrity [[SRI]] is widely deployed,
     we can expand the scope to enable externalized JavaScript as well.
@@ -4943,6 +4947,8 @@ this algorithm returns normally if compilation is allowed, and throws a
       Strict CSP
     </h3>
 
+    <em>This section is not normative.</em>
+
     Deployment of an effective CSP against XSS is a challenge (as described in
     <a href="https://dl.acm.org/doi/10.1145/2976749.2978363">CSP Is Dead, Long
     Live CSP!</a> [[LONG-LIVE-CSP]]). However, enforcing the following set of CSP
@@ -4982,6 +4988,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     <h3 id="exfiltration">
       Exfiltration
     </h3>
+
+    <em>This section is not normative.</em>
 
     Data exfiltration can occur when the contents of the request, such as the URL, contain
     information about the user or page that should be restricted and not shared.


### PR DESCRIPTION
Several "authoring considerations" sections should have been marked as non-normative, as noted in https://github.com/w3c/webappsec-csp/issues/653. This PR addresses that oversight.