### PR TITLE
Correctly match `*` as a `host-part`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4015,7 +4015,9 @@ this algorithm returns normally if compilation is allowed, and throws a
   <ol class="algorithm">
     1. If |host| is not a [=domain=], return "`Does Not Match`".
 
-    2.  If |pattern| <a>starts with</a> "`*.`":
+    2. If |pattern| is "`*`", return "`Matches`".
+
+    3.  If |pattern| <a>starts with</a> "`*.`":
 
         1.  Let |remaining| be |pattern| with the leading U+002A (`*`) removed and <a>ASCII lowercased</a>.
 
@@ -4023,12 +4025,11 @@ this algorithm returns normally if compilation is allowed, and throws a
 
         3.  Return "`Does Not Match`".
 
-    3.  If |pattern| is not an <a>ASCII case-insensitive</a> match for |host|, return
+    4.  If |pattern| is not an <a>ASCII case-insensitive</a> match for |host|, return
         "`Does Not Match`".
 
-    4.  Return "`Matches`".
+    5.  Return "`Matches`".
   </ol>
-
   <h5 id="match-ports" algorithm>
     `port-part` matching
   </h5>

--- a/index.bs
+++ b/index.bs
@@ -4030,6 +4030,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
     5.  Return "`Matches`".
   </ol>
+
   <h5 id="match-ports" algorithm>
     `port-part` matching
   </h5>


### PR DESCRIPTION
This PR adds support for `*` to the `host-part` matching algorithm, allowing patterns like `https://*:123` to correctly match any host.

Fixes w3c/webappsec-csp#656