### PR TITLE
Fix check of request initiator being "fetch"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4350,12 +4350,12 @@ this algorithm returns normally if compilation is allowed, and throws a
   1.  If |request|'s [=request/initiator=] is "`prefetch`" or "`prerender`",
       return `default-src`.
 
-  2.  If |request|'s <a for="request">initiator</a> is "`fetch`" or its
-      <a for="request">destination</a> is "", return `connect-src`.
-
-  3.  Switch on |request|'s <a for="request">destination</a>, and execute
+  2.  Switch on |request|'s <a for="request">destination</a>, and execute
       the associated steps:
 
+      : the empty string
+      ::
+        1.  Return `connect-src`.
       : "`manifest`"
       ::
         1.  Return `manifest-src`.
@@ -4409,7 +4409,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       ::
         1. Return null.
 
-  4.  Return `connect-src`.
+  3.  Return `connect-src`.
 
   Note: The algorithm returns `connect-src` as a default fallback. This is
   intended for new fetch destinations that are added and which don't explicitly


### PR DESCRIPTION
Request's initiator cannot be "fetch". This fixes #660.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/663.html" title="Last updated on Oct 14, 2024, 7:40 AM UTC (e0b8101)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/663/ce17e10...antosart:e0b8101.html" title="Last updated on Oct 14, 2024, 7:40 AM UTC (e0b8101)">Diff</a>