### PR TITLE
Add `trusted-types-eval` source expression for `script-src`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -490,7 +490,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   <ol class="algorithm">
     1.  If |serialized| is a [=byte sequence=], then set |serialized| to be the result of
         [=isomorphic decoding=] |serialized|.
-        
+
     2.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
         of |source|, and a [=policy/disposition=] of |disposition|.
 
@@ -693,8 +693,9 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>"
                      / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>"
                      / "<dfn>'report-sample'</dfn>" / "<dfn>'unsafe-allow-redirects'</dfn>"
-                     / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'report-sha256'</dfn>"
-                     / "<dfn>'report-sha384'</dfn>" / "<dfn>'report-sha512'</dfn>"
+                     / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'trusted-types-eval'</dfn>"
+                     / "<dfn>'report-sha256'</dfn>" / "<dfn>'report-sha384'</dfn>"
+                     / "<dfn>'report-sha512'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -1539,9 +1540,17 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
           Otherwise if |policy| contains a [=directive=] whose [=directive/name=] is
           "`default-src`", then set |source-list| to that directive's [=directive/value=].
 
-      3.  If |source-list| is not null, and does not contain a [=source expression=] which is
-          an [=ASCII case-insensitive=] match for the string "<a grammar>`'unsafe-eval'`</a>",
-          then:
+      1.  If |source-list| is not null:
+
+          1.  Let |trustedTypesRequired| be the result of executing [$Does sink type require trusted types?$], with
+              |realm|, `'script'`, and `false`.
+
+          1.  If |trustedTypesRequired| is `true` and |source-list| contains a [=source expression=] which is an
+              [=ASCII case-insensitive=] match for the string "<a grammar>`'trusted-types-eval'`</a>", then skip the
+              following steps.
+
+          1.  If |source-list| contains a [=source expression=] which is an [=ASCII case-insensitive=] match for the
+              string "<a grammar>`'unsafe-eval'`</a>", then skip the following steps.
 
           1.  Let |violation| be the result of executing [[#create-violation-for-global]] on
               |global|, |policy|, and "`script-src`".
@@ -2861,8 +2870,8 @@ Content-Type: application/reports+json
       <a grammar>nonce-source</a> or a <a grammar>hash-source</a> that matches
       the inline block.
 
-  4.  The following JavaScript execution sinks are gated on the "`unsafe-eval`"
-      source expression:
+  4.  The following JavaScript execution sinks are gated on the "`unsafe-eval`" and "`trusted-types-eval`"
+      source expressions:
 
       *   {{eval()}}
       *   {{Function()}}


### PR DESCRIPTION
This new keyword allows enabling eval only when trusted types are enforced. Such that in browsers that don't support trusted types no eval is allowed, unlike with `unsafe-eval`. This concept was brought up at previous WebAppSec WG meetings.

Implementor Interest: 

- [x] Mozilla (see https://github.com/mozilla/standards-positions/issues/1032)

- [x] WebKit (see https://github.com/WebKit/standards-positions/issues/355)

- [ ] Chromium - Not sure how best to get an official Google position but Lukas is supportive per https://github.com/WebKit/standards-positions/issues/355#issuecomment-2294149279


Implementation Bugs:

- [x] WebKit (see https://bugs.webkit.org/show_bug.cgi?id=285603)
- [x] Gecko (see https://bugzilla.mozilla.org/show_bug.cgi?id=1940493)
- [x] Chromium (see https://issues.chromium.org/issues/388437274)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/webappsec-csp/pull/665.html" title="Last updated on Jan 8, 2025, 4:12 PM UTC (29f6b70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/665/268bdff...lukewarlow:29f6b70.html" title="Last updated on Jan 8, 2025, 4:12 PM UTC (29f6b70)">Diff</a>