### PR TITLE
Fix parsing response's CSP type mismatch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -471,18 +471,21 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     Parse a serialized CSP
   </h4>
 
-  To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=string=] |serialized|, a
-  [=policy/source=] |source|, and a [=policy/disposition=] |disposition|, execute the
-  following steps.
+  To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=byte sequence=] or
+  [=string=] |serialized|, a [=policy/source=] |source|, and a [=policy/disposition=]
+  |disposition|, execute the following steps.
 
   This algorithm returns a [=Content Security Policy object=]. If |serialized| could not be
   parsed, the object's [=policy/directive set=] will be empty.
 
   <ol class="algorithm">
-    1.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
+    1.  If |serialized| is a [=byte sequence=], then set |serialized| to be the result of
+        [=isomorphic decoding=] |serialized|.
+        
+    2.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
         of |source|, and a [=policy/disposition=] of |disposition|.
 
-    2.  <a for=list>For each</a> |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
+    3.  <a for=list>For each</a> |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
         the U+003B SEMICOLON character (`;`):
 
         1.  [=Strip leading and trailing ASCII whitespace=] from |token|.
@@ -513,37 +516,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
         8.  [=set/append|Append=] |directive| to |policy|'s [=policy/directive set=].
 
-    3.  Return |policy|.
-  </ol>
-
-  <h4 id="parse-serialized-policy-list" algorithm>
-    Parse a serialized CSP list
-  </h4>
-
-  To <dfn abstract-op>parse a serialized CSP list</dfn>, given a [=byte sequence=] or [=string=]
-  |list|, a [=policy/source=] |source|, and a [=policy/disposition=] |disposition|, execute
-  the following steps.
-
-  This algorithm returns a [=list=] of [=Content Security Policy objects=]. If |list| cannot be
-  parsed, the returned list will be empty.
-
-  <ol class="algorithm">
-    1.  If |list| is a [=byte sequence=], then set |list| to be the result of <a
-        lt="isomorphic decode">isomorphic decoding</a> |list|.
-
-    2.  Let |policies| be an empty [=list=].
-
-    3.  [=list/For each=] |token| returned by <a lt="split a string on commas">splitting |list| on commas</a>:
-
-        1.  Let |policy| be the result of <a abstract-op lt="parse a serialized CSP">parsing</a>
-            |token|, with a [=policy/source=] of |source|, and [=policy/disposition=] of
-            |disposition|.
-
-        2.  If |policy|'s [=policy/directive set=] is empty, [=iteration/continue=].
-
-        3.  [=list/append|Append=] |policy| to |policies|.
-
-    4.  Return |policies|.
+    4.  Return |policy|.
   </ol>
 
   <h4 id="parse-response-csp" algorithm dfn export>
@@ -551,26 +524,38 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   </h4>
 
   To <dfn abstract-op>parse a response's Content Security Policies</dfn> given a <a>response</a>
-  |response|:
+  |response|, execute the following steps.
+
+  This algorithm returns a [=list=] of [=Content Security Policy objects=]. If the policies cannot
+  be parsed, the returned list will be empty.
 
   <ol class="algorithm">
-    1.  Let |policies| be the result of <a abstract-op lt="parse a serialized CSP list">parsing</a>
-        the result of [=extracting header list values=] given `Content-Security-Policy` and
-        |response|'s [=response/header list=], with a [=policy/source=] of "`header`", and a
-        [=policy/disposition=] of "`enforce`".
+    1.  Let |policies| be an empty [=list=].
 
-    2.  Append to |policies| the result of
-        <a abstract-op lt="parse a serialized CSP list">parsing</a> the result of
-        [=extracting header list values=] given `Content-Security-Policy-Report-Only` and
-        |response|'s [=response/header list=], with a [=policy/source=] of "`header`", and a
-        [=policy/disposition=] of "`report`".
+    2.  <a for=list>For each</a> |token| returned by [=extracting header list values=] given
+        `Content-Security-Policy` and |response|'s [=response/header list=]:
 
-    3.  <a for=list>For each</a> |policy| of |policies|:
+        1.  Let |policy| be the result of
+            <a abstract-op lt="parse a serialized CSP list">parsing</a> |token|, with a
+            [=policy/source=] of "`header`", and a [=policy/disposition=] of "`enforce`".
+
+        2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.
+
+    3.  <a for=list>For each</a> |token| returned by [=extracting header list values=] given
+        `Content-Security-Policy-Report-Only` and |response|'s [=response/header list=]:
+
+        1.  Let |policy| be the result of
+            <a abstract-op lt="parse a serialized CSP list">parsing</a> |token|, with a
+            [=policy/source=] of "`header`", and a [=policy/disposition=] of "`report`".
+
+        2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.
+
+    4.  <a for=list>For each</a> |policy| of |policies|:
 
         1.  Set |policy|'s [=policy/self-origin=] to |response|'s [=response/url=]'s
             [=url/origin=].
 
-    4.  Return |policies|.
+    5.  Return |policies|.
   </ol>
 
   Note: When <a abstract-op lt="parse a response's Content Security Policies">parsing a response's


### PR DESCRIPTION
This fixes the "Parse response’s Content Security Policies" algorithm, which wanted to use the result of [extracting header list values](https://fetch.spec.whatwg.org/#extract-header-list-values), a list of byte sequences, as input for [parsing](https://w3c.github.io/webappsec-csp/#abstract-opdef-parse-a-serialized-csp-list), which takes either a byte sequence or a string.

As it turns out, [extracting header list values](https://fetch.spec.whatwg.org/#extract-header-list-values) already takes care of splitting the header value on commas and returning a list (provided that the ABNF grammar of the header specifies so, which the Content-Security-Policy grammar does), so the CSP spec can be further simplified by removing the part handling  commas in header values.

This fixes #684.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/685.html" title="Last updated on Oct 14, 2024, 8:22 AM UTC (0a2ac3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/685/ce17e10...antosart:0a2ac3d.html" title="Last updated on Oct 14, 2024, 8:22 AM UTC (0a2ac3d)">Diff</a>