### PR TITLE
[editorial] Fix wrong references to parse a serialized CSP list

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Build, Validate, and Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2

--- a/index.bs
+++ b/index.bs
@@ -536,7 +536,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
         `Content-Security-Policy` and |response|'s [=response/header list=]:
 
         1.  Let |policy| be the result of
-            <a abstract-op lt="parse a serialized CSP list">parsing</a> |token|, with a
+            <a abstract-op lt="parse a serialized CSP">parsing</a> |token|, with a
             [=policy/source=] of "`header`", and a [=policy/disposition=] of "`enforce`".
 
         2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.
@@ -545,7 +545,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
         `Content-Security-Policy-Report-Only` and |response|'s [=response/header list=]:
 
         1.  Let |policy| be the result of
-            <a abstract-op lt="parse a serialized CSP list">parsing</a> |token|, with a
+            <a abstract-op lt="parse a serialized CSP">parsing</a> |token|, with a
             [=policy/source=] of "`header`", and a [=policy/disposition=] of "`report`".
 
         2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.


### PR DESCRIPTION
This fixes an invalid reference introduced in #685.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/691.html" title="Last updated on Nov 22, 2024, 4:13 PM UTC (9558c60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/691/b33a9a2...antosart:9558c60.html" title="Last updated on Nov 22, 2024, 4:13 PM UTC (9558c60)">Diff</a>