### PR TITLE
Use "navigation request's policy container's CSP list" instead of "navigation request's client's global object's CSP list"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1264,9 +1264,9 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
     3.  If |result| is "`Allowed`", and if |navigation request|'s
         <a for="request">current URL</a>'s <a for="url">scheme</a> is `javascript`:
 
-        1.  <a for=list>For each</a> |policy| of |navigation request|'s <a for="request">client</a>'s
-            <a for="environment settings object">global object</a>'s
-            <a for="global object">CSP list</a>:
+        1.  <a for=list>For each</a> |policy| of |navigation request|'s
+            <a for="request">policy container</a>'s
+            <a for="policy container">CSP list</a>:
 
             1.  <a for=set>For each</a> |directive| of |policy|:
 


### PR DESCRIPTION
Complements https://github.com/w3c/webappsec-csp/pull/494 in order to make the spec consistent.

Preparation for fixing https://github.com/whatwg/html/issues/4651.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/692.html" title="Last updated on Nov 25, 2024, 1:31 PM UTC (619e08a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/692/a2c0141...619e08a.html" title="Last updated on Nov 25, 2024, 1:31 PM UTC (619e08a)">Diff</a>