### PR TITLE
Hash reporting for scripts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1643,10 +1643,10 @@ this algorithm returns normally if compilation is allowed, and throws a
     };
   </pre>
 
-  When a directive that impacts [=script-like=] [=request/destinations=] has a `report-hash` value,
-  and a [=/request=] with a [=script-like=] [=request/destination=] is fetched, a <dfn export>csp
-  hash report</dfn> will be generated and sent out to a reporting endpoint associated with the <a
-  for="/">policy</a>.
+  When a directive that impacts [=script-like=] [=request/destinations=] has a `report-sha256`,
+  `report-sha384` or `report-sha512` value, and a [=/request=] with a [=script-like=]
+  [=request/destination=] is fetched, a <dfn export>csp hash report</dfn> will be generated and
+  sent out to a reporting endpoint associated with the <a for="/">policy</a>.
 
   <p><a>csp hash reports</a> have the <a>report type</a> "csp-hash".</p>
 
@@ -1681,7 +1681,8 @@ Content-Type: application/reports+json
     "document_url": "https://example.com/",
     "subresource_url": "https://example.com/main.js",
     "hash": "sha256-badbeef",
-    "type": "subresource"
+    "type": "subresource",
+    "destination": "script"
   }
 }]
 ```

--- a/index.bs
+++ b/index.bs
@@ -167,6 +167,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   type:dfn;
     text:applying algorithm to bytes; url: #apply-algorithm-to-response
+    text: cryptographic hash function; url: #hash-functions
 
 </pre>
 <pre class="biblio">
@@ -1088,9 +1089,14 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
                   then set |result| to "`Blocked`".
           2. If |directive| is [=`report-hash`=] and |request|'s [=request/destination=] matches
              the |directive|'s [=directive/value=], then:
+              1.  Let |algo| be "sha-256" or another [=cryptographic hash function=].
               1.  Let |hash| be the empty [=string=].
-              1.  If |response| is [=CORS-same-origin=], set |hash| to the result of [=applying
-                  algorithm to bytes=] on |response|'s [=response/body=] and "sha-256".
+              1.  If |response| is [=CORS-same-origin=], then:
+                  1. Let |hash list| be a [=list=] of [=strings=], initially empty.
+                  1. [=list/Append=] |algo| to |hash list|.
+                  1. [=list/Append=] the result of [=applying algorithm to bytes=] on |response|'s
+                     [=response/body=] and |algo| to |hash list|.
+                  1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
               1.  Let |body| be a [=csp hash report body=] with the current document' URL as its
                   [=documentURL=], |request|'s URL as its [=subresourceURL=], |hash| as its
                   [=hash=], and "subresource" as its [=csp hash report body/type=].

--- a/index.bs
+++ b/index.bs
@@ -1119,11 +1119,10 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
       1. [=list/Append=] the result of [=applying algorithm to bytes=] on |response|'s
          [=response/body=] and |algorithm| to |hash list|.
       1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
-  1.  Let |document URL| be the empty [=string=].
   1.  Let |global| be the |request|'s [=request/client=]'s [=/global object=].
-  1.  If |global| is a {{Window}}, set |document URL| to |global|'s [=document=]'s [=Document/URL=].
+  1.  If |global| is not a {{Window}}, return.
   1.  Let |stripped document URL| to be the result of executing [[#strip-url-for-use-in-reports]]
-      on |document URL|.
+      on |global|'s [=document=]'s [=Document/URL=].
   1.  If |policy|'s [=directive set=] does not contain a [=directive=] named "report-to", return.
   1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
       set=].

--- a/index.bs
+++ b/index.bs
@@ -687,9 +687,12 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
     ; Keywords:
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>"
-                     / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>" /
+                     / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>"
                      / "<dfn>'report-sample'</dfn>" / "<dfn>'unsafe-allow-redirects'</dfn>"
                      / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'report-sha256'</dfn>"
+                     / "<dfn>'report-sha384'</dfn>" /"<dfn>'report-sha512'</dfn>"
+
+
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -1088,7 +1091,6 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
               2.  If |policy|'s <a for="policy">disposition</a> is "`enforce`",
                   then set |result| to "`Blocked`".
-          2. Call [=should report hash?=] with |response|, |request|, |directive| and |policy|.
 
       Note: This portion of the check verifies that the page can load the
       response. That is, that a Service Worker hasn't substituted a file which
@@ -1101,10 +1103,14 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   Given a [=response=] |response|, a [=/request=] |request|, a [=directive=] |directive| and a
   [=content security policy object=] |policy|, run the following steps:
 
-  1.  If |directive|'s <a for="directive">value</a> does not <a for="list">contain</a> the
-      expression "<a grammar>`'report-sha256'`</a>", or |directive|'s [=directive/name=]
-      is not "script-src", then return.
-  1.  Let |algo| be "sha-256".
+  1.  Let |algo| be the empty [=string=].
+  1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
+      expression "<a grammar>`'report-sha256'`</a>", set |algo| to "sha256".
+  1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
+      expression "<a grammar>`'report-sha384'`</a>", set |algo| to "sha384".
+  1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
+      expression "<a grammar>`'report-sha512'`</a>", set |algo| to "sha512".
+  1.  If |algo| is the empty [=string=], return.
   1.  Let |hash| be the empty [=string=].
   1.  If |response| is [=CORS-same-origin=], then:
       1. Let |hash list| be a [=list=] of [=strings=], initially empty.
@@ -3790,6 +3796,7 @@ this algorithm returns normally if compilation is allowed, and throws a
           |response|, |request|, |directive|'s <a for="directive">value</a>,
           and |policy|, is "`Does Not Match`", return "`Blocked`".
 
+      5. Call [=should report hash?=] with |response|, |request|, |directive| and |policy|.
   2.  Return "`Allowed`".
 
   <h4 id="matching-urls">URL Matching</h4>

--- a/index.bs
+++ b/index.bs
@@ -1660,7 +1660,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   When a document's response contains the headers:
 ```http
 Reporting-Endpoints: hashes-endpoint="https://example.com/reports"
-Content-Security-Policy: script-src 'report-sha256'; report-to hashes-endpoint
+Content-Security-Policy: script-src 'self' 'report-sha256'; report-to hashes-endpoint
 ```
   and the document loads the script "main.js", a report similar to the following one will be sent:
 ```http

--- a/index.bs
+++ b/index.bs
@@ -1660,7 +1660,7 @@ this algorithm returns normally if compilation is allowed, and throws a
   When a document's response contains the headers:
 ```http
 Reporting-Endpoints: hashes-endpoint="https://example.com/reports"
-Content-Security-Policy: report-hash; report-to hashes-endpoint
+Content-Security-Policy: script-src 'report-sha256'; report-to hashes-endpoint
 ```
   and the document loads the script "main.js", a report similar to the following one will be sent:
 ```http

--- a/index.bs
+++ b/index.bs
@@ -1122,10 +1122,12 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   1.  Let |document URL| be the empty [=string=].
   1.  Let |global| be the |request|'s [=request/client=]'s [=/global object=].
   1.  If |global| is a {{Window}}, set |document URL| to |global|'s [=document=]'s [=Document/URL=].
+  1.  Let |stripped document URL| to be the result of executing [[#strip-url-for-use-in-reports]]
+      on |document URL|.
   1.  If |policy|'s [=directive set=] does not contain a [=directive=] named "report-to", return.
   1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
       set=].
-  1.  Let |body| be a [=csp hash report body=] with |document URL| as its [=documentURL=],
+  1.  Let |body| be a [=csp hash report body=] with |stripped document URL| as its [=documentURL=],
       |request|'s URL as its [=subresourceURL=], |hash| as its
       [=hash=], and "subresource" as its [=csp hash report body/type=].
   1.  [=Generate and queue a report=] with the following arguments:
@@ -3792,17 +3794,19 @@ Content-Type: application/reports+json
 
   1.  If |request|'s <a for="request">destination</a> is <a for="request/destination">script-like</a>:
 
+      1. Call [=potentially report hash=] with |response|, |request|, |directive| and |policy|.
+
       1.  If the result of executing [[#match-nonce-to-source-list]] on
           |request|'s <a for="request">cryptographic nonce metadata</a> and this
           directive's <a for="directive">value</a> is "`Matches`", return
           "`Allowed`".
 
-      2.  If the result of executing
+      1.  If the result of executing
           [[#match-integrity-metadata-to-source-list]] on |request|'s <a
           for="request">integrity metadata</a> and this directive's <a
           for="directive">value</a> is "`Matches`", return "`Allowed`".
 
-      3.  If |directive|'s <a for="directive">value</a> contains
+      1.  If |directive|'s <a for="directive">value</a> contains
           "<a grammar>`'strict-dynamic'`</a>":
 
           1.  If |request|'s <a for="request">parser metadata</a> is not
@@ -3810,11 +3814,10 @@ Content-Type: application/reports+json
 
               Otherwise, return "`Blocked`".
 
-      4.  If the result of executing [[#match-response-to-source-list]] on
+      1.  If the result of executing [[#match-response-to-source-list]] on
           |response|, |request|, |directive|'s <a for="directive">value</a>,
           and |policy|, is "`Does Not Match`", return "`Blocked`".
 
-      5. Call [=potentially report hash=] with |response|, |request|, |directive| and |policy|.
   2.  Return "`Allowed`".
 
   <h4 id="matching-urls">URL Matching</h4>

--- a/index.bs
+++ b/index.bs
@@ -1662,7 +1662,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 Reporting-Endpoints: hashes-endpoint="https://example.com/reports"
 Content-Security-Policy: report-hash; report-to hashes-endpoint
 ```
-  and the document loads the script "main.js", a report similar to the following on will be sent:
+  and the document loads the script "main.js", a report similar to the following one will be sent:
 ```http
 POST /reports HTTP/1.1
 Host: example.com

--- a/index.bs
+++ b/index.bs
@@ -186,7 +186,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   "REPORTING": {
     "href": "https://wicg.github.io/reporting/",
     "title": "Reporting API",
-    "authors": [ "Ilya Gregorik", "Mike West" ]
+    "authors": [ "Ilya Grigorik", "Mike West" ]
   },
   "TIMING": {
       "href": "https://owasp.org/www-pdf-archive/HackPra_Allstars-Browser_Timing_Attacks_-_Paul_Stone.pdf",
@@ -1089,9 +1089,11 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
           2. If |directive| is [=`report-hash`=] and |request|'s [=request/destination=] matches
              the |directive|'s [=directive/value=], then:
               1.  Let |hash| be the empty [=string=].
-              1.  If |request| is CORS enabled, set |hash| to the result of [=applying algorithm to bytes=] on response's bytes and "sha-256".
-              1.  Let |body| be a [=csp hash report body=] with the current document' URL as its [=documentURL=],
-                  |request|'s URL as its [=subresourceURL=] and |hash| as its [=hash=].
+              1.  If |response| is [=CORS-same-origin=], set |hash| to the result of [=applying
+                  algorithm to bytes=] on |response|'s [=response/body=] and "sha-256".
+              1.  Let |body| be a [=csp hash report body=] with the current document' URL as its
+                  [=documentURL=], |request|'s URL as its [=subresourceURL=], |hash| as its
+                  [=hash=], and "subresource" as its [=csp hash report body/type=].
               1.  [=Generate and queue a report=] with the following arguments:
                   :   <var ignore>context</var>
                   ::  <var ignore>settings object</var>
@@ -1623,7 +1625,8 @@ this algorithm returns normally if compilation is allowed, and throws a
   <p>A <dfn>csp hash report body</dfn> is a [=struct=] with the following fields:
       <dfn for="csp hash report body">documentURL</dfn>,
       <dfn for="csp hash report body">subresourceURL</dfn>,
-      <dfn for="csp hash report body">hash</dfn>.
+      <dfn for="csp hash report body">hash</dfn>,
+      <dfn for="csp hash report body">type</dfn>.
 
   <h3 id="violation-events">
     Violation DOM Events

--- a/index.bs
+++ b/index.bs
@@ -689,7 +689,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
     <dfn>keyword-source</dfn> = "<dfn>'self'</dfn>" / "<dfn>'unsafe-inline'</dfn>" / "<dfn>'unsafe-eval'</dfn>"
                      / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>" /
                      / "<dfn>'report-sample'</dfn>" / "<dfn>'unsafe-allow-redirects'</dfn>"
-                     / "<dfn>'wasm-unsafe-eval'</dfn>"
+                     / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'report-sha256'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -700,6 +700,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
     ; Digests: 'sha256-[digest goes here]'
     <dfn>hash-source</dfn>    = "'" <a>hash-algorithm</a> "-" <a>base64-value</a> "'"
     <dfn>hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
+
   </pre>
 
   The <a grammar>host-char</a> production intentionally contains only ASCII
@@ -1087,9 +1088,10 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
               2.  If |policy|'s <a for="policy">disposition</a> is "`enforce`",
                   then set |result| to "`Blocked`".
-          2. If |directive| is [=`report-hash`=] and |request|'s [=request/destination=] matches
-             the |directive|'s [=directive/value=], then:
-              1.  Let |algo| be "sha-256" or another [=cryptographic hash function=].
+          2.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
+              expression "<a grammar>`'report-sha256'`</a>" and |directive|'s [=directive/name=]
+              is "script-src", then:
+              1.  Let |algo| be "sha-256".
               1.  Let |hash| be the empty [=string=].
               1.  If |response| is [=CORS-same-origin=], then:
                   1. Let |hash list| be a [=list=] of [=strings=], initially empty.

--- a/index.bs
+++ b/index.bs
@@ -1082,6 +1082,21 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
               2.  If |policy|'s <a for="policy">disposition</a> is "`enforce`",
                   then set |result| to "`Blocked`".
+          2. If |directive| is [=`report-hash`=] and |request|'s [=request/destination=] matches
+             the |directive|'s [=directive/value=], then:
+              1.  Let |hash| be the empty [=string=].
+              1.  If |request| is CORS enabled, set |hash| to the result of [=applying algorithm to bytes=] on response's bytes and "sha-256".
+              1.  Let |body| be a [=csp hash report body=] with the current document' URL as its [=documentURL=],
+                  |request|'s URL as its [=subresourceURL=] and |hash| as its [=hash=].
+              1.  [=Generate and queue a report=] with the following arguments:
+                  :   <var ignore>context</var>
+                  ::  |settings object|
+                  :   <var ignore>type</var>
+                  ::  "csp-hash"
+                  :   <var ignore>destination</var>
+                  ::  |directive|'s <a for="directive">value</a>.
+                  :   <var ignore>data</var>
+                  ::  |body|
 
       Note: This portion of the check verifies that the page can load the
       response. That is, that a Service Worker hasn't substituted a file which
@@ -1592,6 +1607,19 @@ this algorithm returns normally if compilation is allowed, and throws a
       readonly attribute unsigned long? columnNumber;
     };
   </pre>
+
+  When a [=`report-hash`=] directive is present, <dfn export>csp hash report</dfn> may be generated
+  and sent out to a reporting endpoint associated with the <a for="/">policy</a>.
+
+  <p><a>csp hash reports</a> have the <a>report type</a> "csp-hash".</p>
+
+  <p><a>csp violation reports</a> are not <a>visible to
+  <code>ReportingObserver</code>s</a>.
+
+  <p>A <dfn>csp hash report body</dfn> is a [=struct=] with the following fields:
+      <dfn for="csp hash report body">documentURL</dfn>,
+      <dfn for="csp hash report body">subresourceURL</dfn>,
+      <dfn for="csp hash report body">hash</dfn>.
 
   <h3 id="violation-events">
     Violation DOM Events
@@ -3627,6 +3655,17 @@ this algorithm returns normally if compilation is allowed, and throws a
 
   <pre>
     directive-name  = "report-to"
+    directive-value = <a grammar>token</a>
+  </pre>
+
+  <h4 id="directive-report-hash">`report-hash`</h4>
+
+  The <dfn export>`report-hash`</dfn> directive signifies that script hash reports
+  should be sent to <a lt="endpoint">reporting endpoints</a> [[REPORTING]]. The
+  directive's name and value are described by the following ABNF:
+
+  <pre>
+    directive-name  = "report-hash"
     directive-value = <a grammar>token</a>
   </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -164,6 +164,10 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
   type:dfn
     text: administratively-prohibited; url: #dfn-administratively-prohibited
 
+spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
+  type:dfn;
+    text:applying algorithm to bytes; url: #apply-algorithm-to-response
+
 </pre>
 <pre class="biblio">
 {
@@ -1090,7 +1094,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
                   |request|'s URL as its [=subresourceURL=] and |hash| as its [=hash=].
               1.  [=Generate and queue a report=] with the following arguments:
                   :   <var ignore>context</var>
-                  ::  |settings object|
+                  ::  <var ignore>settings object</var>
                   :   <var ignore>type</var>
                   ::  "csp-hash"
                   :   <var ignore>destination</var>

--- a/index.bs
+++ b/index.bs
@@ -690,9 +690,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
                      / "<dfn>'strict-dynamic'</dfn>" / "<dfn>'unsafe-hashes'</dfn>"
                      / "<dfn>'report-sample'</dfn>" / "<dfn>'unsafe-allow-redirects'</dfn>"
                      / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'report-sha256'</dfn>"
-                     / "<dfn>'report-sha384'</dfn>" /"<dfn>'report-sha512'</dfn>"
-
-
+                     / "<dfn>'report-sha384'</dfn>" / "<dfn>'report-sha512'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -703,7 +701,6 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
     ; Digests: 'sha256-[digest goes here]'
     <dfn>hash-source</dfn>    = "'" <a>hash-algorithm</a> "-" <a>base64-value</a> "'"
     <dfn>hash-algorithm</dfn> = "sha256" / "sha384" / "sha512"
-
   </pre>
 
   The <a grammar>host-char</a> production intentionally contains only ASCII
@@ -1103,29 +1100,29 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   Given a [=response=] |response|, a [=/request=] |request|, a [=directive=] |directive| and a
   [=content security policy object=] |policy|, run the following steps:
 
-  1.  Let |algo| be the empty [=string=].
+  1.  Let |algorithm| be the empty [=string=].
   1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
-      expression "<a grammar>`'report-sha256'`</a>", set |algo| to "sha256".
+      expression "<a grammar>`'report-sha256'`</a>", set |algorithm| to "sha256".
   1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
-      expression "<a grammar>`'report-sha384'`</a>", set |algo| to "sha384".
+      expression "<a grammar>`'report-sha384'`</a>", set |algorithm| to "sha384".
   1.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
-      expression "<a grammar>`'report-sha512'`</a>", set |algo| to "sha512".
-  1.  If |algo| is the empty [=string=], return.
+      expression "<a grammar>`'report-sha512'`</a>", set |algorithm| to "sha512".
+  1.  If |algorithm| is the empty [=string=], return.
   1.  Let |hash| be the empty [=string=].
   1.  If |response| is [=CORS-same-origin=], then:
       1. Let |hash list| be a [=list=] of [=strings=], initially empty.
-      1. [=list/Append=] |algo| to |hash list|.
+      1. [=list/Append=] |algorithm| to |hash list|.
       1. [=list/Append=] the result of [=applying algorithm to bytes=] on |response|'s
-         [=response/body=] and |algo| to |hash list|.
+         [=response/body=] and |algorithm| to |hash list|.
       1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
   1.  Let |document URL| be the empty [=string=].
   1.  Let |global| be the |request|'s [=request/client=]'s [=/global object=].
-  1.  If |global| is a [=/Window=], set |document URL| to |global|'s [=document=]'s URL.
+  1.  If |global| is a {{Window}}, set |document URL| to |global|'s [=document=]'s URL.
   1.  If |policy|'s [=directive set=] does not contain a [=directive=] named "report-to", return.
   1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
       set=].
-  1.  Let |body| be a [=csp hash report body=] with the |document URL| as its
-      [=documentURL=], |request|'s URL as its [=subresourceURL=], |hash| as its
+  1.  Let |body| be a [=csp hash report body=] with |document URL| as its [=documentURL=],
+      |request|'s URL as its [=subresourceURL=], |hash| as its
       [=hash=], and "subresource" as its [=csp hash report body/type=].
   1.  [=Generate and queue a report=] with the following arguments:
       :   <var ignore>context</var>
@@ -1640,8 +1637,8 @@ this algorithm returns normally if compilation is allowed, and throws a
     };
   </pre>
 
-  When a directive has a `report-hash` value, <dfn export>csp hash report</dfn> may be generated and
-  sent out to a reporting endpoint associated with the <a for="/">policy</a>.
+  When a directive has a `report-hash` value, a <dfn export>csp hash report</dfn> may be generated
+  and sent out to a reporting endpoint associated with the <a for="/">policy</a>.
 
   <p><a>csp hash reports</a> have the <a>report type</a> "csp-hash".</p>
 

--- a/index.bs
+++ b/index.bs
@@ -1098,7 +1098,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
   4.  Return |result|.
 
-  <h4 id="should-report-hash" algorithm dfn export>Should report hash?</h4>
+  <h4 id="potentially-report-hash" algorithm dfn export>Potentially report hash</h4>
 
   Given a [=response=] |response|, a [=/request=] |request|, a [=directive=] |directive| and a
   [=content security policy object=] |policy|, run the following steps:
@@ -1640,13 +1640,12 @@ this algorithm returns normally if compilation is allowed, and throws a
     };
   </pre>
 
-  When a [=`report-hash`=] directive is present, <dfn export>csp hash report</dfn> may be generated
-  and sent out to a reporting endpoint associated with the <a for="/">policy</a>.
+  When a directive has a `report-hash` value, <dfn export>csp hash report</dfn> may be generated and
+  sent out to a reporting endpoint associated with the <a for="/">policy</a>.
 
   <p><a>csp hash reports</a> have the <a>report type</a> "csp-hash".</p>
 
-  <p><a>csp violation reports</a> are not <a>visible to
-  <code>ReportingObserver</code>s</a>.
+  <p><a>csp hash reports</a> are not <a>visible to <code>ReportingObserver</code>s</a>.
 
   <p>A <dfn>csp hash report body</dfn> is a [=struct=] with the following fields:
       <dfn for="csp hash report body">documentURL</dfn>,
@@ -3691,17 +3690,6 @@ this algorithm returns normally if compilation is allowed, and throws a
     directive-value = <a grammar>token</a>
   </pre>
 
-  <h4 id="directive-report-hash">`report-hash`</h4>
-
-  The <dfn export>`report-hash`</dfn> directive signifies that script hash reports
-  should be sent to <a lt="endpoint">reporting endpoints</a> [[REPORTING]]. The
-  directive's name and value are described by the following ABNF:
-
-  <pre>
-    directive-name  = "report-hash"
-    directive-value = <a grammar>token</a>
-  </pre>
-
   <h3 id="directives-elsewhere">
     Directives Defined in Other Documents
   </h3>
@@ -3796,7 +3784,7 @@ this algorithm returns normally if compilation is allowed, and throws a
           |response|, |request|, |directive|'s <a for="directive">value</a>,
           and |policy|, is "`Does Not Match`", return "`Blocked`".
 
-      5. Call [=should report hash?=] with |response|, |request|, |directive| and |policy|.
+      5. Call [=potentially report hash=] with |response|, |request|, |directive| and |policy|.
   2.  Return "`Allowed`".
 
   <h4 id="matching-urls">URL Matching</h4>

--- a/index.bs
+++ b/index.bs
@@ -1088,29 +1088,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
               2.  If |policy|'s <a for="policy">disposition</a> is "`enforce`",
                   then set |result| to "`Blocked`".
-          2.  If |directive|'s <a for="directive">value</a> <a for="list">contains</a> the
-              expression "<a grammar>`'report-sha256'`</a>" and |directive|'s [=directive/name=]
-              is "script-src", then:
-              1.  Let |algo| be "sha-256".
-              1.  Let |hash| be the empty [=string=].
-              1.  If |response| is [=CORS-same-origin=], then:
-                  1. Let |hash list| be a [=list=] of [=strings=], initially empty.
-                  1. [=list/Append=] |algo| to |hash list|.
-                  1. [=list/Append=] the result of [=applying algorithm to bytes=] on |response|'s
-                     [=response/body=] and |algo| to |hash list|.
-                  1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
-              1.  Let |body| be a [=csp hash report body=] with the current document' URL as its
-                  [=documentURL=], |request|'s URL as its [=subresourceURL=], |hash| as its
-                  [=hash=], and "subresource" as its [=csp hash report body/type=].
-              1.  [=Generate and queue a report=] with the following arguments:
-                  :   <var ignore>context</var>
-                  ::  <var ignore>settings object</var>
-                  :   <var ignore>type</var>
-                  ::  "csp-hash"
-                  :   <var ignore>destination</var>
-                  ::  |directive|'s <a for="directive">value</a>.
-                  :   <var ignore>data</var>
-                  ::  |body|
+          2. Call [=should report hash?=] with |response|, |request|, |directive| and |policy|.
 
       Note: This portion of the check verifies that the page can load the
       response. That is, that a Service Worker hasn't substituted a file which
@@ -1118,6 +1096,40 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
   4.  Return |result|.
 
+  <h4 id="should-report-hash" algorithm dfn export>Should report hash?</h4>
+
+  Given a [=response=] |response|, a [=/request=] |request|, a [=directive=] |directive| and a
+  [=content security policy object=] |policy|, run the following steps:
+
+  1.  If |directive|'s <a for="directive">value</a> does not <a for="list">contain</a> the
+      expression "<a grammar>`'report-sha256'`</a>", or |directive|'s [=directive/name=]
+      is not "script-src", then return.
+  1.  Let |algo| be "sha-256".
+  1.  Let |hash| be the empty [=string=].
+  1.  If |response| is [=CORS-same-origin=], then:
+      1. Let |hash list| be a [=list=] of [=strings=], initially empty.
+      1. [=list/Append=] |algo| to |hash list|.
+      1. [=list/Append=] the result of [=applying algorithm to bytes=] on |response|'s
+         [=response/body=] and |algo| to |hash list|.
+      1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
+  1.  Let |document URL| be the empty [=string=].
+  1.  Let |global| be the |request|'s [=request/client=]'s [=/global object=].
+  1.  If |global| is a [=/Window=], set |document URL| to |global|'s [=document=]'s URL.
+  1.  If |policy|'s [=directive set=] does not contain a [=directive=] named "report-to", return.
+  1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
+      set=].
+  1.  Let |body| be a [=csp hash report body=] with the |document URL| as its
+      [=documentURL=], |request|'s URL as its [=subresourceURL=], |hash| as its
+      [=hash=], and "subresource" as its [=csp hash report body/type=].
+  1.  [=Generate and queue a report=] with the following arguments:
+      :   <var ignore>context</var>
+      ::  <var ignore>settings object</var>
+      :   <var ignore>type</var>
+      ::  "csp-hash"
+      :   <var ignore>destination</var>
+      ::  |report-to directive|'s [=directive/value=].
+      :   <var ignore>data</var>
+      ::  |body|
 
   <h3 id="html-integration">
     Integration with HTML

--- a/index.bs
+++ b/index.bs
@@ -1637,8 +1637,10 @@ this algorithm returns normally if compilation is allowed, and throws a
     };
   </pre>
 
-  When a directive has a `report-hash` value, a <dfn export>csp hash report</dfn> may be generated
-  and sent out to a reporting endpoint associated with the <a for="/">policy</a>.
+  When a directive that impacts [=script-like=] [=request/destinations=] has a `report-hash` value,
+  and a [=/request=] with a [=script-like=] [=request/destination=] is fetched, a <dfn export>csp
+  hash report</dfn> will be generated and sent out to a reporting endpoint associated with the <a
+  for="/">policy</a>.
 
   <p><a>csp hash reports</a> have the <a>report type</a> "csp-hash".</p>
 
@@ -1650,6 +1652,33 @@ this algorithm returns normally if compilation is allowed, and throws a
       <dfn for="csp hash report body">hash</dfn>,
       <dfn for="csp hash report body">type</dfn>.
 
+  <div class="example">
+  When a document's response contains the headers:
+```http
+Reporting-Endpoints: hashes-endpoint="https://example.com/reports"
+Content-Security-Policy: report-hash; report-to hashes-endpoint
+```
+  and the document loads the script "main.js", a report similar to the following on will be sent:
+```http
+POST /reports HTTP/1.1
+Host: example.com
+...
+Content-Type: application/reports+json
+
+[{
+  "type": "csp-hash-report",
+  "age": 12,
+  "url": "https://example.com/",
+  "user_agent": "Mozilla/5.0 (X11; Linux i686; rv:132.0) Gecko/20100101 Firefox/132.0",
+  "body": {
+    "document_url": "https://example.com/",
+    "subresource_url": "https://example.com/main.js",
+    "hash": "sha256-badbeef",
+    "type": "subresource"
+  }
+}]
+```
+  </div>
   <h3 id="violation-events">
     Violation DOM Events
   </h3>

--- a/index.bs
+++ b/index.bs
@@ -22,7 +22,11 @@ Markup Shorthands: css off, markdown on
 At Risk: The [[#is-element-nonceable]] algorithm.
 </pre>
 <pre class="link-defaults">
-spec:dom; type:interface; text:Document
+spec:dom;
+  type: interface
+    text: Document
+  type: dfn
+    text: URL; url: https://dom.spec.whatwg.org/#dom-document-url
 spec:html
   type: dfn
     text: fallback base url
@@ -1117,7 +1121,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
       1. Let |hash| be the result of [=concatenating=] |hash list| with U+002D (-).
   1.  Let |document URL| be the empty [=string=].
   1.  Let |global| be the |request|'s [=request/client=]'s [=/global object=].
-  1.  If |global| is a {{Window}}, set |document URL| to |global|'s [=document=]'s URL.
+  1.  If |global| is a {{Window}}, set |document URL| to |global|'s [=document=]'s [=Document/URL=].
   1.  If |policy|'s [=directive set=] does not contain a [=directive=] named "report-to", return.
   1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
       set=].

--- a/index.bs
+++ b/index.bs
@@ -1127,8 +1127,9 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   1.  Let |report-to directive| be a [=directive=] named "report-to" from |policy|'s [=directive
       set=].
   1.  Let |body| be a [=csp hash report body=] with |stripped document URL| as its [=documentURL=],
-      |request|'s URL as its [=subresourceURL=], |hash| as its
-      [=hash=], and "subresource" as its [=csp hash report body/type=].
+      |request|'s URL as its [=subresourceURL=], |hash| as its [=hash=], |request|'s
+      [=request/destination=] as its [=csp hash report body/destination=], and "subresource" as its
+      [=csp hash report body/type=].
   1.  [=Generate and queue a report=] with the following arguments:
       :   <var ignore>context</var>
       ::  <var ignore>settings object</var>
@@ -1655,6 +1656,7 @@ this algorithm returns normally if compilation is allowed, and throws a
       <dfn for="csp hash report body">documentURL</dfn>,
       <dfn for="csp hash report body">subresourceURL</dfn>,
       <dfn for="csp hash report body">hash</dfn>,
+      <dfn for="csp hash report body">destination</dfn>,
       <dfn for="csp hash report body">type</dfn>.
 
   <div class="example">


### PR DESCRIPTION
TL;DR - As discussed at https://github.com/yoavweiss/subresource-reporting/issues/4 and on the [WG call](https://github.com/w3c/webappsec/blob/main/meetings/2024/2024-11-20-minutes.md#subresource-reporting-and-csp), this PR adds a new CSP keyword "report-hash", which triggers a new reporting type "csp-hash-report".

# "report-hash" CSP keyword

Complex web applications often need to keep tabs of the subresources that they download, for security purposes.

In particular, upcoming industry standards and best practices (e.g. [PCI-DSS v4](https://east.pcisecuritystandards.org/document_library?category=pcidss&document=pci_dss) - [context](https://docs.google.com/document/d/1RcUpbpWPxXTyW0Qwczs9GCTLPD3-LcbbhL4ooBUevTM/edit?tab=t.0#heading=h.dzquzu6onmmy)) require that web applications keep an inventory of all the scripts they download and execute.

This document proposes a new CSP keyword,
that would enable web developers to create and maintain such inventories in a secure manner.

## Problem

Web developers load many different script assets to their sites, and those scripts can then load other assets.
Some of those assets are versioned and their content's integrity can be validated using [Subresource Integrity](https://w3c.github.io/webappsec-subresource-integrity/) or using [Content Security Policy hashes](https://www.w3.org/TR/CSP3/#grammardef-hash-source). But those are hard to deploy when there's no current way to collect the hashes of all the scripts running on your site.

For dynamic assets, ensuring their integrity is even harder, as they are ever-green scripts that can be updated by their provider at any moment.
The web platform has no means of validating their integrity, neither in reporting nor in enforcement mode.

At the same time, [upcoming security standards](https://docs.google.com/document/d/1RcUpbpWPxXTyW0Qwczs9GCTLPD3-LcbbhL4ooBUevTM/edit?tab=t.0#heading=h.dzquzu6onmmy) require web developers to maintain an up to date inventory of all scripts that execute in the context of their payment page documents,
and have a mechanism to validate their integrity.

In the absence of better mechanisms, developers and merchants will need to settle for lower fidelity security guarantees — e.g. offline hash verification through crawling.
Such mechanisms leave a lot to be desired in terms of their coverage, while at the same time add a lot of implementation complexity. We need a better path.

## Proposal

A new CSP keyword could be used to send reports of all scripts executed in the context of the relevant document,
including their URLs and their hashes (for CORS-enabled or same-origin resources).

That would enable developers to set up endpoints that collect these reports, and process them to maintain an up to date and accurate
inventory of scripts and their integrity for relevant pages.

### Flow
Developers can set the following headers on their navigation responses:
```http
Reporting-Endpoints: hashes-endpoint="https://example.com/reports"
Content-Security-Policy: script-src 'report-sha256'; report-to hashes-endpoint
```

Each loaded and executed script would then [generate and queue a report](https://www.w3.org/TR/reporting-1/#generate-and-queue-a-report) with the resource's URL and, if the response is [CORS-same-origin](https://html.spec.whatwg.org/#cors-same-origin), its integrity [digest](https://w3c.github.io/webappsec-subresource-integrity/#digest).

That would eventually send a report that looks something like the following:
```
POST /reports HTTP/1.1
Host: example.com
...
Content-Type: application/reports+json

[{
  "type": "csp-hash-report",
  "age": 12,
  "url": "https://example.com/",
  "user_agent": "Mozilla/5.0 (X11; Linux i686; rv:132.0) Gecko/20100101 Firefox/132.0",
  "body": {
    "document_url": "https://example.com/",
    "subresource_url": "https://example.com/main.js",
    "hash": "sha256-badbeef",
    "type": "subresource",
    "destination": "script"
  }
}]
```

If multiple CSP hash reports would be queued before reports are sent (at a user agent defined time), the user agent
[will serialize the entire list of reports](https://www.w3.org/TR/reporting-1/#try-delivery) and send them in a single report.

The "type" attribute of the report provides room for future extensibility, where we could add hashes for inline scripts, evals, inline event handlers or javascript: URLs. 

These reports would have no visibility to ReportingObserver, as there are no current use cases for it.

We need a new report type as these reports are different in nature from violation reports, and they are triggered at a very different point of the request's lifecycle (at least for subresources).

## Considered alternatives

### Resource-timing

The Resource Timing API can be used to gather up all the URLs of script resources in a document today.

It could also be extended to provide an integrity hash for CORS-enabled or same-origin resources. 

However, that is not ideal because:
* Currently browsers don’t calculate these hashes, so starting to calculate them for all scripts in all documents could introduce some overhead.
  Therefore, adding hashes to resource timing may require some opt-in mechanism.
* Malicious scripts on the site can tamper with Resource Timing data and obfuscate their presence on the page (by e.g. reporting known-good hashes instead of their own).

### Service workers

A Service Worker can tee the response streams for CORS-enabled scripts, calculate their hashes and report them to the server.

There are a few fundemental issues with that approach though:
* A Service Worker will not cover the first time a site loads.
* Service Worker can be uninstalled by an attacker.
* A Service Worker can add overhead (even if future optimizations can reduce that).

### A dedicated Subresource Reporting feature

This is something considered in https://github.com/yoavweiss/subresource-reporting, but following discussions on https://github.com/yoavweiss/subresource-reporting/issues/4 and on the [WG call](https://github.com/w3c/webappsec/blob/main/meetings/2024/2024-11-20-minutes.md#subresource-reporting-and-csp), we decided that integrating the feature as part of CSP would enable developers to better take advantage of it in order to deploy hash-based CSP restrictions.

## Security & Privacy considerations

This proposal doesn't expose new information when it comes to URLs - URLs are already exposed in Resource Timing and Service Workers,
and developers can use the `initiatorType` or `Request.destination` respectively to get that information, albeit in less-secure and more complex ways.

Resource hashes are not currently exposed, but we plan to expose them only for CORS-enabled or same-origin resources, that the document can already fully read.
That means that developers can already fetch those resources and calculate their hashes on their own. (again, with added complexity)

## Open questions

* Would the CORS requirement prevent popular scripts from having their hashes collected?
  - If so, do we need a complementary Document-Policy that enforces CORS for all subresources?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/webappsec-csp/pull/693.html" title="Last updated on Dec 6, 2024, 9:00 AM UTC (5a988bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/693/a2c0141...yoavweiss:5a988bd.html" title="Last updated on Dec 6, 2024, 9:00 AM UTC (5a988bd)">Diff</a>