### PR TITLE
Fix eval compilationSink in EnsureCSPDoesNotBlockStringCompilation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1443,7 +1443,7 @@ spec: WebRTC; urlPrefix: https://www.w3.org/TR/webrtc/
 
   1.  Else:
 
-      1.  Let |compilationSink| be "Function" if |compilationType| is "`FUNCTION`", and "Eval" otherwise.
+      1.  Let |compilationSink| be "Function" if |compilationType| is "`FUNCTION`", and "eval" otherwise.
 
       1.  Let |isTrusted| be `true` if |bodyArg| [=implements=] {{TrustedScript}}, and `false` otherwise.
 


### PR DESCRIPTION
Closes #695


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/webappsec-csp/pull/699.html" title="Last updated on Dec 4, 2024, 11:27 AM UTC (939e6c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/699/a2c0141...fred-wang:939e6c4.html" title="Last updated on Dec 4, 2024, 11:27 AM UTC (939e6c4)">Diff</a>