### PR TITLE
Change x-frame-options obsoletes wording

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3677,7 +3677,7 @@ Content-Type: application/reports+json
   header's \``DENY`\`, and `'self'` to that header's \``SAMEORIGIN`\`. [[!HTML]]
 
   In order to allow backwards-compatible deployment, the
-  <a>`frame-ancestors`</a> directive <em>supersedes</em> the
+  <a>`frame-ancestors`</a> directive <em>overrides</em> the
   \`<code>[:X-Frame-Options:]</code>\` header. If a resource is delivered with
   a <a for="/">policy</a> that includes a <a>directive</a> named
   <a>`frame-ancestors`</a> and whose <a for="policy">disposition</a> is

--- a/index.bs
+++ b/index.bs
@@ -3677,7 +3677,7 @@ Content-Type: application/reports+json
   header's \``DENY`\`, and `'self'` to that header's \``SAMEORIGIN`\`. [[!HTML]]
 
   In order to allow backwards-compatible deployment, the
-  <a>`frame-ancestors`</a> directive <em>obsoletes</em> the
+  <a>`frame-ancestors`</a> directive <em>supersedes</em> the
   \`<code>[:X-Frame-Options:]</code>\` header. If a resource is delivered with
   a <a for="/">policy</a> that includes a <a>directive</a> named
   <a>`frame-ancestors`</a> and whose <a for="policy">disposition</a> is


### PR DESCRIPTION
As discussed at https://github.com/whatwg/html/issues/10936#issuecomment-2604422113 "obsoletes" seems to be being misconstrued to mean X-Frame-Options should no longer be used when that was not the intent.

So I'm suggesting "overrides" as a better word? Or could go with "supplants" or "supersedes" (though they may have same issue as "obsoletes")?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tunetheweb/webappsec-csp/pull/702.html" title="Last updated on Jan 23, 2025, 3:59 PM UTC (d7638be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/702/bd58fec...tunetheweb:d7638be.html" title="Last updated on Jan 23, 2025, 3:59 PM UTC (d7638be)">Diff</a>