### PR TITLE
[Editorial] Fix csp-hash report type in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1679,7 +1679,7 @@ Host: example.com
 Content-Type: application/reports+json
 
 [{
-  "type": "csp-hash-report",
+  "type": "csp-hash",
   "age": 12,
   "url": "https://example.com/",
   "user_agent": "Mozilla/5.0 (X11; Linux i686; rv:132.0) Gecko/20100101 Firefox/132.0",


### PR DESCRIPTION
Fixes #726


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/729.html" title="Last updated on May 30, 2025, 8:10 AM UTC (7c16d30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/729/af1af21...antosart:7c16d30.html" title="Last updated on May 30, 2025, 8:10 AM UTC (7c16d30)">Diff</a>