### PR TITLE
Fix URL in report-uri request

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1930,7 +1930,7 @@ Content-Type: application/reports+json
                   :   <a for="request">method</a>
                   ::  "`POST`"
                   :   <a for="request">url</a>
-                  ::  |violation|'s <a for="violation">url</a>
+                  ::  |endpoint|
                   :   <a for="request">origin</a>
                   ::  |violation|'s <a for="violation">global object</a>'s <a>relevant settings
                       object</a>'s <a for="environment settings object">origin</a>


### PR DESCRIPTION
The endpoint variable appears to be unused. Looking at the creation of the request, I think the intention was to use it in the URL. That's also what other browsers appear to be doing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/webappsec-csp/pull/731.html" title="Last updated on Jun 1, 2025, 7:40 AM UTC (26f1fff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/731/2d2653d...TimvdLippe:26f1fff.html" title="Last updated on Jun 1, 2025, 7:40 AM UTC (26f1fff)">Diff</a>