### PR TITLE
Change CSPViolationReportBody to dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1632,20 +1632,18 @@ this algorithm returns normally if compilation is allowed, and throws a
   <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
-    [Exposed=Window]
-    interface CSPViolationReportBody : ReportBody {
-      [Default] object toJSON();
-      readonly attribute USVString documentURL;
-      readonly attribute USVString? referrer;
-      readonly attribute USVString? blockedURL;
-      readonly attribute DOMString effectiveDirective;
-      readonly attribute DOMString originalPolicy;
-      readonly attribute USVString? sourceFile;
-      readonly attribute DOMString? sample;
-      readonly attribute SecurityPolicyViolationEventDisposition disposition;
-      readonly attribute unsigned short statusCode;
-      readonly attribute unsigned long? lineNumber;
-      readonly attribute unsigned long? columnNumber;
+    dictionary CSPViolationReportBody : ReportBody {
+      USVString documentURL;
+      USVString? referrer;
+      USVString? blockedURL;
+      DOMString effectiveDirective;
+      DOMString originalPolicy;
+      USVString? sourceFile;
+      DOMString? sample;
+      SecurityPolicyViolationEventDisposition disposition;
+      unsigned short statusCode;
+      unsigned long? lineNumber;
+      unsigned long? columnNumber;
     };
   </pre>
 


### PR DESCRIPTION
Following the changes in w3c/reporting#284 all report bodies now need to be dictionaries, following the conclusion of w3c/reporting#216


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/webappsec-csp/pull/737.html" title="Last updated on Jun 18, 2025, 5:57 PM UTC (4c491cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/737/7690298...TimvdLippe:4c491cd.html" title="Last updated on Jun 18, 2025, 5:57 PM UTC (4c491cd)">Diff</a>