### PR TITLE
Fix path matching in match-url-to-source-expression

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4077,8 +4077,7 @@ Content-Type: application/reports+json
       6.  If |expression| contains a non-empty <a grammar>`path-part`</a>, and
           |redirect count| is 0, then:
 
-          1.  Let |path| be the resulting of joining |url|'s <a for="url">path</a>
-              on the U+002F SOLIDUS character (`/`).
+          1.  Let |path| be the result of running the <a>URL path serializer</a> on |url|.
 
           2.  If |expression|'s <a grammar>`path-part`</a> does not <a>`path-part` match</a> |path|,
               return "`Does Not Match`".


### PR DESCRIPTION
Fixes #772.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/773.html" title="Last updated on Jun 30, 2025, 12:04 PM UTC (c9d7f4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/773/a441899...antosart:c9d7f4b.html" title="Last updated on Jun 30, 2025, 12:04 PM UTC (c9d7f4b)">Diff</a>