### PR TITLE
[Editorial] Fix reference to parse-metadata in SRI

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3939,7 +3939,7 @@ Content-Type: application/reports+json
   3.  If |integrity expressions| is empty, return "`Does Not Match`".
 
   4.  Let |integrity sources| be the result of executing the algorithm defined
-      in [[SRI#parse-metadata]] on |integrity metadata|. [[!SRI]]
+      in [[SRI#parse-metadata-section]] on |integrity metadata|. [[!SRI]]
 
   5.  If |integrity sources| is "`no metadata`" or an empty set, return "`Does
       Not Match`".


### PR DESCRIPTION
The section in Subresource Integrity was renamed in https://github.com/w3c/webappsec-subresource-integrity/pull/135. We should probably reference the algorithm and not the section, we can do that once it is exported (https://github.com/w3c/webappsec-subresource-integrity/pull/152).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/777.html" title="Last updated on Jul 10, 2025, 6:28 AM UTC (33f8a0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/777/97e4a82...antosart:33f8a0d.html" title="Last updated on Jul 10, 2025, 6:28 AM UTC (33f8a0d)">Diff</a>