### PR TITLE
[Editorial] Reference algorithm instead of section for parse-metadata in SRI

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3938,8 +3938,8 @@ Content-Type: application/reports+json
 
   3.  If |integrity expressions| is empty, return "`Does Not Match`".
 
-  4.  Let |integrity sources| be the result of executing the algorithm defined
-      in [[SRI#parse-metadata-section]] on |integrity metadata|. [[!SRI]]
+  4.  Let |integrity sources| be the result of <a>parsing metadata</a> given
+      |integrity metadata|. [[!SRI]]
 
   5.  If |integrity sources| is "`no metadata`" or an empty set, return "`Does
       Not Match`".


### PR DESCRIPTION
Now that the algorithm "parse metadata" is exposed in Subresource Integrity, referencing it directly seems better than referencing the section it is included in.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/778.html" title="Last updated on Jul 11, 2025, 6:05 AM UTC (13d6934)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/778/1137e96...antosart:13d6934.html" title="Last updated on Jul 11, 2025, 6:05 AM UTC (13d6934)">Diff</a>