### PR TITLE
Extend CSP script-src hashes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1830,6 +1830,7 @@ Content-Type: application/reports+json
   3. Return the result of executing the <a>URL serializer</a> on |result|.
 
   <h3 id="strip-https-url" algorithm>Strip HTTP(S) URL</h3>
+
   Given a [=/URL=] |url|, this algorithm returns the URL with potentially
   sensitive fields blanked.
 


### PR DESCRIPTION
This implements the work described in https://github.com/w3ctag/design-reviews/issues/1128


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carlosjoan91/webappsec-csp/pull/784.html" title="Last updated on Sep 18, 2025, 9:49 PM UTC (4a5576d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/784/9dd7cf1...carlosjoan91:4a5576d.html" title="Last updated on Sep 18, 2025, 9:49 PM UTC (4a5576d)">Diff</a>