### PR TITLE
Apply `strict-dynamic` to inline scripts.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4412,6 +4412,10 @@ Content-Type: application/reports+json
 
       2.  <a for=set>For each</a> |expression| of |list|:
 
+          1.  If |expression| is the "<a grammar>`'strict-dynamic'`</a>" <a grammar>keyword-source</a>:
+
+              1.  If |type| is "`script`", and |element| is not [=parser-inserted=], return "`Matches`".
+
           1.  If |expression| matches the <a grammar>`hash-source`</a> grammar:
 
               1.  Let |algorithm| be null.
@@ -4447,8 +4451,6 @@ Content-Type: application/reports+json
       "<a grammar>`'unsafe-hashes'`</a>" source expression is present,
       they will also apply to event handlers, style attributes and `javascript:`
       navigations.
-
-  ISSUE(w3c/webappsec-csp#426): This should handle `'strict-dynamic'` for dynamically inserted inline scripts.
 
   6.  Return "`Does Not Match`".
 


### PR DESCRIPTION
As noted in #426, the current "Does element match source list for type and source?" algorithm does not properly handle `strict-dynamic` checks for non-parser-inserted inline scripts. This patch adds a relevant step to the algorithm to match both browser behavior and our existing tests:

https://wpt.fyi/results/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html?label=experimental&label=master&aligned

Fixes #426.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/787.html" title="Last updated on Oct 23, 2025, 8:16 AM UTC (73fb5d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/787/9dd7cf1...73fb5d6.html" title="Last updated on Oct 23, 2025, 8:16 AM UTC (73fb5d6)">Diff</a>