### PR TITLE
[Editorial] Fix broken references to Trusted Types spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1516,7 +1516,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
           whose [=TrustedScript/data=] is set to |codeString| if |isTrusted| is `true`, and
           |codeString| otherwise.
 
-      1. Let |sourceString| be the result of executing the [=Get Trusted Type compliant string=] algorithm, with
+      1. Let |sourceString| be the result of executing the [=get trusted type compliant string=] algorithm, with
          {{TrustedScript}}, |realm|, |sourceToValidate|, |compilationSink|, and `'script'`.
 
       1.  If the algorithm throws an error, throw an {{EvalError}}.
@@ -1539,7 +1539,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
       1.  If |source-list| is not null:
 
-          1.  Let |trustedTypesRequired| be the result of executing [=Does sink type require trusted types?=], with
+          1.  Let |trustedTypesRequired| be the result of executing [=does sink type require trusted types?=], with
               |realm|, `'script'`, and `false`.
 
           1.  If |trustedTypesRequired| is `true` and |source-list| contains a [=source expression=] which is an


### PR DESCRIPTION
The abstract-ops became dfns in Trusted Types, so the links need to be updated here.

"Does sink type require trusted types?" is not exported yet, but it will be after https://github.com/w3c/trusted-types/pull/603 gets merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/webappsec-csp/pull/790.html" title="Last updated on Nov 6, 2025, 1:55 PM UTC (72a7ff9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/790/13c7d8e...antosart:72a7ff9.html" title="Last updated on Nov 6, 2025, 1:55 PM UTC (72a7ff9)">Diff</a>