### PR TITLE
Add 'unsafe-webtransport-hashes' keyword to connect-src

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2220,16 +2220,19 @@ Content-Type: application/reports+json
 
   1.  Let |source list| be directive's <a for="directive">value</a>.
 
+  1.  If |request|'s [=request/mode=] is "`webtransport`" and |request|'s
+      <a for="request">WebTransport-hash list</a> [=list/is not empty=]:
+
+      1. If |source list| [=list/contains=] a <a>source expression</a>
+         which is an <a>ASCII case-insensitive</a> match for the
+         <a grammar>`keyword-source`</a>
+         "<a grammar>`'unsafe-webtransport-hashes'`</a>", return "`Allowed`".
+
+      1.  Return "`Blocked`".
+
   1.  If the result of executing [[#match-request-to-source-list]] on
       |request|, |source list|, and |policy|, is "`Matches`", return
       "`Allowed`".
-
-  1.  If |request|'s [=request/mode=] is "`webtransport`", |request|'s
-      <a for="request">WebTransport-hash list</a> [=list/is not empty=],
-      and |source list| [=list/contains=] a <a>source expression</a> which
-      is an <a>ASCII case-insensitive</a> match for the
-      <a grammar>`keyword-source`</a>
-      "<a grammar>`'unsafe-webtransport-hashes'`</a>", return "`Allowed`".
 
   1.  Return "`Blocked`".
 
@@ -2250,16 +2253,19 @@ Content-Type: application/reports+json
 
   1.  Let |source list| be directive's <a for="directive">value</a>.
 
+  1.  If |request|'s [=request/mode=] is "`webtransport`" and |request|'s
+      <a for="request">WebTransport-hash list</a> [=list/is not empty=]:
+
+      1. If |source list| [=list/contains=] a <a>source expression</a>
+         which is an <a>ASCII case-insensitive</a> match for the
+         <a grammar>`keyword-source`</a>
+         "<a grammar>`'unsafe-webtransport-hashes'`</a>", return "`Allowed`".
+
+      1.  Return "`Blocked`".
+
   1.  If the result of executing [[#match-response-to-source-list]] on
       |response|, |request|, |source list|, and |policy|, is "`Matches`",
       return "`Allowed`".
-
-  1.  If |request|'s [=request/mode=] is "`webtransport`", |request|'s
-      <a for="request">WebTransport-hash list</a> [=list/is not empty=],
-      and |source list| [=list/contains=] a <a>source expression</a> which
-      is an <a>ASCII case-insensitive</a> match for the
-      <a grammar>`keyword-source`</a>
-      "<a grammar>`'unsafe-webtransport-hashes'`</a>", return "`Allowed`".
 
   1.  Return "`Blocked`".
 


### PR DESCRIPTION
Fixes #683. Assumes a ~unsafe-~`WebTransport-hash list` ~flag~ on [request](https://fetch.spec.whatwg.org/#concept-request) (seems simplest post https://github.com/w3c/webtransport/pull/697). 

@dveditz @annevk @martinthomson WDYT?
 

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webappsec-csp/pull/791.html" title="Last updated on Jan 16, 2026, 7:57 PM UTC (97ee459)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/791/a131bcb...jan-ivar:97ee459.html" title="Last updated on Jan 16, 2026, 7:57 PM UTC (97ee459)">Diff</a>