### PR TITLE
Add "text" destination type, for JavaScript text imports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4519,6 +4519,7 @@ Content-Type: application/reports+json
         1. Return `worker-src`.
 
       : "`json`"
+      : "`text`"
       : "`webidentity`"
       ::
         1. Return `connect-src`.


### PR DESCRIPTION
This change is to support the changes in whatwg/html#11933 and whatwg/fetch#1898, by adding `text` as a destination type.

Tests for this are included in web-platform-tests/wpt#56812.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eemeli/webappsec-csp/pull/794.html" title="Last updated on Dec 17, 2025, 3:23 PM UTC (373064d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/794/a131bcb...eemeli:373064d.html" title="Last updated on Dec 17, 2025, 3:23 PM UTC (373064d)">Diff</a>