### PR TITLE
Integrate with speculation rules 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,6 +40,7 @@ spec:html
     text: style
   type: element-attr
     text: ping
+    text: type
   type:interface
     text:SharedWorker
 spec:fetch
@@ -697,6 +698,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
                      / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'trusted-types-eval'</dfn>"
                      / "<dfn>'report-sha256'</dfn>" / "<dfn>'report-sha384'</dfn>"
                      / "<dfn>'report-sha512'</dfn>" / "<dfn>'unsafe-webtransport-hashes'</dfn>"
+                     / "<dfn>'inline-speculation-rules'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -1239,7 +1241,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   application, event handlers, etc.), and "`Blocked`" otherwise:
 
   Note: The valid values for |type| are "`script`", "`script attribute`",
-  "`style`", and "`style attribute`".
+  "`script speculationrules`", "`style`", and "`style attribute`".
 
   <ol class="algorithm">
     1.  Assert: |element| is not null.
@@ -2909,7 +2911,8 @@ Content-Type: application/reports+json
       implicitly by not specifying a `script-src` (or `default-src`) directive,
       or explicitly, by specifying "`unsafe-inline`", a
       <a grammar>nonce-source</a> or a <a grammar>hash-source</a> that matches
-      the inline block.
+      the inline block, or specifying "`inline-speculation-rules`" when the
+      <{script/type}> attribute matches "`speculationrules`".
 
   4.  The following JavaScript execution sinks are gated on the "`unsafe-eval`" and "`trusted-types-eval`"
       source expressions:
@@ -4069,7 +4072,7 @@ Content-Type: application/reports+json
       Note: An empty source list (that is, a directive without a value: `script-src`,
       as opposed to `script-src host1`) is equivalent to a source list containing `'none'`,
       and will not match any URL.
-      
+
       Note: The `'none'` keyword has no effect when other source expressions are
       present. That is, the list « `'none'` » does not match any URL. A list consisting
       of « `'none'`, `https://example.com` », on the other hand, would match
@@ -4220,7 +4223,7 @@ Content-Type: application/reports+json
   Note: The matching relation is asymmetric. That is, |pattern| matching |host| does not
   mean that |host| will match |pattern|. For example, `*.example.com` <a>`host-part` matches</a>
   `www.example.com`, but `www.example.com` does not <a>`host-part` match</a> `*.example.com`.
-  
+
   Note: A future version of this specification may allow literal IPv6 and IPv4 addresses,
   depending on usage and demand. Given the weak security properties of IP addresses in
   relation to named hosts, however, authors are encouraged to prefer the latter whenever possible.
@@ -4261,7 +4264,7 @@ Content-Type: application/reports+json
 
     3.  Let |normalizedInput| be null if |input| null; otherwise |input|
         interpreted as decimal number.
-    
+
     4.  If |normalizedInput| equals |url|'s [=url/port=], return "`Matches`".
 
     5.  If |url|'s [=url/port=] is null:
@@ -4393,7 +4396,12 @@ Content-Type: application/reports+json
           Note: `'strict-dynamic'` only applies to scripts, not other resource
           types. Usage is explained in more detail in [[#strict-dynamic-usage]].
 
-      3.  If |expression| is an <a>ASCII case-insensitive</a> match for the
+      3.  If |type| is "`script speculationrules`" and |expression| matches the
+          <a grammar>keyword-source</a>
+          "<a grammar>`'inline-speculation-rules'`</a>", set |allow all inline|
+          to `true`.
+
+      4.  If |expression| is an <a>ASCII case-insensitive</a> match for the
           <a grammar>`keyword-source`</a> "<a grammar>`'unsafe-inline'`</a>",
           set |allow all inline| to `true`.
 
@@ -4444,8 +4452,9 @@ Content-Type: application/reports+json
   1.  If [[#allow-all-inline]] returns "`Allows`" given |list| and |type|,
       return "`Matches`".
 
-  2.  If |type| is "`script`" or "`style`", and [[#is-element-nonceable]]
-      returns "`Nonceable`" when executed upon |element|:
+  2.  If |type| is "`script`", "`script speculationrules`", or "`style`", and
+      [[#is-element-nonceable]] returns "`Nonceable`" when executed upon
+      |element|:
 
       1.  <a for=set>For each</a> |expression| of |list|:
 
@@ -4466,8 +4475,8 @@ Content-Type: application/reports+json
           "<a grammar>`'unsafe-hashes'`</a>",
           set |unsafe-hashes flag| to `true`. Break out of the loop.
 
-  5.  If |type| is "`script`" or "`style`", or |unsafe-hashes flag| is
-      `true`:
+  5.  If |type| is "`script`",  "`script speculationrules`", or "`style`", or
+      |unsafe-hashes flag| is `true`:
 
       1.  Set |source| to the result of executing <a>UTF-8 encode</a>
           on the result of executing <a for="JavaScript string" data-lt="convert">JavaScript string converting</a>
@@ -4588,8 +4597,18 @@ Content-Type: application/reports+json
         1. Return `connect-src`.
 
       : "`report`"
+      : "`speculationrules`"
       ::
         1. Return null.
+
+        <p class="note">At present, requests with the
+        "`speculationrules`" destination can only be issued by the
+        [:Speculation-Rules:] HTTP header, for which CSP does not apply.
+        If support is added for loading external speculation rules via
+        the <{script}> element's <{script/src}> attribute, for which CSP
+        would apply, then we would need to make this case more
+        complicated, for example by introducing a new
+        [=request/initiator=] and switching on that.
 
   3.  Return `connect-src`.
 
@@ -5245,7 +5264,7 @@ Content-Type: application/reports+json
       <pre>
         <a http-header>Content-Security-Policy</a>: img-src 'none'; script-src 'none'; font-src 'none'
       </pre>
-      
+
       Supplementing this policy with `default-src 'none'` would improve the page's robustness
       against this kind of attack.
     </div>

--- a/index.bs
+++ b/index.bs
@@ -4596,19 +4596,19 @@ Content-Type: application/reports+json
       ::
         1. Return `connect-src`.
 
-      : "`report`"
       : "`speculationrules`"
       ::
-        1. Return null.
+        1. If |request|'s [=request/initiator=] is "`speculation-rules-header`", return null.
 
-        <p class="note">At present, requests with the
-        "`speculationrules`" destination can only be issued by the
-        [:Speculation-Rules:] HTTP header, for which CSP does not apply.
-        If support is added for loading external speculation rules via
-        the <{script}> element's <{script/src}> attribute, for which CSP
-        would apply, then we would need to make this case more
-        complicated, for example by introducing a new
-        [=request/initiator=] and switching on that.
+        2. Return `script-src-elem`.
+
+        Note: Speculation rules fetched via the `Speculation-Rules` HTTP response
+        header are not subject to CSP. Only speculation rules fetched via the <{script}>
+        element are subject to `script-src-elem`.
+
+      : "`report`"
+      ::
+        1. Return null.
 
   3.  Return `connect-src`.
 

--- a/index.bs
+++ b/index.bs
@@ -698,7 +698,6 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
                      / "<dfn>'wasm-unsafe-eval'</dfn>" / "<dfn>'trusted-types-eval'</dfn>"
                      / "<dfn>'report-sha256'</dfn>" / "<dfn>'report-sha384'</dfn>"
                      / "<dfn>'report-sha512'</dfn>" / "<dfn>'unsafe-webtransport-hashes'</dfn>"
-                     / "<dfn>'inline-speculation-rules'</dfn>"
 
     ISSUE: Bikeshed `unsafe-allow-redirects`.
 
@@ -2913,8 +2912,7 @@ Content-Type: application/reports+json
       implicitly by not specifying a `script-src` (or `default-src`) directive,
       or explicitly, by specifying "`unsafe-inline`", a
       <a grammar>nonce-source</a> or a <a grammar>hash-source</a> that matches
-      the inline block, or specifying "`inline-speculation-rules`" when the
-      <{script/type}> attribute matches "`speculationrules`".
+      the inline block.
 
   4.  The following JavaScript execution sinks are gated on the "`unsafe-eval`" and "`trusted-types-eval`"
       source expressions:
@@ -4492,12 +4490,7 @@ Content-Type: application/reports+json
           Note: `'strict-dynamic'` only applies to scripts, not other resource
           types. Usage is explained in more detail in [[#strict-dynamic-usage]].
 
-      3.  If |type| is "`script speculationrules`" and |expression| matches the
-          <a grammar>keyword-source</a>
-          "<a grammar>`'inline-speculation-rules'`</a>", set |allow all inline|
-          to `true`.
-
-      4.  If |expression| is an <a>ASCII case-insensitive</a> match for the
+      3.  If |expression| is an <a>ASCII case-insensitive</a> match for the
           <a grammar>`keyword-source`</a> "<a grammar>`'unsafe-inline'`</a>",
           set |allow all inline| to `true`.
 

--- a/index.bs
+++ b/index.bs
@@ -2332,6 +2332,7 @@ Content-Type: application/reports+json
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src-elem</a> <a grammar>'self'</a>;
                                <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>speculation-rules-src</a> <a grammar>'self'</a>;
                                <a>style-src-elem</a> <a grammar>'self'</a>;
                                <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
@@ -2361,6 +2362,7 @@ Content-Type: application/reports+json
                                <a>object-src</a> <a grammar>'self'</a>;
                                <a>script-src-elem</a> https://example.com;
                                <a>script-src-attr</a> <a grammar>'self'</a>;
+                               <a>speculation-rules-src</a> <a grammar>'self'</a>;
                                <a>style-src-elem</a> <a grammar>'self'</a>;
                                <a>style-src-attr</a> <a grammar>'self'</a>;
                                <a>worker-src</a> <a grammar>'self'</a>
@@ -3117,6 +3119,99 @@ Content-Type: application/reports+json
   4.  If the result of executing [[#match-element-to-source-list]] on
       |element|, this directive's <a for="directive">value</a>, |type|,
       and |source|, is "`Does Not Match`", return "`Blocked`".
+
+  5.  Return "`Allowed`".
+
+  <h4 id="directive-speculation-rules-src">`speculation-rules-src`</h4>
+
+  The syntax for the directive's name and value is described by the following ABNF:
+
+  <pre>
+    directive-name  = "speculation-rules-src"
+    directive-value = <a grammar>serialized-source-list</a>
+  </pre>
+
+  The <dfn export>speculation-rules-src</dfn> directive restricts the sources
+  from which speculation rules may be loaded, whether via
+  <{script}> elements or the `Speculation-Rules` HTTP response header.
+
+  If `speculation-rules-src` is not present, the user agent will fall back to
+  `script-src-elem`, then `script-src`, then `default-src` when evaluating
+  whether a given speculation rules resource should be allowed.
+
+  <div class="example">
+    Given a page with the following Content Security Policy:
+
+    <pre>
+      <a http-header>Content-Security-Policy</a>: <a>speculation-rules-src</a> https://cdn.example.com/
+    </pre>
+
+    Only speculation rules from `https://cdn.example.com/` will be allowed,
+    regardless of the values set in `script-src-elem`, `script-src`, or
+    `default-src`.
+  </div>
+
+  <h5 algorithm id="speculation-rules-src-pre-request">
+    `speculation-rules-src` Pre-request check
+  </h5>
+
+  This directive's <a for="directive">pre-request check</a> is as follows:
+
+  Given a <a for="/">request</a> |request| and a <a for="/">policy</a> |policy|:
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `speculation-rules-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-request-to-source-list]] on
+      |request|, this directive's <a for="directive">value</a>, and |policy|,
+      is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h5 algorithm id="speculation-rules-src-post-request">
+    `speculation-rules-src` Post-request check
+  </h5>
+
+  This directive's <a for="directive">post-request check</a> is as follows:
+
+  Given a <a for="/">request</a> |request|, a <a>response</a> |response|, and a
+  <a for="/">policy</a> |policy|:
+
+  1.  Let |name| be the result of executing [[#effective-directive-for-a-request]]
+      on |request|.
+
+  2.  If the result of executing [[#should-directive-execute]] on |name|,
+      `speculation-rules-src` and |policy| is "`No`", return "`Allowed`".
+
+  3.  If the result of executing [[#match-response-to-source-list]] on
+      |response|, |request|, this directive's <a for="directive">value</a>,
+      and |policy|, is "`Does Not Match`", return "`Blocked`".
+
+  4.  Return "`Allowed`".
+
+  <h5 algorithm id="speculation-rules-src-inline">
+    `speculation-rules-src` Inline Check
+  </h5>
+
+  This directive's <a for="directive">inline check</a> algorithm is as follows:
+
+  Given an {{Element}} |element|, a string |type|, a <a for="/">policy</a>
+  |policy| and a string |source|:
+
+  1.  Assert: |element| is not null.
+
+  2.  Let |name| be the result of executing [[#effective-directive-for-inline-check]]
+      on |type|.
+
+  3.  If the result of executing [[#should-directive-execute]] on |name|,
+      `speculation-rules-src`, and |policy| is "`No`", return "`Allowed`".
+
+  4.  If the result of executing [[#match-element-to-source-list]] on
+      |element|, this directive's <a for="directive">value</a>, |type|,
+      and |source| is "`Does Not Match`", return "`Blocked`".
 
   5.  Return "`Allowed`".
 
@@ -3951,6 +4046,7 @@ Content-Type: application/reports+json
         * `object-src`
         * `script-src`
         * `script-src-elem`
+        * `speculation-rules-src`
         * `style-src`
         * `style-src-elem`
         * `worker-src`
@@ -4598,13 +4694,7 @@ Content-Type: application/reports+json
 
       : "`speculationrules`"
       ::
-        1. If |request|'s [=request/initiator=] is "`speculation-rules-header`", return null.
-
-        2. Return `script-src-elem`.
-
-        Note: Speculation rules fetched via the `Speculation-Rules` HTTP response
-        header are not subject to CSP. Only speculation rules fetched via the <{script}>
-        element are subject to `script-src-elem`.
+        1. Return `speculation-rules-src`.
 
       : "`report`"
       ::
@@ -4633,6 +4723,9 @@ Content-Type: application/reports+json
       : "`navigation`"
       ::
         1.  Return `script-src-elem`.
+      : "`script speculationrules`"
+      ::
+        1.  Return `speculation-rules-src`.
       : "`script attribute`"
       ::
         1.  Return `script-src-attr`.
@@ -4655,6 +4748,10 @@ Content-Type: application/reports+json
   Given a string |directive name|:
 
   1.  Switch on |directive name|:
+
+      : "`speculation-rules-src`"
+      ::
+        1.  Return `<< "speculation-rules-src", "script-src-elem", "script-src", "default-src" >>`.
 
       : "`script-src-elem`"
       ::
@@ -5350,6 +5447,8 @@ Content-Type: application/reports+json
   ::  This document (see [[#directive-script-src-attr]])
   :   <a>`script-src-elem`</a>
   ::  This document (see [[#directive-script-src-elem]])
+  :   <a>`speculation-rules-src`</a>
+  ::  This document (see [[#directive-speculation-rules-src]])
   :   <a>`style-src`</a>
   ::  This document (see [[#directive-style-src]])
   :   <a>`style-src-attr`</a>

--- a/index.bs
+++ b/index.bs
@@ -4483,8 +4483,9 @@ Content-Type: application/reports+json
       1.  If |expression| matches the <a grammar>`nonce-source`</a> or
           <a grammar>`hash-source`</a> grammar, return "`Does Not Allow`".
 
-      2.  If |type| is "`script`", "`script attribute`" or "`navigation`"
-          and |expression| matches the <a grammar>keyword-source</a>
+      2.  If |type| is "`script`", "`script attribute`",
+          "`script speculationrules`", or "`navigation`", and |expression|
+          matches the <a grammar>keyword-source</a>
           "<a grammar>`'strict-dynamic'`</a>", return "`Does Not Allow`".
 
           Note: `'strict-dynamic'` only applies to scripts, not other resource
@@ -4517,9 +4518,9 @@ Content-Type: application/reports+json
 
      <a>Source lists</a> that do not
      <a for="source list">allow all inline behavior</a> when |type| is
-     '`script`' or '`script attribute`' due to the presence of
-     '`strict-dynamic`', but <a for="source list">allow all inline behavior</a>
-     otherwise:
+     '`script`', '`script attribute`', or '`script speculationrules`' due to
+     the presence of '`strict-dynamic`', but
+     <a for="source list">allow all inline behavior</a> otherwise:
 
      <pre>
       'unsafe-inline' 'strict-dynamic'


### PR DESCRIPTION
Adds the following:

From https://github.com/w3c/webappsec-csp/pull/776:
- Handling of the new "speculationrules" request destination, which is used by the Speculation-Rules HTTP header

New additions:

 - New `speculation-rules-src` fetch directive that restricts the sources from which speculation rules may be loaded, whether via <script> elements or the Speculation-Rules HTTP response header
 - Fallback chain: `speculation-rules-src` → `script-src-elem` → `script-src` → `default-src`, applied uniformly to both inline and external speculation rules
 - Handling of the "speculationrules" request destination now returns `speculation-rules-src` (removing the previous header exemption that returned null).

This reflects the agreed plan from whatwg/html#11697


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vickiez/webappsec-csp/pull/808.html" title="Last updated on Aug 20, 2026, 9:42 PM UTC (65da675)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/808/7845c09...vickiez:65da675.html" title="Last updated on Aug 20, 2026, 9:42 PM UTC (65da675)">Diff</a>