### PR TITLE
Update nonceable attribute checks for link elements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4343,10 +4343,12 @@ Content-Type: application/reports+json
       |element|'s <a for=Element>attribute list</a>:
 
       1.  If |attribute|'s name contains an <a>ASCII case-insensitive</a> match for
-          "<code>&lt;script</code>" or "<code>&lt;style</code>", return "`Not Nonceable`".
+          "<code>&lt;link</code>", "<code>&lt;script</code>", or "<code>&lt;style</code>",
+          return "`Not Nonceable`".
 
       2.  If |attribute|'s value contains an <a>ASCII case-insensitive</a> match for
-          "<code>&lt;script</code>" or "<code>&lt;style</code>", return "`Not Nonceable`".
+          "<code>&lt;link</code>", "<code>&lt;script</code>", or "<code>&lt;style</code>",
+          return "`Not Nonceable`".
 
   3.  If |element| had a [=duplicate-attribute=] [=parse error=] during tokenization, return
       "`Not Nonceable`".


### PR DESCRIPTION
This PR adds `<link` to the blocklist for nonceable elements. If we're going to keep this algorithm, it should cover all nonceable elements, not just the script and style tags.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/810.html" title="Last updated on Apr 8, 2026, 6:48 AM UTC (70e2a02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/810/7845c09...70e2a02.html" title="Last updated on Apr 8, 2026, 6:48 AM UTC (70e2a02)">Diff</a>