### PR TITLE
[Editorial] 'policy' is a local term, not global.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -436,13 +436,13 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   and restricted behaviors, and may be applied to a {{Document}}, {{WorkerGlobalScope}}, or
   {{WorkletGlobalScope}}.
 
-  Each policy has an associated <dfn for="policy" export>directive set</dfn>, which is an <a>ordered
+  Each policy has an associated <dfn for="content security policy object" export>directive set</dfn>, which is an <a>ordered
   set</a> of <a>directives</a> that define the policy's implications when applied.
 
-  Each policy has an associated <dfn for="policy" export>disposition</dfn>, which is either
+  Each policy has an associated <dfn for="content security policy object" export>disposition</dfn>, which is either
   "`enforce`" or "`report`".
 
-  Each policy has an associated <dfn for="policy" export>source</dfn>, which is either "`header`"
+  Each policy has an associated <dfn for="content security policy object" export>source</dfn>, which is either "`header`"
   or "`meta`".
 
   Multiple [=/policies=] can be applied to a single resource. A <dfn export>CSP

--- a/index.bs
+++ b/index.bs
@@ -458,7 +458,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
   A [=/CSP list=] <dfn export>contains a header-delivered Content Security
   Policy</dfn> if its [=CSP list/policies=] [=list/contain=] a [=/policy=] whose
-  [=policy/source=] is "`header`".
+  [=content security policy object/source=] is "`header`".
 
   A <dfn export>serialized CSP</dfn> is an <a>ASCII string</a> consisting of a semicolon-delimited
   series of <a>serialized directives</a>, adhering to the following ABNF grammar [[!RFC5234]]:
@@ -483,18 +483,18 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   </h4>
 
   To <dfn abstract-op>parse a serialized CSP</dfn>, given a [=byte sequence=] or
-  [=string=] |serialized|, a [=policy/source=] |source|, and a [=policy/disposition=]
+  [=string=] |serialized|, a [=content security policy object/source=] |source|, and a [=content security policy object/disposition=]
   |disposition|, execute the following steps.
 
   This algorithm returns a [=Content Security Policy object=]. If |serialized| could not be
-  parsed, the object's [=policy/directive set=] will be empty.
+  parsed, the object's [=content security policy object/directive set=] will be empty.
 
   <ol class="algorithm">
     1.  If |serialized| is a [=byte sequence=], then set |serialized| to be the result of
         [=isomorphic decoding=] |serialized|.
 
-    2.  Let |policy| be a new [=/policy=] with an empty [=policy/directive set=], a [=policy/source=]
-        of |source|, and a [=policy/disposition=] of |disposition|.
+    2.  Let |policy| be a new [=/policy=] with an empty [=content security policy object/directive set=], a [=content security policy object/source=]
+        of |source|, and a [=content security policy object/disposition=] of |disposition|.
 
     3.  <a for=list>For each</a> |token| returned by [=strictly split a string|strictly splitting=] |serialized| on
         the U+003B SEMICOLON character (`;`):
@@ -512,7 +512,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
             Note: Directive names are case-insensitive, that is: `script-SRC 'none'` and
             `ScRiPt-sRc 'none'` are equivalent.
 
-        5.  If |policy|'s [=policy/directive set=] contains a [=directive=] whose [=directive/name=]
+        5.  If |policy|'s [=content security policy object/directive set=] contains a [=directive=] whose [=directive/name=]
             is |directive name|, [=iteration/continue=].
 
             Note: In this case, the user agent SHOULD notify developers that a duplicate
@@ -525,7 +525,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
         7.  Let |directive| be a new [=directive=] whose [=directive/name=] is |directive name|, and
             [=directive/value=] is |directive value|.
 
-        8.  [=set/append|Append=] |directive| to |policy|'s [=policy/directive set=].
+        8.  [=set/append|Append=] |directive| to |policy|'s [=content security policy object/directive set=].
 
     4.  Return |policy|.
   </ol>
@@ -548,18 +548,18 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
         1.  Let |policy| be the result of
             <a abstract-op lt="parse a serialized CSP">parsing</a> |token|, with a
-            [=policy/source=] of "`header`", and a [=policy/disposition=] of "`enforce`".
+            [=content security policy object/source=] of "`header`", and a [=content security policy object/disposition=] of "`enforce`".
 
-        2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.
+        2.  If |policy|'s [=content security policy object/directive set=] is not empty, append |policy| to |policies|.
 
     3.  <a for=list>For each</a> |token| returned by [=extracting header list values=] given
         `Content-Security-Policy-Report-Only` and |response|'s [=response/header list=]:
 
         1.  Let |policy| be the result of
             <a abstract-op lt="parse a serialized CSP">parsing</a> |token|, with a
-            [=policy/source=] of "`header`", and a [=policy/disposition=] of "`report`".
+            [=content security policy object/source=] of "`header`", and a [=content security policy object/disposition=] of "`report`".
 
-        2.  If |policy|'s [=policy/directive set=] is not empty, append |policy| to |policies|.
+        2.  If |policy|'s [=content security policy object/directive set=] is not empty, append |policy| to |policies|.
 
     4.  Return a [=/CSP list=] whose [=CSP list/policies=] is |policies| and
         [=CSP list/self-origin=] is |response|'s [=response/url=]'s [=url/origin=].
@@ -1573,7 +1573,7 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
           4.  Execute [[#report-violation]] on |violation|.
 
-          5.  If |policy|'s [=policy/disposition=] is "`enforce`", then set |result| to
+          5.  If |policy|'s [=content security policy object/disposition=] is "`enforce`", then set |result| to
               "`Blocked`".
 
   4.  If |result| is "`Blocked`", throw an `EvalError` exception.
@@ -1622,7 +1622,7 @@ this algorithm returns normally if compilation is allowed, and throws a
 
         3.  Execute [[#report-violation]] on |violation|.
 
-        4.  If |policy|'s [=policy/disposition=] is "`enforce`", then set |result| to
+        4.  If |policy|'s [=content security policy object/disposition=] is "`enforce`", then set |result| to
             "`Blocked`".
 
 4.  If |result| is "`Blocked`", throw a {{WebAssembly.CompileError}} exception.


### PR DESCRIPTION
@antosart WDYT of this? In short, we're linking to the wrong term as `for` because I misunderstood what Bikeshed did with `local-lt`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/pull/812.html" title="Last updated on Apr 16, 2026, 1:00 PM UTC (7cca5f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/812/7845c09...7cca5f3.html" title="Last updated on Apr 16, 2026, 1:00 PM UTC (7cca5f3)">Diff</a>