### PR TITLE
Editorial: Improve clarity of EnsureCSPDoesNotBlockStringCompilation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1497,11 +1497,9 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
   returns normally if string compilation is allowed, and throws an "`EvalError`"
   if not:
 
-  1.  If |compilationType| is "`TIMER`", then:
+  1.  Let |sourceString| be |codeString|.
 
-      1.  Let |sourceString| be |codeString|.
-
-  1.  Else:
+  1.  If |compilationType| is not "`TIMER`", then:
 
       1.  Let |compilationSink| be "Function" if |compilationType| is "`FUNCTION`", and "eval" otherwise.
 
@@ -1524,16 +1522,14 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
               1. Otherwise, set |isTrusted| to `false`.
 
-      1.  Let |sourceToValidate| be a [=new=] {{TrustedScript}} object created in |realm|
-          whose [=TrustedScript/data=] is set to |codeString| if |isTrusted| is `true`, and
-          |codeString| otherwise.
+      1.  If |isTrusted| is `false`, then:
 
-      1. Let |sourceString| be the result of executing the [=get trusted type compliant string=] algorithm, with
-         {{TrustedScript}}, |realm|, |sourceToValidate|, |compilationSink|, and `'script'`.
+          1.  Set |sourceString| to the result of executing the [=get trusted type compliant string=] algorithm, with
+              {{TrustedScript}}, |realm|, |codeString|, |compilationSink|, and `'script'`.
 
-      1.  If the algorithm throws an error, throw an {{EvalError}}.
+          1.  If the algorithm throws an error, throw an {{EvalError}}.
 
-      1.  If |sourceString| is not equal to |codeString|, throw an {{EvalError}}.
+          1.  If |sourceString| is not equal to |codeString|, throw an {{EvalError}}.
 
   1.  Let |result| be "`Allowed`".
 


### PR DESCRIPTION
I noticed a weird line in the algorithm, so I decided to clean it up a bit to make it more easily understandable. This is editorial and doesn't impact behaviour.


The weird line:
> Let sourceToValidate be a [new](https://webidl.spec.whatwg.org/#new) [TrustedScript](https://w3c.github.io/trusted-types/dist/spec/#trustedscript) object created in realm whose [data](https://w3c.github.io/trusted-types/dist/spec/#trustedscript-data) is set to codeString if isTrusted is true, and codeString otherwise.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/webappsec-csp/pull/817.html" title="Last updated on Jul 28, 2026, 5:31 PM UTC (f95bf7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/817/4e01ae7...lukewarlow:f95bf7f.html" title="Last updated on Jul 28, 2026, 5:31 PM UTC (f95bf7f)">Diff</a>