### PR TITLE
Remove redundant TrustedScript data checks from CSP algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1505,22 +1505,20 @@ spec:SRI; urlPrefix: https://w3c.github.io/webappsec-subresource-integrity
 
       1.  Let |isTrusted| be `true` if |bodyArg| [=implements=] {{TrustedScript}}, and `false` otherwise.
 
-      1.  If |isTrusted| is `true` then:
-
-          1. If |bodyString| is not equal to |bodyArg|'s [=TrustedScript/data=], set |isTrusted| to `false`.
-
       1.  If |isTrusted| is `true`, then:
 
-          1. Assert: |parameterArgs|' [list/size=] is equal to [parameterStrings]' [=list/size=].
+        1. Assert: |bodyString| is equal to |bodyArg|'s [=TrustedScript/data=].
 
-          1. [=list/iterate|For each=] |index| of [=the range=] 0 to |parameterArgs]' [list/size=]:
-              1. Let |arg| be |parameterArgs|[|index|].
+        1. Assert: |parameterArgs|' [=list/size=] is equal to |parameterStrings|' [=list/size=].
 
-              1. If |arg| [=implements=] {{TrustedScript}}, then:
+        1. [=list/iterate|For each=] |index| of [=the range=] 0 to |parameterArgs|' [=list/size=]:
+          1. Let |arg| be |parameterArgs|[|index|].
 
-                  1. if |parameterStrings|[|index|] is not equal to |arg|'s [=TrustedScript/data=], set |isTrusted| to `false`.
+          1. If |arg| [=implements=] {{TrustedScript}}, then:
 
-              1. Otherwise, set |isTrusted| to `false`.
+            1. Assert: |parameterStrings|[|index|] is equal to |arg|'s [=TrustedScript/data=].
+
+          1. Otherwise, set |isTrusted| to `false`.
 
       1.  If |isTrusted| is `false`, then:
 


### PR DESCRIPTION
HostGetCodeForEval extracts the internal [[Data]] from TrustedScript
objects before HostEnsureCanCompileStrings invokes the CSP algorithm.
So, by the time EnsureCSPDoesNotBlockStringCompilation receives bodyArg
and parameterArgs, they are already plain strings.

These checks are now redundant since the comparison of
parameterStrings[index] and bodyString against the TrustedScript
objects' data, and the verification that arguments implement
TrustedScript, are already done by HostGetCodeForEval.

see:
https://html.spec.whatwg.org/#hostgetcodeforeval(argument)
https://html.spec.whatwg.org/#hostensurecancompilestrings(realm,-parameterstrings,-bodystring,-codestring,-compilationtype,-parameterargs,-bodyarg)
https://www.w3.org/TR/CSP3/#can-compile-strings


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lochipi/webappsec-csp/pull/818.html" title="Last updated on Aug 7, 2026, 3:59 PM UTC (3731c15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/818/43b9e49...Lochipi:3731c15.html" title="Last updated on Aug 7, 2026, 3:59 PM UTC (3731c15)">Diff</a>