### PR TITLE
Handle blob scheme when matching 'self'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4141,19 +4141,22 @@ Content-Type: application/reports+json
 
       7.  Return "`Matches`".
 
-  4.  If |expression| is an <a>ASCII case-insensitive</a> match for "`'self'`",
-      return "`Matches`" if one or more of the following conditions is met:
+  4.  If |expression| is an <a>ASCII case-insensitive</a> match for "`'self'`", then:
 
-      1.  |origin| and |url|'s [=url/origin=] are [=same origin=]
+      1. If |url|'s [=url/scheme=] is "`blob`", return "`Does Not Match`".
 
-      2.  |origin|'s {{URL/host}} is the same as |url|'s {{URL/host}},
-          |origin|'s {{URL/port}} and |url|'s {{URL/port}} are either the same
-          or the <a>default ports</a> for their respective <a for="url">scheme</a>s, and
-          one or more of the following conditions is met:
+      2. Return "`Matches`" if one or more of the following conditions is met:
 
-          1.  |url|'s <a for="url">scheme</a> is "`https`" or "`wss`"
-          2.  |origin|'s <a for="url">scheme</a> is "`http`" and |url|'s
-              <a for="url">scheme</a> is "`http`" or "`ws`"
+          1.  |origin| and |url|'s [=url/origin=] are [=same origin=]
+    
+          2.  |origin|'s {{URL/host}} is the same as |url|'s {{URL/host}},
+              |origin|'s {{URL/port}} and |url|'s {{URL/port}} are either the same
+              or the <a>default ports</a> for their respective <a for="url">scheme</a>s, and
+              one or more of the following conditions is met:
+    
+              1.  |url|'s <a for="url">scheme</a> is "`https`" or "`wss`"
+              2.  |origin|'s <a for="url">scheme</a> is "`http`" and |url|'s
+                  <a for="url">scheme</a> is "`http`" or "`ws`"
 
       Note: Like the <a grammar>`scheme-part`</a> logic above, the "`'self'`"
       matching algorithm allows upgrades to secure schemes when it is safe to do


### PR DESCRIPTION
Tested by `/content-security-policy/blob/blob-urls-do-not-match-self.sub.html`, and the other blob tests, a `blob` URL never matches `self`.

Fixes #487


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/webappsec-csp/pull/821.html" title="Last updated on Aug 26, 2026, 2:26 PM UTC (cd960cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-csp/821/e81d712...TimvdLippe:cd960cd.html" title="Last updated on Aug 26, 2026, 2:26 PM UTC (cd960cd)">Diff</a>